### PR TITLE
Hide clock without hiding middletopbar

### DIFF
--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { ToastContainer, toast, Slide } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.min.css';
-import { viewsStates } from '../../redux/reducers/uif';
+import { viewsStates, modes } from '../../redux/reducers/uif';
 import { SALCommandStatus } from '../../redux/actions/ws';
 import { getNotificationMessage, relativeTime } from '../../Utils';
 import Button from '../GeneralPurpose/Button/Button';
@@ -316,7 +316,7 @@ class Layout extends Component {
 
           <div className={styles.middleTopbar}>
             <div id="middleTopbar"/>
-            <div className={styles.clock}>
+            <div className={[styles.clock, this.props.mode === modes.EDIT ? styles.hidden : ''].join(' ')}>
               <Clock timeData={this.props.timeData} hideAnalog hideOffset={true}/>
             </div>
           </div>

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -14,7 +14,7 @@ import MenuIcon from '../icons/MenuIcon/MenuIcon';
 import HeartbeatIcon from '../icons/HeartbeatIcon/HeartbeatIcon';
 import NotchCurve from './NotchCurve/NotchCurve';
 import EditIcon from '../icons/EditIcon/EditIcon';
-import Clock from '../Time/Clock/Clock'
+import Clock from '../Time/Clock/Clock';
 import styles from './Layout.module.css';
 
 const BREAK_1 = 865;
@@ -69,7 +69,7 @@ class Layout extends Component {
       lastHeartbeat: undefined,
       hovered: false, // true if leftTopbar is being hovered
     };
-    
+
     this.requestToastID = null;
   }
 
@@ -315,9 +315,14 @@ class Layout extends Component {
           </div>
 
           <div className={styles.middleTopbar}>
-            <div id="middleTopbar"/>
-            <div className={[styles.clock, this.props.mode === modes.EDIT ? styles.hidden : ''].join(' ')}>
-              <Clock timeData={this.props.timeData} hideAnalog hideOffset={true}/>
+            <div id="middleTopbar" />
+            <div
+              className={[
+                styles.clock,
+                this.props.mode === modes.EDIT && !this.state.toolbarOverflow ? styles.hidden : '',
+              ].join(' ')}
+            >
+              <Clock timeData={this.props.timeData} hideAnalog hideOffset={true} />
             </div>
           </div>
 

--- a/love/src/components/Layout/Layout.module.css
+++ b/love/src/components/Layout/Layout.module.css
@@ -100,7 +100,6 @@
 }
 
 .middleTopbar {
-  overflow: hidden;
 }
 
 .clock {


### PR DESCRIPTION
The `middleTopbar` was hidden in edit mode making the clock hide (desired) but the devices dropdown hide too (undesired).
Now only the clock is hidden.