### PR TITLE
Telemetry selection from configform

### DIFF
--- a/love/src/components/AuxTel/LATISS/LATISS.jsx
+++ b/love/src/components/AuxTel/LATISS/LATISS.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import styles from './LATISS.module.css';
 import StatusText from '../../GeneralPurpose/StatusText/StatusText';
 import { stateToStyleLATISS, movingElementStateMap, raftsStateMap, shutterStateMap } from '../../../Config';
-import SubscriptionTableContainer from '../../GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
 
 export default class LATISS extends Component {
   static FILTER_ANGLE = 5.71;

--- a/love/src/components/EventLog/EventLog.container.jsx
+++ b/love/src/components/EventLog/EventLog.container.jsx
@@ -4,10 +4,6 @@ import EventLog from './EventLog';
 import { addGroupSubscription } from '../../redux/actions/ws';
 import { removeCSCLogMessages, removeCSCErrorCodeData } from '../../redux/actions/summaryData';
 import {
-  getStreamData,
-  getCSCHeartbeat,
-  getCSCLogMessages,
-  getCSCErrorCodeData,
   getGroupSortedErrorCodeData,
   getGroupSortedLogMessageData,
 } from '../../redux/selectors';

--- a/love/src/components/EventLog/EventLog.jsx
+++ b/love/src/components/EventLog/EventLog.jsx
@@ -1,14 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import styles from './EventLog.module.css';
-import BackArrowIcon from '../icons/BackArrowIcon/BackArrowIcon';
-import CSCDetailContainer from '../CSCSummary/CSCDetail/CSCDetail.container';
-import Button from '../GeneralPurpose/Button/Button';
 import { formatTimestamp, getStringRegExp } from '../../Utils';
 import InfoIcon from '../icons/InfoIcon/InfoIcon';
 import WarningIcon from '../icons/WarningIcon/WarningIcon';
 import ErrorIcon from '../icons/ErrorIcon/ErrorIcon';
-import { CardList, Card, Title, SubTitle, Separator } from '../GeneralPurpose/CardList/CardList';
+import { CardList, Card, Title, Separator } from '../GeneralPurpose/CardList/CardList';
 import TextField from '../TextField/TextField';
 
 export default class EventLog extends PureComponent {
@@ -174,8 +171,6 @@ export default class EventLog extends PureComponent {
   };
 
   render() {
-    const { props } = this;
-
     return (
       <div className={styles.CSCGroupLogContainer}>
         <CardList className={styles.cardList}>

--- a/love/src/components/EventLog/EventLog.module.css
+++ b/love/src/components/EventLog/EventLog.module.css
@@ -249,7 +249,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  align-items: end;
+  align-items: flex-end;
   margin-right: 2rem;
   margin-bottom: 0.5rem;
 }

--- a/love/src/components/GeneralPurpose/Panel/Panel.jsx
+++ b/love/src/components/GeneralPurpose/Panel/Panel.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styles from './Panel.module.css';
 import Button from '../Button/Button';
-import GearIcon from '../../icons/GearIcon/GearIcon';
 
 /**
  * A generic placeholder with a title that can be used

--- a/love/src/components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container.jsx
+++ b/love/src/components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container.jsx
@@ -75,12 +75,12 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     subscribeToStreams: (streams) => {
-      streams.map((groupName) => {
+      streams.forEach((groupName) => {
         dispatch(addGroupSubscription(groupName));
       });
     },
     unsubscribeToStreams: (streams) => {
-      streams.map((groupName) => {
+      streams.forEach((groupName) => {
         dispatch(requestGroupSubscriptionRemoval(groupName));
       });
     },

--- a/love/src/components/GeneralPurpose/SubscriptionTable/SubscriptionTable.jsx
+++ b/love/src/components/GeneralPurpose/SubscriptionTable/SubscriptionTable.jsx
@@ -1,6 +1,4 @@
 import React, { Component } from 'react';
-import SummaryPanel from '../SummaryPanel/SummaryPanel';
-import Label from '../SummaryPanel/Label';
 import Value from '../SummaryPanel/Value';
 // import Title from '../SummaryPanel/Title';
 import { CardList, Card, Title, SubTitle, Separator } from '../CardList/CardList';

--- a/love/src/components/GeneralPurpose/SubscriptionTable/SubscriptionTable.module.css
+++ b/love/src/components/GeneralPurpose/SubscriptionTable/SubscriptionTable.module.css
@@ -47,7 +47,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  align-items: end;
+  align-items: flex-end;
   margin-right: 2rem;
   margin-bottom: 0.5rem;
 }

--- a/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
+++ b/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
@@ -32,15 +32,25 @@ export const schema = {
     telemetryConfiguration: {
       type: 'object',
       description: `Dictionary describing the telemetries to monitor
+      and functions that can return an integer from 0 to 4 that represents
+      a different health status level.
+      
       Its shape must be: 
       {
-        "<component.salindex.topic>": ["<parameter_name>", ...]
+        "<component.salindex.topic>": {
+          <parameter_name>: healthfunction,
+          ...
+        }
         
       }
       such that for each <parameter_name> the data could be accessed in python with 
       
-      data = await salobj.Remote(domain, <component>, <salindex>).tel_<topic>
-      value = data.<parameter_name>
+      
+      >>> data = await salobj.Remote(domain, <component>, <salindex>).tel_<topic>
+      >>> value = data.<parameter_name>
+
+      
+      
       `,
       isPrivate: false,
       externalStep: 'TelemetrySelectionTable',

--- a/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
+++ b/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
@@ -4,6 +4,7 @@ import HealthStatusSummary from './HealthStatusSummary';
 import { addGroupSubscription, requestGroupSubscriptionRemoval } from '../../redux/actions/ws';
 import { getStreamsData } from '../../redux/selectors/selectors.js';
 import SubscriptionTableContainer from '../GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
+import { HEALTH_STATUS_VARIABLES_DECLARATION } from './TelemetrySelectionTable/TelemetrySelectionTable';
 
 const defaultHealthFunction = `return Math.floor(new Date().getSeconds()  / 4) % 5 ;`;
 export const schema = {
@@ -95,9 +96,10 @@ const HealthStatusSummaryContainer = ({
     if (!prevDict[`${component}-${salindex}`][topic]) prevDict[`${component}-${salindex}`][topic] = {};
 
     Object.keys(telemetryConfiguration[subscriptionName]).forEach((parameterName) => {
-      prevDict[`${component}-${salindex}`][topic][parameterName] = new Function(
-        telemetryConfiguration[subscriptionName][parameterName],
+      const code = [HEALTH_STATUS_VARIABLES_DECLARATION, telemetryConfiguration[subscriptionName][parameterName]].join(
+        '\n',
       );
+      prevDict[`${component}-${salindex}`][topic][parameterName] = new Function('value', code);
     });
     return prevDict;
   }, {});

--- a/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
+++ b/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
@@ -99,6 +99,7 @@ const HealthStatusSummaryContainer = ({
       const code = [HEALTH_STATUS_VARIABLES_DECLARATION, telemetryConfiguration[subscriptionName][parameterName]].join(
         '\n',
       );
+      /* eslint-disable no-new-func*/
       prevDict[`${component}-${salindex}`][topic][parameterName] = new Function('value', code);
     });
     return prevDict;

--- a/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
+++ b/love/src/components/HealthStatusSummary/HealthStatusSummary.container.jsx
@@ -43,6 +43,7 @@ export const schema = {
       value = data.<parameter_name>
       `,
       isPrivate: false,
+      externalStep: 'TelemetrySelectionTable',
       default: {
         'ATMCS-0-mount_AzEl_Encoders': {
           cRIO_timestamp: defaultHealthFunction,

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.container.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.container.jsx
@@ -12,12 +12,18 @@ const TelemetrySelectionTableContainer = ({
   onCancel,
   ...props
 }) => {
+
+  const [telemetries, setTelemetries] = React.useState({});
+
+  if(allTelemetries && Object.keys(allTelemetries).length > 4 && Object.keys(telemetries).length === 0){
+    setTelemetries(allTelemetries);
+  }
   return (
     <TelemetrySelectionTable
       {...props}
       subscribeToStream={subscribeToStream}
       unsubscribeToStream={unsubscribeToStream}
-      allTelemetries={allTelemetries}
+      allTelemetries={telemetries}
       onCancel={onCancel}
       onSetSelection={onSave}
     />

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.container.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.container.jsx
@@ -18,6 +18,8 @@ const TelemetrySelectionTableContainer = ({
       subscribeToStream={subscribeToStream}
       unsubscribeToStream={unsubscribeToStream}
       allTelemetries={allTelemetries}
+      onCancel={onCancel}
+      onSetSelection={onSave}
     />
   );
 };

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.container.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.container.jsx
@@ -4,7 +4,12 @@ import { getAllTelemetries } from '../../../redux/selectors';
 import { addGroupSubscription, requestGroupSubscriptionRemoval } from '../../../redux/actions/ws';
 import TelemetrySelectionTable from './TelemetrySelectionTable';
 
-const TelemetrySelectionTableContainer = ({ allTelemetries, subscribeToStream, unsubscribeToStream,
+const TelemetrySelectionTableContainer = ({
+  allTelemetries,
+  subscribeToStream,
+  unsubscribeToStream,
+  onSave,
+  onCancel,
   ...props
 }) => {
   return (
@@ -35,7 +40,4 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(TelemetrySelectionTableContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(TelemetrySelectionTableContainer);

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
@@ -56,7 +56,7 @@ export default class TelemetrySelectionTable extends PureComponent {
     /** Indicates if component should display bottom selection bar*/
     showSelection: PropTypes.bool,
 
-    /** Object that describes the initially selected telemetries. 
+    /** Object that describes the initially selected telemetries and their health functions.
      * Must have his structure:
      * 
      * {
@@ -142,6 +142,13 @@ export default class TelemetrySelectionTable extends PureComponent {
       filters,
       setFilters: this.setFilters,
     };
+  }
+
+  componentDidUpdate = () => {
+    console.log('this.props.allTelemetries', this.props.allTelemetries);
+    if(this.props.allTelemetries && Object.keys(this.props.allTelemetries).length > 4){
+      this.props.unsubscribeToStream();
+    }
   }
 
   componentDidMount = () => {
@@ -501,23 +508,6 @@ export default class TelemetrySelectionTable extends PureComponent {
                         filter={this.state.filters.stream}
                       />
                     )}
-                    {this.props.columnsToDisplay.includes('timestamp') && (
-                      <ColumnHeader
-                        {...defaultColumnProps}
-                        header={'Timestamp'}
-                        filterName={'timestamp'}
-                        filter={this.state.filters.timestamp}
-                        secondaryText={'YYYY/MM/DD'}
-                      />
-                    )}
-                    {this.props.columnsToDisplay.includes('name') && (
-                      <ColumnHeader
-                        {...defaultColumnProps}
-                        header={'Name'}
-                        filterName={'name'}
-                        filter={this.state.filters.name}
-                      />
-                    )}
                     {this.props.columnsToDisplay.includes('param_name') && (
                       <ColumnHeader
                         {...defaultColumnProps}
@@ -535,14 +525,14 @@ export default class TelemetrySelectionTable extends PureComponent {
                         filter={this.state.filters.data_type}
                       />
                     )}
-                    {this.props.columnsToDisplay.includes('value') && (
+                    {/* {this.props.columnsToDisplay.includes('value') && (
                       <ColumnHeader
                         {...defaultColumnProps}
                         header={'Value'}
                         filterName={'value'}
                         filter={this.state.filters.value}
                       />
-                    )}
+                    )} */}
                     {this.props.columnsToDisplay.includes('units') && (
                       <ColumnHeader
                         className={styles.narrowCol}
@@ -590,19 +580,15 @@ export default class TelemetrySelectionTable extends PureComponent {
                       {this.props.columnsToDisplay.includes('stream') && (
                         <td className={styles.string}>{row.stream}</td>
                       )}
-                      {this.props.columnsToDisplay.includes('timestamp') && (
-                        <td className={styles.string}>{formatTimestamp(row.timestamp)}</td>
-                      )}
-                      {this.props.columnsToDisplay.includes('name') && <td className={styles.string}>{row.name}</td>}
                       {this.props.columnsToDisplay.includes('param_name') && (
                         <td className={styles.string}>{row.param_name}</td>
                       )}
                       {this.props.columnsToDisplay.includes('data_type') && (
                         <td className={[styles.string, styles.mediumCol].join(' ')}>{row.data_type}</td>
                       )}
-                      {this.props.columnsToDisplay.includes('value') && (
+                      {/* {this.props.columnsToDisplay.includes('value') && (
                         <td className={[styles.number, styles.valueCell].join(' ')}>{JSON.stringify(row.value)}</td>
-                      )}
+                      )} */}
                       {this.props.columnsToDisplay.includes('units') && (
                         <td className={[styles.string, styles.narrowCol].join(' ')}>{row.units}</td>
                       )}

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
@@ -303,8 +303,8 @@ export default class TelemetrySelectionTable extends PureComponent {
     let statusCode = 0;
     if (this.state.healthFunctions[paramName]) {
       try {
-        // eslint-disable-next-line
         const code = [HEALTH_STATUS_VARIABLES_DECLARATION, this.state.healthFunctions[paramName]].join('\n');
+        /* eslint-disable no-new-func*/
         let user_func = new Function('value', code);
         statusCode = user_func(value);
       } catch (err) {

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
@@ -17,7 +17,7 @@ const HEALTH_STATUS_CODES = {
   4: 'Invalid',
 };
 
-const HEALTH_STATUS_VARIABLES_DECLARATION = Object.entries(HEALTH_STATUS_CODES)
+export const HEALTH_STATUS_VARIABLES_DECLARATION = Object.entries(HEALTH_STATUS_CODES)
   .map(([key, label]) => {
     return `const ${label.toUpperCase()}=${key};`;
   })

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/TelemetrySelectionTable.jsx
@@ -55,6 +55,18 @@ export default class TelemetrySelectionTable extends PureComponent {
     onSetSelection: PropTypes.func,
     /** Indicates if component should display bottom selection bar*/
     showSelection: PropTypes.bool,
+
+    /** Object that describes the initially selected telemetries. 
+     * Must have his structure:
+     * 
+     * {
+     *   "<component.salindex.topic>": {
+     *     <parameter_name>: healthfunction,
+     *     ...
+     *   }
+     * }
+     */
+    initialData: PropTypes.object,
   };
 
   static defaultProps = {
@@ -73,6 +85,7 @@ export default class TelemetrySelectionTable extends PureComponent {
     ],
     telemetries: {},
     showSelection: true,
+    initialData: {}
   };
 
   constructor() {
@@ -133,6 +146,16 @@ export default class TelemetrySelectionTable extends PureComponent {
 
   componentDidMount = () => {
     this.props.subscribeToStream();
+
+    const initialData = JSON.parse(this.props.initialData);
+    const selectedRows = Object.keys(initialData).flatMap((cscSalindexTopic) =>{
+      return Object.keys(initialData[cscSalindexTopic]).map(parameterName => {
+        return `${cscSalindexTopic}-${parameterName}`;
+      });
+    });
+    this.setState({
+      selectedRows
+    });
   };
 
   componentWillUnmount = () => {
@@ -408,12 +431,12 @@ export default class TelemetrySelectionTable extends PureComponent {
     return data;
   };
 
-  setSelection = (event) => {
+  setSelection = () => {
     const data = this.getData().filter((row) => {
       const key = `${row.component}-${row.stream}-${row.param_name}`;
       return this.state.selectedRows.indexOf(key) >= 0;
     });
-    this.props.onSetSelection(this.state.selectedRows, data, event);
+    this.props.onSetSelection(this.state.selectedRows, data);
   };
 
   render() {
@@ -695,7 +718,7 @@ export default class TelemetrySelectionTable extends PureComponent {
               title="Set selected telemetries"
               className={styles.selectionSetButton}
               onClick={(ev) => {
-                this.setSelection(this.state.selectedRows, ev);
+                this.setSelection();
               }}
             >
               {' '}

--- a/love/src/components/UIF/ComponentIndex.jsx
+++ b/love/src/components/UIF/ComponentIndex.jsx
@@ -35,7 +35,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../ScriptQueue/ScriptQueue.container').schema.props,
-      }
+      },
     },
   },
   CSCDetail: {
@@ -45,7 +45,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../CSCSummary/CSCDetail/CSCDetail.container').schema.props,
-      }
+      },
     },
   },
   CSCExpanded: {
@@ -55,7 +55,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../CSCSummary/CSCExpanded/CSCExpanded.container').schema.props,
-      }
+      },
     },
   },
   CSCGroupLog: {
@@ -65,7 +65,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../CSCSummary/CSCGroupLog/CSCGroupLog.container').schema.props,
-      }
+      },
     },
   },
   CSCGroup: {
@@ -75,7 +75,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../CSCSummary/CSCGroup/CSCGroup.container').schema.props,
-      }
+      },
     },
   },
   CSCSummary: {
@@ -85,7 +85,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../CSCSummary/CSCSummary.container').schema.props,
-      }
+      },
     },
   },
   LabeledStatusText: {
@@ -95,29 +95,10 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../GeneralPurpose/LabeledStatusText/LabeledStatusText.container').schema.props,
-      }
+      },
     },
   },
-  TimeSeriesPlot: {
-    component: require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').default,
-    schema: {
-      ...require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').schema,
-      props: {
-        ...defaultSchemaProps,
-        ...require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').schema.props,
-      }
-    },
-  },
-  TelemetryLog: {
-    component: require('../TelemetryLog/TelemetryLog.container').default,
-    schema: {
-      ...require('../TelemetryLog/TelemetryLog.container').schema,
-      props: {
-        ...defaultSchemaProps,
-        ...require('../TelemetryLog/TelemetryLog.container').schema.props,
-      }
-    },
-  },
+
   Watcher: {
     component: require('../Watcher/Watcher.container').default,
     schema: {
@@ -125,7 +106,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../Watcher/Watcher.container').schema.props,
-      }
+      },
     },
   },
   GenericCamera: {
@@ -135,7 +116,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../GenericCamera/GenericCamera').schema.props,
-      }
+      },
     },
   },
   ObservingLogInput: {
@@ -145,7 +126,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../ObservingLog/ObservingLogInput.container').schema.props,
-      }
+      },
     },
   },
   ObservingLogMessages: {
@@ -155,7 +136,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../ObservingLog/ObservingLogMessages.container').schema.props,
-      }
+      },
     },
   },
   HealthStatusSummary: {
@@ -165,7 +146,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../HealthStatusSummary/HealthStatusSummary.container').schema.props,
-      }
+      },
     },
   },
   Clock: {
@@ -183,13 +164,33 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../TimeSeries/TimeSeries.container').schema.props,
-      }
+      },
     },
   },
+  // TimeSeriesPlot: {
+  //   component: require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').default,
+  //   schema: {
+  //     ...require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').schema,
+  //     props: {
+  //       ...defaultSchemaProps,
+  //       ...require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').schema.props,
+  //     }
+  //   },
+  // },
   TimeSeriesPlot: {
     component: require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').default,
     schema: require('../GeneralPurpose/TimeSeriesPlot/TimeSeriesPlot.container').schema,
   },
+  // TelemetryLog: {
+  //   component: require('../TelemetryLog/TelemetryLog.container').default,
+  //   schema: {
+  //     ...require('../TelemetryLog/TelemetryLog.container').schema,
+  //     props: {
+  //       ...defaultSchemaProps,
+  //       ...require('../TelemetryLog/TelemetryLog.container').schema.props,
+  //     }
+  //   },
+  // },
   TelemetryLog: {
     component: require('../TelemetryLog/TelemetryLog.container').default,
     schema: require('../TelemetryLog/TelemetryLog.container').schema,
@@ -201,7 +202,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../GeneralPurpose/SubscriptionTable/SubscriptionTable.container').schema.props,
-      }
+      },
     },
   },
   EventLog: {
@@ -211,7 +212,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../EventLog/EventLog.container').schema.props,
-      }
+      },
     },
   },
   CommandPanel: {
@@ -221,7 +222,7 @@ export const uifIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../CommandPanel/CommandPanel.container').schema.props,
-      }
+      },
     },
   },
 };
@@ -234,7 +235,7 @@ export const auxtelIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../AuxTel/Mount/SummaryPanel/SummaryPanel.container').schema.props,
-      }
+      },
     },
   },
   LightPath: {
@@ -244,7 +245,7 @@ export const auxtelIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../AuxTel/Mount/LightPath.container').schema.props,
-      }
+      },
     },
   },
   MotorTable: {
@@ -254,7 +255,7 @@ export const auxtelIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../AuxTel/Mount/MotorTable/MotorTable.container').schema.props,
-      }
+      },
     },
   },
   Camera: {
@@ -264,7 +265,7 @@ export const auxtelIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../AuxTel/Camera/Camera.container').schema.props,
-      }
+      },
     },
   },
   Dome: {
@@ -274,7 +275,7 @@ export const auxtelIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../AuxTel/Dome/Dome.container').schema.props,
-      }
+      },
     },
   },
   LATISS: {
@@ -284,7 +285,7 @@ export const auxtelIndex = {
       props: {
         ...defaultSchemaProps,
         ...require('../AuxTel/LATISS/LATISS.container').schema.props,
-      }
+      },
     },
   },
 };

--- a/love/src/components/UIF/CustomView.jsx
+++ b/love/src/components/UIF/CustomView.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Responsive as ResponsiveGridLayout, WidthProvider } from 'react-grid-layout'; // GridLayout
+import { Responsive as ResponsiveGridLayout } from 'react-grid-layout'; // GridLayout
 import PropTypes from 'prop-types';
 import styles from './CustomView.module.css';
 import '../AuxTel/Mount/MotorTable/MotorTable.container';
@@ -9,8 +9,6 @@ import GearIcon from '../icons/GearIcon/GearIcon';
 import ErrorBoundary from '../GeneralPurpose/ErrorBoundary/ErrorBoundary';
 import Panel from '../GeneralPurpose/Panel/Panel';
 import DashedBox from '../GeneralPurpose/DashedBox/DashedBox';
-
-const WithProvidedResponsiveGridLayout = WidthProvider(ResponsiveGridLayout);
 
 export const DEVICE_TO_SIZE = {
   '4K': 2560,

--- a/love/src/components/UIF/ViewEditor/ConfigForm.jsx
+++ b/love/src/components/UIF/ViewEditor/ConfigForm.jsx
@@ -31,6 +31,7 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
   }, [componentConfig]);
 
   const updateConfig = (key, value) => {
+    console.log('key', key, value);
     const newConfig = { ...config };
     newConfig[key] = value;
     setConfig(newConfig);
@@ -44,8 +45,13 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
     onSaveConfig(componentIndex, newConfig);
   };
 
-  const onExtraStepSave = () => {
-    console.log('saved');
+  const onExtraStepSave = (propKey, newData) => {
+    updateConfig(propKey, newData);
+    setExternalStep({
+      show: false,
+      component: undefined,
+      propKey: ''
+    })
   };
 
   const onExtraStepCancel = () => {
@@ -61,7 +67,7 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
     const Component = externalStepComponents[propConfig.externalStep];
     setExternalStep({
       show: true,
-      component: <Component onSave={onExtraStepSave} onCancel={onExtraStepCancel} initialData={propData} />,
+      component: <Component onSave={(newData) => onExtraStepSave(propKey, newData)} onCancel={onExtraStepCancel} initialData={propData} />,
       propKey,
     });
   };
@@ -70,6 +76,8 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
     return null;
   }
 
+  console.log('externalStep', externalStep);
+
   if (externalStep.show) {
     return (
       <Modal isOpen={externalStep.show} onRequestClose={onExtraStepCancel} contentLabel="Component configuration modal">
@@ -77,6 +85,7 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
       </Modal>
     );
   }
+
   return (
     <Modal
       isOpen={isOpen}

--- a/love/src/components/UIF/ViewEditor/ConfigForm.jsx
+++ b/love/src/components/UIF/ViewEditor/ConfigForm.jsx
@@ -23,7 +23,7 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
   const [externalStep, setExternalStep] = useState({
     show: false,
     component: null,
-    propKey: ''
+    propKey: '',
   });
 
   useEffect(() => {
@@ -53,15 +53,15 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
     setExternalStep({
       show: false,
       component: undefined,
-      propKey: ''
-    })
+      propKey: '',
+    });
   };
 
-  const showExtraStep = (propKey, propData) => {
-    const Component = externalStepComponents[propData.externalStep];
+  const showExtraStep = (propKey, propConfig, propData) => {
+    const Component = externalStepComponents[propConfig.externalStep];
     setExternalStep({
       show: true,
-      component: <Component onSave={onExtraStepSave} onCancel={onExtraStepCancel} />,
+      component: <Component onSave={onExtraStepSave} onCancel={onExtraStepCancel} initialData={propData} />,
       propKey,
     });
   };
@@ -69,7 +69,6 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
   if (!isOpen) {
     return null;
   }
-
 
   if (externalStep.show) {
     return (
@@ -123,7 +122,7 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
                   <React.Fragment>
                     <Button
                       status="default"
-                      onClick={() => showExtraStep(key, componentProps[key])}
+                      onClick={() => showExtraStep(key, componentProps[key], value)}
                       className={styles.editButton}
                     >
                       {`Edit ${key}`}
@@ -157,7 +156,7 @@ function ConfigForm({ isOpen, componentIndex, componentName, componentConfig, on
                 );
               }
             }
-            if (componentProps[key].externalStep == undefined && ['boolean'].includes(componentProps[key].type)) {
+            if (['boolean'].includes(componentProps[key].type)) {
               configElementInput = (
                 <input
                   type={'checkbox'}

--- a/love/src/components/UIF/ViewEditor/ConfigForm.module.css
+++ b/love/src/components/UIF/ViewEditor/ConfigForm.module.css
@@ -21,3 +21,8 @@
   background: transparent;
   border: 1px solid var(--secondary-font-dimmed-color);
 }
+
+.editButton {
+  margin-top: 1rem;
+  margin-bottom: -0.5rem;
+}


### PR DESCRIPTION
Makes `HealthStatusSummary`  use `TelemetrySelectionTable` to select telemetries to monitor and change their health status function configs.

This behavior can be replicated for other props and components by setting the prop `externalStep` in the schema of a container component.

This also implied a refactor of the `TelemetrySelectionTable`.

![image](https://user-images.githubusercontent.com/3409401/81234200-4c9ee600-8fc6-11ea-8774-f62d9da3cbe5.png)


![image](https://user-images.githubusercontent.com/3409401/81234170-3c870680-8fc6-11ea-83eb-de892b511e80.png)
