### PR TITLE
Use callback ref for generic camera canvas handling

### DIFF
--- a/love/src/components/GenericCamera/GenericCamera.jsx
+++ b/love/src/components/GenericCamera/GenericCamera.jsx
@@ -28,7 +28,29 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
   const [retryCount, setRetryCount] = useState(0);
   const [initialLoading, setInitialLoading] = useState(true);
 
-  const canvasRef = useRef(null);
+  // const canvasRef = useRef(null);
+  const [canvasRef, setCanvasRef] = useState(null);
+
+  const onCanvasRefChange = React.useCallback(
+    (canvasNode) => {
+      setCanvasRef(canvasNode);
+      /** Listen to size changes of the canvas parent element*/
+      if (!canvasNode) return;
+      if (error !== null) return;
+      const observer = new ResizeObserver((entries) => {
+        const container = entries[0];
+        setContainerWidth(container.contentRect.width);
+        setContainerHeight(container.contentRect.height);
+      });
+
+      observer.observe(canvasNode.parentNode);
+
+      return () => {
+        observer.disconnect();
+      };
+    },
+    [error],
+  );
 
   useEffect(() => {
     /** Start the stream once and update image size on every receive
@@ -48,7 +70,6 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
     };
 
     const imageErrorCallback = (error) => {
-      console.log(error);
       retryFetch(error);
     };
 
@@ -61,12 +82,12 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
           setError(null);
           setInitialLoading(false);
           setRetryCount(0);
-          if (canvasRef.current) {
+          if (canvasRef) {
             setImageWidth(image.width);
             setImageHeight(image.height);
-            canvasRef.current.width = image.width;
-            canvasRef.current.height = image.height;
-            CameraUtils.draw(image.body, canvasRef.current);
+            canvasRef.width = image.width;
+            canvasRef.height = image.height;
+            CameraUtils.draw(image.body, canvasRef);
           }
         },
         signal,
@@ -80,40 +101,25 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
       controller.abort();
       clearTimeout(retryTimeout);
     };
-  }, [serverURL]);
+  }, [serverURL, canvasRef]);
 
-  useEffect(() => {
-    /** Listen to size changes of the canvas parent element*/
-    if (!canvasRef.current) return;
-    if (error !== null) return;
-    const observer = new ResizeObserver((entries) => {
-      const container = entries[0];
-      setContainerWidth(container.contentRect.width);
-      setContainerHeight(container.contentRect.height);
-    });
-
-    observer.observe(canvasRef.current.parentNode);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [error]);
 
   useEffect(() => {
     /** Sync canvas size with its container and stream  */
     if (error !== null) return;
     if (initialLoading) return;
+    if (!canvasRef) return;
     const imageAspectRatio = imageWidth / imageHeight;
     const containerAspectRatio = containerWidth / containerHeight;
 
     if (containerAspectRatio <= imageAspectRatio) {
       // image width does not fit container
-      canvasRef.current.style.width = `${containerWidth}px`;
-      canvasRef.current.style.height = `${containerWidth / imageAspectRatio}px`;
+      canvasRef.style.width = `${containerWidth}px`;
+      canvasRef.style.height = `${containerWidth / imageAspectRatio}px`;
     } else {
       // image height does not fit in container
-      canvasRef.current.style.height = `${containerHeight}px`;
-      canvasRef.current.style.width = `${containerHeight * imageAspectRatio}px`;
+      canvasRef.style.height = `${containerHeight}px`;
+      canvasRef.style.width = `${containerHeight * imageAspectRatio}px`;
     }
 
     /**
@@ -123,7 +129,7 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
      * but this might be less readable
      */
     //
-  }, [imageWidth, imageHeight, containerWidth, containerHeight, error, initialLoading]);
+  }, [imageWidth, imageHeight, containerWidth, containerHeight, error, initialLoading, canvasRef]);
 
   if (error !== null) {
     return (
@@ -134,7 +140,7 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
     );
   }
 
-  if (initialLoading ) {
+  if (initialLoading) {
     return (
       <div className={styles.errorContainer}>
         <p>Fetching stream from {serverURL}, please wait.</p>
@@ -142,5 +148,5 @@ export default function GenericCamera({ serverURL = schema.props.serverURL.defau
     );
   }
 
-  return <canvas ref={canvasRef}></canvas>;
+  return <canvas ref={onCanvasRefChange}></canvas>;
 }


### PR DESCRIPTION
Previously, handling canvas.current update from None to `<canvas/>` was messy and hard to predict. Using a callback ref fixes it.