### PR TITLE
Csc group logs

### DIFF
--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
@@ -32,7 +32,6 @@ export const schema = {
 };
 
 const CSCDetailContainer = ({
-  realm,
   group,
   name,
   salindex,
@@ -44,7 +43,6 @@ const CSCDetailContainer = ({
 }) => {
   return (
     <CSCDetail
-      realm={realm}
       group={group}
       name={name}
       salindex={salindex}

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
@@ -8,7 +8,6 @@ export default class CSCDetail extends Component {
   static propTypes = {
     name: PropTypes.string,
     group: PropTypes.string,
-    realm: PropTypes.string,
     salindex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     data: PropTypes.object,
     onCSCClick: PropTypes.func,
@@ -23,7 +22,6 @@ export default class CSCDetail extends Component {
   static defaultProps = {
     name: '',
     group: '',
-    realm: '',
     data: {},
     onCSCClick: () => 0,
     heartbeatData: null,
@@ -113,7 +111,9 @@ export default class CSCDetail extends Component {
     if (summaryState.name === 'UNKNOWN') stateClass = CSCDetail.states[0].class;
     return (
       <div
-        onClick={() => this.props.onCSCClick(props.realm, props.group, props.name, props.salindex)}
+        onClick={() =>
+          this.props.onCSCClick({group: props.group, csc: props.name, salindex: props.salindex })
+        }
         className={[styles.CSCDetailContainer, this.props.embedded ? styles.minWidth : ''].join(' ')}
       >
         <div className={[styles.summaryStateSection, summaryState.class].join(' ')}>

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -36,7 +36,6 @@ const CSCExpandedContainer = ({
   name,
   salindex,
   group,
-  realm,
   onCSCClick,
   clearCSCErrorCodes,
   clearCSCLogMessages,
@@ -51,7 +50,6 @@ const CSCExpandedContainer = ({
       name={name}
       salindex={salindex}
       group={group}
-      realm={realm}
       onCSCClick={onCSCClick}
       clearCSCErrorCodes={clearCSCErrorCodes}
       errorCodeData={errorCodeData}

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -12,7 +12,6 @@ export default class CSCExpanded extends PureComponent {
     name: PropTypes.string,
     salindex: PropTypes.number,
     group: PropTypes.string,
-    realm: PropTypes.string,
     onCSCClick: PropTypes.func,
     clearCSCErrorCodes: PropTypes.func,
     clearCSCLogMessages: PropTypes.func,
@@ -25,7 +24,6 @@ export default class CSCExpanded extends PureComponent {
     name: '',
     salindex: undefined,
     group: '',
-    realm: '',
     onCSCClick: () => 0,
     clearCSCErrorCodes: () => 0,
     clearCSCLogMessages: () => 0,
@@ -137,28 +135,26 @@ export default class CSCExpanded extends PureComponent {
           <div className={styles.topBarContainerWrapper}>
             <div className={styles.topBarContainer}>
               <div className={styles.breadcrumContainer}>
-                {
-                  this.props.group && <>
+                {this.props.group && (
+                  <>
                     <div
                       className={styles.backArrowIconWrapper}
-                      onClick={() =>
-                        this.props.onCSCClick(this.props.realm, this.props.group, this.props.name, this.props.salindex)
-                      }
+                      onClick={() => this.props.onCSCClick({ group: this.props.group })}
                     >
                       <BackArrowIcon />
                     </div>
                     <span
                       className={styles.breadcrumbGroup}
-                      onClick={() => this.props.onCSCClick(this.props.realm, this.props.group, 'all')}
+                      onClick={() =>
+                        this.props.onCSCClick({ group: this.props.group, csc: 'all' })
+                      }
                     >
                       {props.group}
                     </span>
-                    <span>{' '}&#62; </span>
+                    <span> &#62; </span>
                   </>
-                }
-                <span>
-                  {cscText(this.props.name, this.props.salindex)}
-                </span>
+                )}
+                <span>{cscText(this.props.name, this.props.salindex)}</span>
               </div>
               <div className={[styles.stateContainer].join(' ')}>
                 <div>
@@ -176,37 +172,37 @@ export default class CSCExpanded extends PureComponent {
             </div>
           </div>
           {this.props.errorCodeData.length > 0 ? (
-            <div className={[styles.logContainer, styles.errorCodeContainer].join(' ')}>
-              <div className={styles.logContainerTopBar}>
-                <div>ERROR CODE</div>
-                <div>
-                  <Button
-                    size="extra-small"
-                    onClick={() => this.props.clearCSCErrorCodes(this.props.name, this.props.salindex)}
-                  >
-                    CLEAR
-                  </Button>
-                </div>
-              </div>
-              <div className={[styles.log, styles.messageLogContent].join(' ')}>
-                {this.props.errorCodeData.map((msg, index) => {
-                  return (
-                    <div key={`${msg.private_rcvStamp.value}-${index}`} className={styles.logMessage}>
-                      <div className={styles.errorCode} title={`Error code ${msg.errorCode.value}`}>
-                        {msg.errorCode.value}
-                      </div>
-                      <div className={styles.messageTextContainer}>
-                        <div className={styles.timestamp} title="private_rcvStamp">
-                          {new Date(msg.private_rcvStamp.value * 1000).toUTCString()}
-                        </div>
-                        <div className={styles.messageText}>{msg.errorReport.value}</div>
-                        <div className={styles.messageTraceback}>{msg.traceback.value}</div>
-                      </div>
-                    </div>
-                  );
-                })}
+          <div className={[styles.logContainer, styles.errorCodeContainer].join(' ')}>
+            <div className={styles.logContainerTopBar}>
+              <div>ERROR CODE</div>
+              <div>
+                <Button
+                  size="extra-small"
+                  onClick={() => this.props.clearCSCErrorCodes(this.props.name, this.props.salindex)}
+                >
+                  CLEAR
+                </Button>
               </div>
             </div>
+            <div className={[styles.log, styles.messageLogContent].join(' ')}>
+              {this.props.errorCodeData.map((msg, index) => {
+                return (
+                  <div key={`${msg.private_rcvStamp.value}-${index}`} className={styles.logMessage}>
+                    <div className={styles.errorCode} title={`Error code ${msg.errorCode.value}`}>
+                      {msg.errorCode.value}
+                    </div>
+                    <div className={styles.messageTextContainer}>
+                      <div className={styles.timestamp} title="private_rcvStamp">
+                        {new Date(msg.private_rcvStamp.value * 1000).toUTCString()}
+                      </div>
+                      <div className={styles.messageText}>{msg.errorReport.value}</div>
+                      <div className={styles.messageTraceback}>{msg.traceback.value}</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
           ) : null}
 
           <LogMessageDisplay

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -138,7 +138,7 @@ export default class CSCExpanded extends PureComponent {
             <div className={styles.topBarContainer}>
               <div className={styles.breadcrumContainer}>
                 {
-                  this.props.realm && this.props.group && <>
+                  this.props.group && <>
                     <div
                       className={styles.backArrowIconWrapper}
                       onClick={() =>

--- a/love/src/components/CSCSummary/CSCGroup/CSCGroup.jsx
+++ b/love/src/components/CSCSummary/CSCGroup/CSCGroup.jsx
@@ -14,22 +14,16 @@ export default class CSCGroup extends Component {
   }
   static propTypes = {
     name: PropTypes.string,
-    realm: PropTypes.string,
     cscs: PropTypes.array,
     onCSCClick: PropTypes.func,
-    selectedCSCs: PropTypes.array,
-    hierarchy: PropTypes.object,
     embedded: PropTypes.bool,
   };
 
   static defaultProps = {
     name: '',
-    realm: '',
     cscs: [],
-    // onCSCClick: () => 0,
     subscribeToStreams: () => 0,
-    // selectedCSCs: [],
-    hierarchy: {},
+    selectedCSC: undefined,
     embedded: false,
   };
 
@@ -46,16 +40,14 @@ export default class CSCGroup extends Component {
 
     return groupView ? (
       <CSCGroupLogContainer
-        realm={selectedCSC.realm}
         group={selectedCSC.group}
         name={selectedCSC.csc}
         onCSCClick={this.onCSCClick}
-        hierarchy={this.props.hierarchy}
+        cscList={this.props.cscs}
         embedded={true}
       />
     ) : (
       <CSCExpandedContainer
-        realm={selectedCSC.realm}
         group={selectedCSC.group}
         name={selectedCSC.csc}
         salindex={selectedCSC.salindex}
@@ -64,8 +56,8 @@ export default class CSCGroup extends Component {
     );
   };
 
-  onCSCClick = (realm, group, csc, salindex) => {
-    if (this.state.selectedCSC !== undefined) {
+  onCSCClick = ({ group, csc, salindex }) => {
+    if (!csc) {
       this.setState({
         selectedCSC: undefined,
       });
@@ -74,26 +66,22 @@ export default class CSCGroup extends Component {
 
     this.setState({
       selectedCSC: {
-        realm,
         group,
         csc,
         salindex,
       },
     });
-
   };
   render() {
-    // let selectedCSC = this.props.selectedCSCs.filter((data) => {
-    //   return data.realm === this.props.realm && data.group === this.props.name;
-    // });
     let { selectedCSC } = this.state;
-    // const expanded = selectedCSC !== undefined;
-    // [selectedCSC] = selectedCSC;
     return selectedCSC ? (
       this.renderExpandedView(selectedCSC)
     ) : (
       <div className={styles.CSCGroupContainer}>
-        <div className={styles.CSCGroupTitle} onClick={() => this.onCSCClick(this.props.realm, this.props.name, 'all')}>
+        <div
+          className={styles.CSCGroupTitle}
+          onClick={() => this.onCSCClick({  group: this.props.name, csc: 'all' })}
+        >
           {this.props.name}
         </div>
         <div className={styles.CSCDetailsContainer}>
@@ -101,7 +89,6 @@ export default class CSCGroup extends Component {
             return (
               <div key={csc.name + csc.salindex} className={styles.CSCDetailContainer}>
                 <CSCDetailContainer
-                  realm={this.props.realm}
                   group={this.props.name}
                   name={csc.name}
                   salindex={csc.salindex}

--- a/love/src/components/CSCSummary/CSCGroup/CSCGroup.jsx
+++ b/love/src/components/CSCSummary/CSCGroup/CSCGroup.jsx
@@ -6,6 +6,12 @@ import CSCExpandedContainer from '../CSCExpanded/CSCExpanded.container';
 import CSCGroupLogContainer from '../CSCGroupLog/CSCGroupLog.container';
 
 export default class CSCGroup extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedCSC: undefined,
+    };
+  }
   static propTypes = {
     name: PropTypes.string,
     realm: PropTypes.string,
@@ -20,9 +26,9 @@ export default class CSCGroup extends Component {
     name: '',
     realm: '',
     cscs: [],
-    onCSCClick: () => 0,
+    // onCSCClick: () => 0,
     subscribeToStreams: () => 0,
-    selectedCSCs: [],
+    // selectedCSCs: [],
     hierarchy: {},
     embedded: false,
   };
@@ -36,14 +42,14 @@ export default class CSCGroup extends Component {
   };
 
   renderExpandedView = (selectedCSC) => {
-    const groupView = selectedCSC.csc === 'all';
+    const groupView = selectedCSC.csc == 'all';
 
     return groupView ? (
       <CSCGroupLogContainer
         realm={selectedCSC.realm}
         group={selectedCSC.group}
         name={selectedCSC.csc}
-        onCSCClick={this.props.onCSCClick}
+        onCSCClick={this.onCSCClick}
         hierarchy={this.props.hierarchy}
         embedded={true}
       />
@@ -53,25 +59,41 @@ export default class CSCGroup extends Component {
         group={selectedCSC.group}
         name={selectedCSC.csc}
         salindex={selectedCSC.salindex}
-        onCSCClick={this.props.onCSCClick}
+        onCSCClick={this.onCSCClick}
       />
     );
   };
 
-  render() {
-    let selectedCSC = this.props.selectedCSCs.filter((data) => {
-      return data.realm === this.props.realm && data.group === this.props.name;
+  onCSCClick = (realm, group, csc, salindex) => {
+    if (this.state.selectedCSC !== undefined) {
+      this.setState({
+        selectedCSC: undefined,
+      });
+      return;
+    }
+
+    this.setState({
+      selectedCSC: {
+        realm,
+        group,
+        csc,
+        salindex,
+      },
     });
-    const expanded = selectedCSC.length > 0;
-    [selectedCSC] = selectedCSC;
-    return expanded ? (
+
+  };
+  render() {
+    // let selectedCSC = this.props.selectedCSCs.filter((data) => {
+    //   return data.realm === this.props.realm && data.group === this.props.name;
+    // });
+    let { selectedCSC } = this.state;
+    // const expanded = selectedCSC !== undefined;
+    // [selectedCSC] = selectedCSC;
+    return selectedCSC ? (
       this.renderExpandedView(selectedCSC)
     ) : (
       <div className={styles.CSCGroupContainer}>
-        <div
-          className={styles.CSCGroupTitle}
-          onClick={() => this.props.onCSCClick(this.props.realm, this.props.name, 'all')}
-        >
+        <div className={styles.CSCGroupTitle} onClick={() => this.onCSCClick(this.props.realm, this.props.name, 'all')}>
           {this.props.name}
         </div>
         <div className={styles.CSCDetailsContainer}>
@@ -83,7 +105,7 @@ export default class CSCGroup extends Component {
                   group={this.props.name}
                   name={csc.name}
                   salindex={csc.salindex}
-                  onCSCClick={this.props.onCSCClick}
+                  onCSCClick={this.onCSCClick}
                   embedded={true}
                   shouldSubscribe={true}
                 />

--- a/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.container.jsx
+++ b/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.container.jsx
@@ -6,7 +6,8 @@ import { getGroupSortedErrorCodeData } from '../../../redux/selectors';
 import { removeCSCErrorCodeData } from '../../../redux/actions/summaryData';
 
 export const schema = {
-  description: 'Displays the error code logs for a set of CSCs, including error code, message, traceback and timestamp. Also includes current summary state and heartbeat for each CSC',
+  description:
+    'Displays the error code logs for a set of CSCs, including error code, message, traceback and timestamp. Also includes current summary state and heartbeat for each CSC',
   defaultSize: [24, 29],
   props: {
     group: {
@@ -31,11 +32,9 @@ export const schema = {
 };
 
 const CSCGroupLogContainer = ({
-  realm,
   group,
   name,
   onCSCClick,
-  hierarchy,
   clearCSCErrorCodes,
   subscribeToStream,
   errorCodeData,
@@ -44,11 +43,9 @@ const CSCGroupLogContainer = ({
 }) => {
   return (
     <CSCGroupLog
-      realm={realm}
       group={group}
       name={name}
       onCSCClick={onCSCClick}
-      hierarchy={hierarchy}
       clearCSCErrorCodes={clearCSCErrorCodes}
       subscribeToStream={subscribeToStream}
       errorCodeData={errorCodeData}
@@ -70,20 +67,9 @@ const mapDispatchtoProps = (dispatch) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  if (ownProps.realm && ownProps.hierarchy[ownProps.realm] && ownProps.hierarchy[ownProps.realm][ownProps.group]) {
-    const errorCodeData = getGroupSortedErrorCodeData(state, ownProps.hierarchy[ownProps.realm][ownProps.group]);
-    return {
-      errorCodeData: errorCodeData,
-    };
-  }
-  if (ownProps.cscList) {
-    const errorCodeData = getGroupSortedErrorCodeData(state, ownProps.cscList);
-    return {
-      errorCodeData: errorCodeData,
-    };
-  }
+  const errorCodeData = getGroupSortedErrorCodeData(state, ownProps.cscList);
   return {
-    errorCodeData: [],
+    errorCodeData: errorCodeData,
   };
 };
 

--- a/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.jsx
+++ b/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.jsx
@@ -9,10 +9,8 @@ export default class CSCGroupLog extends Component {
   static propTypes = {
     name: PropTypes.string,
     group: PropTypes.string,
-    realm: PropTypes.string,
     data: PropTypes.object,
     onCSCClick: PropTypes.func,
-    hierarchy: PropTypes.object,
     clearCSCErrorCodes: PropTypes.func,
     clearCSCLogMessages: PropTypes.func,
     subscribeToStream: PropTypes.func,
@@ -23,10 +21,8 @@ export default class CSCGroupLog extends Component {
   static defaultProps = {
     name: '',
     group: '',
-    realm: '',
     data: {},
     onCSCClick: () => 0,
-    hierarchy: {},
     clearCSCErrorCodes: () => 0,
     clearCSCLogMessages: () => 0,
     errorCodeData: [],
@@ -34,27 +30,15 @@ export default class CSCGroupLog extends Component {
   };
 
   componentDidMount = () => {
-    if (this.props.hierarchy[this.props.realm]) {
-      this.props.hierarchy[this.props.realm][this.props.group].forEach(({ name, salindex }) => {
-        this.props.subscribeToStream(name, salindex);
-      });
-    } else if (this.props.cscList) {
       this.props.cscList.forEach(({ name, salindex }) => {
         this.props.subscribeToStream(name, salindex);
       });
-    }
   };
 
   clearGroupErrorCodes = () => {
-    if (this.props.hierarchy[this.props.realm]) {
-      this.props.hierarchy[this.props.realm][this.props.group].forEach(({ name, salindex }) => {
-        this.props.clearCSCErrorCodes(name, salindex);
-      });
-    } else if (this.props.cscList) {
       this.props.cscList.forEach(({ name, salindex }) => {
         this.props.clearCSCErrorCodes(name, salindex);
       });
-    }
   };
 
   render() {
@@ -68,7 +52,7 @@ export default class CSCGroupLog extends Component {
                 {this.props.embedded && (
                   <div
                     className={styles.backArrowIconWrapper}
-                    onClick={() => this.props.onCSCClick(this.props.realm, this.props.group, 'all')}
+                    onClick={() => this.props.onCSCClick({  group: this.props.group })}
                   >
                     <BackArrowIcon />
                   </div>
@@ -98,7 +82,6 @@ export default class CSCGroupLog extends Component {
                     <div className={styles.messageTextContainer}>
                       <div className={styles.messageTopSection}>
                         <CSCDetailContainer
-                          realm={this.props.realm}
                           group={this.props.group}
                           name={msg.csc}
                           salindex={msg.salindex}

--- a/love/src/components/CSCSummary/CSCRealm/CSCRealm.jsx
+++ b/love/src/components/CSCSummary/CSCRealm/CSCRealm.jsx
@@ -1,22 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styles from './CSCRealm.module.css';
-import CSCGroup from '../CSCGroup/CSCGroup';
+import CSCGroupContainer from '../CSCGroup/CSCGroup.container';
 
 export default class CSCRealm extends Component {
   static propTypes = {
     name: PropTypes.string,
     groups: PropTypes.object,
-    // onCSCClick: PropTypes.func,
-    // selectedCSCs: PropTypes.array,
     hierarchy: PropTypes.object,
   };
 
   static defaultProps = {
     name: '',
     groups: {},
-    // onCSCClick: () => 0,
-    // selectedCSCs: [],
     hierarchy: {},
   };
 
@@ -27,13 +23,9 @@ export default class CSCRealm extends Component {
         {Object.keys(this.props.groups).map((group) => {
           return (
             <div key={group} className={styles.CSCGroupContainer}>
-              <CSCGroup
-                realm={this.props.name}
+              <CSCGroupContainer
                 name={group}
                 cscs={this.props.groups[group]}
-                // onCSCClick={this.props.onCSCClick}
-                // selectedCSCs={this.props.selectedCSCs}
-                hierarchy={this.props.hierarchy}
                 embedded={true}
               />
             </div>

--- a/love/src/components/CSCSummary/CSCRealm/CSCRealm.jsx
+++ b/love/src/components/CSCSummary/CSCRealm/CSCRealm.jsx
@@ -7,16 +7,16 @@ export default class CSCRealm extends Component {
   static propTypes = {
     name: PropTypes.string,
     groups: PropTypes.object,
-    onCSCClick: PropTypes.func,
-    selectedCSCs: PropTypes.array,
+    // onCSCClick: PropTypes.func,
+    // selectedCSCs: PropTypes.array,
     hierarchy: PropTypes.object,
   };
 
   static defaultProps = {
     name: '',
     groups: {},
-    onCSCClick: () => 0,
-    selectedCSCs: [],
+    // onCSCClick: () => 0,
+    // selectedCSCs: [],
     hierarchy: {},
   };
 
@@ -31,8 +31,8 @@ export default class CSCRealm extends Component {
                 realm={this.props.name}
                 name={group}
                 cscs={this.props.groups[group]}
-                onCSCClick={this.props.onCSCClick}
-                selectedCSCs={this.props.selectedCSCs}
+                // onCSCClick={this.props.onCSCClick}
+                // selectedCSCs={this.props.selectedCSCs}
                 hierarchy={this.props.hierarchy}
                 embedded={true}
               />

--- a/love/src/components/CSCSummary/CSCSummary.container.jsx
+++ b/love/src/components/CSCSummary/CSCSummary.container.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import CSCSummary from './CSCSummary';
 import { CSCSummaryHierarchy } from '../../Config';
-import { requestGroupSubscription, requestGroupSubscriptionRemoval } from '../../redux/actions/ws';
 
 export const schema = {
   description: 'Summary of all CSCs, including heartbeats, summary state, logs and error codes',
@@ -10,45 +8,13 @@ export const schema = {
   props: {},
 };
 
-const CSCSummaryContainer = ({ subscribeToStreams, unsubscribeToStreams, expandHeight }) => {
+const CSCSummaryContainer = ({ expandHeight }) => {
   return (
     <CSCSummary
       hierarchy={CSCSummaryHierarchy}
-      subscribeToStreams={subscribeToStreams}
-      unsubscribeToStreams={unsubscribeToStreams}
       expandHeight={expandHeight}
     />
   );
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    subscribeToStreams: () => {
-      dispatch(requestGroupSubscription('event-Heartbeat-0-stream'));
-      Object.keys(CSCSummaryHierarchy).forEach((realm) => {
-        const groupsDict = CSCSummaryHierarchy[realm];
-        Object.keys(groupsDict).forEach((group) => {
-          groupsDict[group].forEach((csc) => {
-            dispatch(requestGroupSubscription(`event-${csc.name}-${csc.salindex}-summaryState`));
-            dispatch(requestGroupSubscription(`event-${csc.name}-${csc.salindex}-logMessage`));
-            dispatch(requestGroupSubscription(`event-${csc.name}-${csc.salindex}-errorCode`));
-          });
-        });
-      });
-    },
-    unsubscribeToStreams: () => {
-      dispatch(requestGroupSubscriptionRemoval('event-Heartbeat-0-stream'));
-      Object.keys(CSCSummaryHierarchy).forEach((realm) => {
-        const groupsDict = CSCSummaryHierarchy[realm];
-        Object.keys(groupsDict).forEach((group) => {
-          groupsDict[group].forEach((csc) => {
-            dispatch(requestGroupSubscriptionRemoval(`event-${csc.name}-${csc.salindex}-summaryState`));
-            dispatch(requestGroupSubscriptionRemoval(`event-${csc.name}-${csc.salindex}-logMessage`));
-            dispatch(requestGroupSubscriptionRemoval(`event-${csc.name}-${csc.salindex}-errorCode`));
-          });
-        });
-      });
-    },
-  };
-};
-export default connect(null, mapDispatchToProps)(CSCSummaryContainer);
+export default CSCSummaryContainer;

--- a/love/src/components/CSCSummary/CSCSummary.container.jsx
+++ b/love/src/components/CSCSummary/CSCSummary.container.jsx
@@ -5,16 +5,18 @@ import { CSCSummaryHierarchy } from '../../Config';
 export const schema = {
   description: 'Summary of all CSCs, including heartbeats, summary state, logs and error codes',
   defaultSize: [57, 35],
-  props: {},
+  props: {
+    hierarchy: {
+      type: 'object',
+      description: 'Hierarchy on which to display CSC summaries',
+      isPrivate: false,
+      default: CSCSummaryHierarchy,
+    },
+  },
 };
 
-const CSCSummaryContainer = ({ expandHeight }) => {
-  return (
-    <CSCSummary
-      hierarchy={CSCSummaryHierarchy}
-      expandHeight={expandHeight}
-    />
-  );
+const CSCSummaryContainer = ({ hierarchy = CSCSummaryHierarchy, expandHeight }) => {
+  return <CSCSummary hierarchy={hierarchy} expandHeight={expandHeight} />;
 };
 
 export default CSCSummaryContainer;

--- a/love/src/components/CSCSummary/CSCSummary.jsx
+++ b/love/src/components/CSCSummary/CSCSummary.jsx
@@ -27,41 +27,6 @@ export default class CSCSummary extends Component {
       },
     },
   };
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedCSCs: [],
-      // selectedCSCs: [{ realm: 'Aux Telescope', group: 'CSC Group 1', csc: 'ATCamera' }],
-    };
-  }
-
-  componentDidMount = () => {
-    this.props.subscribeToStreams();
-  };
-
-  componentWillUnmount = () => {
-    this.props.unsubscribeToStreams();
-  };
-
-  // toggleCSCExpansion = (realm, group, csc, salindex) => {
-  //   const newSelectedCSCs = [...this.state.selectedCSCs];
-
-  //   for (let i = 0; i < this.state.selectedCSCs.length; i += 1) {
-  //     const currentCSC = this.state.selectedCSCs[i];
-  //     if (realm === currentCSC.realm && group === currentCSC.group) {
-  //       newSelectedCSCs.splice(i, 1);
-  //       if (csc === currentCSC.csc && salindex === currentCSC.salindex) {
-  //         this.setState({ selectedCSCs: newSelectedCSCs });
-  //         return;
-  //       }
-  //     }
-  //   }
-  //   this.setState({
-  //     selectedCSCs: [...newSelectedCSCs, { realm, group, csc, salindex }],
-  //   });
-  // };
-
   render() {
     return (
       <Panel title="CSC Summary" className={styles.panel} expandHeight={this.props.expandHeight}>
@@ -69,11 +34,7 @@ export default class CSCSummary extends Component {
           {Object.keys(this.props.hierarchy).map((realm) => {
             return (
               <div key={realm} className={styles.CSCRealmContainer}>
-                <CSCRealm
-                  name={realm}
-                  groups={this.props.hierarchy[realm]}
-                  hierarchy={this.props.hierarchy}
-                />
+                <CSCRealm name={realm} groups={this.props.hierarchy[realm]} hierarchy={this.props.hierarchy} />
               </div>
             );
           })}

--- a/love/src/components/CSCSummary/CSCSummary.jsx
+++ b/love/src/components/CSCSummary/CSCSummary.jsx
@@ -10,23 +10,6 @@ export default class CSCSummary extends Component {
     expandHeight: PropTypes.bool,
   };
 
-  static defaultProps = {
-    hierarchy: {
-      'Aux Telescope': {
-        'CSC Group 1': [
-          { name: 'ScriptQueue', salindex: 1 },
-          { name: 'ATDome', salindex: 1 },
-        ],
-      },
-      'Main Telescope': {
-        'CSC Group 1': [{ name: 'CSC4', salindex: 0 }],
-        'CSC Group 2': [],
-      },
-      Observatory: {
-        'CSC Group 1': [],
-      },
-    },
-  };
   render() {
     return (
       <Panel title="CSC Summary" className={styles.panel} expandHeight={this.props.expandHeight}>

--- a/love/src/components/CSCSummary/CSCSummary.jsx
+++ b/love/src/components/CSCSummary/CSCSummary.jsx
@@ -44,23 +44,23 @@ export default class CSCSummary extends Component {
     this.props.unsubscribeToStreams();
   };
 
-  toggleCSCExpansion = (realm, group, csc, salindex) => {
-    const newSelectedCSCs = [...this.state.selectedCSCs];
+  // toggleCSCExpansion = (realm, group, csc, salindex) => {
+  //   const newSelectedCSCs = [...this.state.selectedCSCs];
 
-    for (let i = 0; i < this.state.selectedCSCs.length; i += 1) {
-      const currentCSC = this.state.selectedCSCs[i];
-      if (realm === currentCSC.realm && group === currentCSC.group) {
-        newSelectedCSCs.splice(i, 1);
-        if (csc === currentCSC.csc && salindex === currentCSC.salindex) {
-          this.setState({ selectedCSCs: newSelectedCSCs });
-          return;
-        }
-      }
-    }
-    this.setState({
-      selectedCSCs: [...newSelectedCSCs, { realm, group, csc, salindex }],
-    });
-  };
+  //   for (let i = 0; i < this.state.selectedCSCs.length; i += 1) {
+  //     const currentCSC = this.state.selectedCSCs[i];
+  //     if (realm === currentCSC.realm && group === currentCSC.group) {
+  //       newSelectedCSCs.splice(i, 1);
+  //       if (csc === currentCSC.csc && salindex === currentCSC.salindex) {
+  //         this.setState({ selectedCSCs: newSelectedCSCs });
+  //         return;
+  //       }
+  //     }
+  //   }
+  //   this.setState({
+  //     selectedCSCs: [...newSelectedCSCs, { realm, group, csc, salindex }],
+  //   });
+  // };
 
   render() {
     return (
@@ -72,8 +72,6 @@ export default class CSCSummary extends Component {
                 <CSCRealm
                   name={realm}
                   groups={this.props.hierarchy[realm]}
-                  onCSCClick={this.toggleCSCExpansion}
-                  selectedCSCs={this.state.selectedCSCs}
                   hierarchy={this.props.hierarchy}
                 />
               </div>


### PR DESCRIPTION
Enable displaying CSC logs from `CSCGroup` components by refactoring many things.
Now `CSCSummary` is only in charge of layout organization (the hierarchy) and `CSCGroup` and childs handle subscriptions and data processing. This makes the use of `realm` prop unnecessary except for  `CSCSummary`.