### PR TITLE
Feature/fix subscriptions

### DIFF
--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 
 export const hasCommandPrivileges = false;
 export const hasFakeData = true;
@@ -26,7 +26,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
   */
-  
+
   function noop() {}
   const opts = optsPar || {};
 
@@ -393,14 +393,23 @@ export const getFakeHistoricalTimeSeries = (selectedRows, dateStart, dateEnd) =>
     .flat();
 };
 
-
 export const saveGroupSubscriptions = (Component) => {
   return () => {
     const [groupName, setGroupName] = useState('');
 
-    const changeGroup = (groupName) => {
+    const saveSubscriptionLocally = (groupName) => {
       setGroupName(groupName);
     };
-    return <Component groupName={groupName} changeGroup={changeGroup} />;
+
+    const removeSubscriptionLocally = () => {
+      setGroupName('');
+    };
+    return (
+      <Component
+        groupName={groupName}
+        saveSubscriptionLocally={saveSubscriptionLocally}
+        removeSubscriptionLocally={removeSubscriptionLocally}
+      />
+    );
   };
 };

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -395,18 +395,21 @@ export const getFakeHistoricalTimeSeries = (selectedRows, dateStart, dateEnd) =>
 
 export const saveGroupSubscriptions = (Component) => {
   return () => {
-    const [groupName, setGroupName] = useState('');
+    const [subscriptionsList, setSubscriptionsList] = useState([]);
 
     const saveSubscriptionLocally = (groupName) => {
-      setGroupName(groupName);
+      if (!subscriptionsList.includes(groupName)) {
+        setSubscriptionsList([...subscriptionsList, groupName]);
+      }
     };
 
-    const removeSubscriptionLocally = () => {
-      setGroupName('');
+    const removeSubscriptionLocally = (groupName) => {
+      setSubscriptionsList(subscriptionsList.filter((name) => name !== groupName));
     };
+
     return (
       <Component
-        groupName={groupName}
+        subscriptionsList={subscriptionsList}
         saveSubscriptionLocally={saveSubscriptionLocally}
         removeSubscriptionLocally={removeSubscriptionLocally}
       />

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1,3 +1,5 @@
+import React, {useState} from 'react';
+
 export const hasCommandPrivileges = false;
 export const hasFakeData = true;
 
@@ -389,4 +391,16 @@ export const getFakeHistoricalTimeSeries = (selectedRows, dateStart, dateEnd) =>
       return currentValue;
     })
     .flat();
+};
+
+
+export const saveGroupSubscriptions = (Component) => {
+  return () => {
+    const [groupName, setGroupName] = useState('');
+
+    const changeGroup = (groupName) => {
+      setGroupName(groupName);
+    };
+    return <Component groupName={groupName} changeGroup={changeGroup} />;
+  };
 };

--- a/love/src/components/TelemetryLog/TelemetryLog.container.jsx
+++ b/love/src/components/TelemetryLog/TelemetryLog.container.jsx
@@ -2,15 +2,32 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import TelemetryLog from './TelemetryLog';
 import { requestGroupSubscription, requestGroupSubscriptionRemoval } from '../../redux/actions/ws';
-import {saveGroupSubscriptions} from '../../Utils';
+import { saveGroupSubscriptions } from '../../Utils';
 
-const TelemetryLogContainer = ({ data, groupName, changeGroup, subscribeToStream, unsubscribeToStream }) => {
-  const subscribeAndChangeGroup = (category, csc, stream) => {
-    subscribeToStream(category, csc, stream);
-    changeGroup([category, csc, stream].join('-'));
+const TelemetryLogContainer = ({
+  data,
+  groupName,
+  saveSubscriptionLocally,
+  removeSubscriptionLocally,
+  subscribeToStream,
+  unsubscribeToStream,
+}) => {
+  const subscribeAndSaveGroup = (groupName) => {
+    subscribeToStream(groupName);
+    saveSubscriptionLocally(groupName);
   };
+
+  const unsubscribeAndRemoveGroup = (groupName) => {
+    unsubscribeToStream(groupName);
+    removeSubscriptionLocally(groupName);
+  };
+
   return (
-    <TelemetryLog data={data} subscribeToStream={subscribeAndChangeGroup} unsubscribeToStream={unsubscribeToStream} />
+    <TelemetryLog
+      data={data}
+      subscribeToStream={subscribeAndSaveGroup}
+      unsubscribeToStream={unsubscribeAndRemoveGroup}
+    />
   );
 };
 
@@ -24,14 +41,10 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    subscribeToStream: (category, csc, stream) => {
-      const groupName = [category, csc, stream].join('-');
+    subscribeToStream: (groupName) => {
       dispatch(requestGroupSubscription(groupName));
-
-      return groupName;
     },
-    unsubscribeToStream: (category, csc, stream) => {
-      const groupName = [category, csc, stream].join('-');
+    unsubscribeToStream: (groupName) => {
       dispatch(requestGroupSubscriptionRemoval(groupName));
     },
   };

--- a/love/src/components/TelemetryLog/TelemetryLog.container.jsx
+++ b/love/src/components/TelemetryLog/TelemetryLog.container.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import TelemetryLog from './TelemetryLog';
 import { requestGroupSubscription, requestGroupSubscriptionRemoval } from '../../redux/actions/ws';
+import {saveGroupSubscriptions} from '../../Utils';
 
 const TelemetryLogContainer = ({ data, groupName, changeGroup, subscribeToStream, unsubscribeToStream }) => {
   const subscribeAndChangeGroup = (category, csc, stream) => {
@@ -36,18 +37,9 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
-const ConnectedLogContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(TelemetryLogContainer);
-
-const StreamGroupSetter = () => {
-  const [groupName, setGroupName] = useState('');
-
-  const changeGroup = (groupName) => {
-    setGroupName(groupName);
-  };
-
-  return <ConnectedLogContainer groupName={groupName} changeGroup={changeGroup} />;
-};
-export default StreamGroupSetter;
+export default saveGroupSubscriptions(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(TelemetryLogContainer),
+);

--- a/love/src/components/TelemetryLog/TelemetryLog.container.jsx
+++ b/love/src/components/TelemetryLog/TelemetryLog.container.jsx
@@ -5,8 +5,8 @@ import { requestGroupSubscription, requestGroupSubscriptionRemoval } from '../..
 import { saveGroupSubscriptions } from '../../Utils';
 
 const TelemetryLogContainer = ({
-  data,
-  groupName,
+  streams,
+  subscriptionsList,
   saveSubscriptionLocally,
   removeSubscriptionLocally,
   subscribeToStream,
@@ -24,19 +24,21 @@ const TelemetryLogContainer = ({
 
   return (
     <TelemetryLog
-      data={data}
+      streams={streams}
       subscribeToStream={subscribeAndSaveGroup}
       unsubscribeToStream={unsubscribeAndRemoveGroup}
+      subscriptionsList={subscriptionsList}
     />
   );
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const scriptqueue = state.ws.subscriptions.filter((s) => s.groupName === ownProps.groupName); //'event-ScriptQueue-all');
+  let streams = state.ws.subscriptions.filter((s) => ownProps.subscriptionsList.includes(s.groupName));
+  if (streams.length === 0) return {};
+  streams = streams.filter(s=>s.data);
 
-  if (scriptqueue.length === 0) return {};
-  if (!scriptqueue[0].data) return {};
-  return { data: scriptqueue[0].data };
+  if (streams.length === 0) return {};
+  return { streams: streams };
 };
 
 const mapDispatchToProps = (dispatch) => {

--- a/love/src/components/TelemetryLog/TelemetryLog.jsx
+++ b/love/src/components/TelemetryLog/TelemetryLog.jsx
@@ -27,7 +27,7 @@ export default class TelemetryLog extends Component {
     category: 'event',
     csc: 'ScriptQueue',
     stream: 'all',
-    data: {}
+    data: {},
   };
 
   updateMessageList = (msg) => {
@@ -65,27 +65,18 @@ export default class TelemetryLog extends Component {
   };
 
   subscribeToStream = () => {
-    this.props.subscribeToStream(
-      this.state.category,
-      this.state.csc,
-      this.state.stream
-    );
+    this.props.subscribeToStream([this.state.category, this.state.csc, this.state.stream].join('-'));
   };
 
   unsubscribeToStream = () => {
-    this.props.unsubscribeToStream(
-      this.state.category,
-      this.state.csc,
-      this.state.stream,
-      this.receiveMessage,
-    );
+    this.props.unsubscribeToStream([this.state.category, this.state.csc, this.state.stream].join('-'));
   };
 
   componentDidUpdate = (prevProps) => {
-    if(this.props.data !== prevProps.data){
+    if (this.props.data !== prevProps.data) {
       this.updateMessageList(this.props.data);
     }
-  }
+  };
 
   render() {
     return (

--- a/love/src/components/TelemetryLog/TelemetryLog.jsx
+++ b/love/src/components/TelemetryLog/TelemetryLog.jsx
@@ -73,8 +73,8 @@ export default class TelemetryLog extends Component {
   };
 
   componentDidUpdate = (prevProps) => {
-    if (this.props.data !== prevProps.data) {
-      this.updateMessageList(this.props.data);
+    if (this.props.streams !== prevProps.streams) {
+      this.updateMessageList(this.props.streams);
     }
   };
 


### PR DESCRIPTION
groupName subscription in TelemetryLog was hardcoded. 
Now it selects the portion of the subscriptions list in the state using the list of streams in a High Order Component (HOC) which is passed as props to the TelemetryLog.container

This was a workaround for not being able to get the local component state from mapStateToProps.

It would have been better and cleaner to use something like
```javascript
const mapStateToProps = (state, ownProps, ownState) => {
  let streams = state.ws.subscriptions.filter((s) => ownState.subscriptionsList.includes(s.groupName));
  ...
}
```

See: https://github.com/lsst-ts/LOVE-frontend/blob/bfdee005bf1c9f6bf92a4f23a67b830da0bd0a6e/love/src/components/TelemetryLog/TelemetryLog.container.jsx#L36