### PR TITLE
Choose smaller device label as default when parsing container

### DIFF
--- a/love/src/components/UIF/CustomView.jsx
+++ b/love/src/components/UIF/CustomView.jsx
@@ -197,13 +197,24 @@ class CustomView extends Component {
   };
 
   getDeviceLabel = (width) => {
+    const minDevice = Object.entries(DEVICE_TO_SIZE).reduce((previousMinKey, [key, width])=> {
+      if(previousMinKey===''){
+        return key;
+      }
+
+      if(width < DEVICE_TO_SIZE[previousMinKey]){
+        return key;        
+      }
+      return previousMinKey;
+    }, '');
+
     const entry = Object.entries(DEVICE_TO_SIZE).find(([key, deviceOptionWidth]) => {
       if (deviceOptionWidth <= width) {
         return true;
       }
       return false;
     });
-    return entry[0];
+    return entry?.[0] ?? minDevice;
   };
 
   parseContainer = (container) => {


### PR DESCRIPTION
Reducing the device width below 320px from the chrome inspector throws this error:

![image](https://user-images.githubusercontent.com/3409401/79909541-27697f80-83eb-11ea-96cb-d93c1bb5780c.png)
