### PR TITLE
Generic table

### DIFF
--- a/love/src/components/AuxTel/Mount/MotorTable/MotorTable.jsx
+++ b/love/src/components/AuxTel/Mount/MotorTable/MotorTable.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Table, Thead, Tbody, Td, Tr, Th } from '../../../GeneralPurpose/SimpleTable/SimpleTable';
+import SimpleTable from '../../../GeneralPurpose/SimpleTable/SimpleTable';
 import StatusText from '../../../GeneralPurpose/StatusText/StatusText';
 import {
   motorDriveStateMap,
@@ -116,83 +116,86 @@ export default class MotorTable extends Component {
       },
     };
 
-    // console.log(data);
-    // console.log(this.props);
+    const simpleTableData = Object.values(data);
+    const defaultFormatter = value => {
+      if (isNaN(value)) return value;
+      return Number.isInteger(value) ? value : value.toFixed(5)
+    };
+
+    const headers = [
+      {
+        field: 'name',
+        label: 'Motor'
+      },
+      {
+        field: 'angle',
+        label: <>Axis Angle <span className={styles.units}>[deg]</span></>,
+        type: 'number',
+        formatter: (value) => isNaN(value) || Number.isInteger(value) ? value : `${value.toFixed(5)}º`
+      },
+      {
+        field: 'velocity',
+        label: <>Velocity <span className={styles.units}>[deg/s]</span></>,
+        type: 'number',
+        formatter: defaultFormatter
+      },
+      {
+        field: 'measuredTorque',
+        label: <>Meas. Torque <span className={styles.units}>[A]</span></>,
+        formatter: defaultFormatter
+      },
+      {
+        field: 'torqueDemand',
+        label: <>Dem. Torque <span className={styles.units}>[A]</span></>,
+        formatter: defaultFormatter
+      },
+      {
+        field: 'motorEncoder',
+        label: 'Encoder',
+        formatter: defaultFormatter
+      },
+      {
+        field: 'motorEncoderRaw',
+        label: 'Encoder Raw',
+        formatter: defaultFormatter
+      },
+      {
+        field: 'brakeStatus',
+        label: 'Brake status',
+        className: styles.statusColumn,
+        formatter: (value) => {
+          const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
+
+          return (
+            <StatusText small status={stateToStyleMotorBrake[brakeStatus]}>
+              {brakeStatus}
+            </StatusText>
+          )
+        }
+      },
+      {
+        field: 'driveStatus',
+        label: 'Drive status',
+        formatter: (value) => {
+          const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
+          return (
+            <StatusText small status={stateToStyleMotorDrive[driveStatus]}>
+              {driveStatus}
+            </StatusText>
+          );
+        },
+        className: styles.statusColumn
+      }
+    ];
+
+
+
     return (
-      <Table className={styles.table}>
-        <Thead>
-          <Tr className={styles.headerRow}>
-            <Th>Motor</Th>
-            <Th>
-              Axis Angle <span className={styles.units}>[deg]</span>
-            </Th>
-            <Th>
-              Velocity <span className={styles.units}>[deg/s]</span>
-            </Th>
-            <Th>
-              Meas. Torque <span className={styles.units}>[A]</span>
-            </Th>
-            <Th>
-              Dem. Torque <span className={styles.units}>[A]</span>
-            </Th>
-            <Th>Encoder</Th>
-            <Th>Encoder Raw</Th>
-            <Th className={styles.statusColumn}>Brake status</Th>
-            <Th className={styles.statusColumn}>Drive status</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {Object.keys(data).map((key) => {
-            const row = data[key];
-            return (
-              <Tr key={key}>
-                {Object.keys(row).map((col) => {
-                  const value = row[col];
-                  if (col === 'angle') {
-                    return (
-                      <Td key={col} isNumber>
-                        {isNaN(value) || Number.isInteger(value) ? value : `${Math.round(value * 10000) / 10000}º`}
-                      </Td>
-                    );
-                  }
-                  if (col === 'driveStatus') {
-                    const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
-                    return (
-                      <Td key={col} className={styles.statusColumn}>
-                        <StatusText small status={stateToStyleMotorDrive[driveStatus]}>
-                          {driveStatus}
-                        </StatusText>
-                      </Td>
-                    );
-                  }
-                  if (col === 'brakeStatus') {
-                    const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
-                    return (
-                      <Td key={col} className={styles.statusColumn}>
-                        <StatusText small status={stateToStyleMotorBrake[brakeStatus]}>
-                          {brakeStatus}
-                        </StatusText>
-                      </Td>
-                    );
-                  }
-                  if (isNaN(value)) {
-                    return (
-                      <Td isNumber key={col}>
-                        {value}
-                      </Td>
-                    );
-                  }
-                  return (
-                    <Td isNumber key={col}>
-                      {Number.isInteger(value) ? value : Math.round(value * 10000) / 10000}
-                    </Td>
-                  );
-                })}
-              </Tr>
-            );
-          })}
-        </Tbody>
-      </Table>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <SimpleTable headers={headers} data={simpleTableData} />
+      </div>
+
+
     );
   }
 }

--- a/love/src/components/AuxTel/Mount/MotorTable/MotorTable.jsx
+++ b/love/src/components/AuxTel/Mount/MotorTable/MotorTable.jsx
@@ -125,43 +125,43 @@ export default class MotorTable extends Component {
     const headers = [
       {
         field: 'name',
-        label: 'Motor'
+        title: 'Motor'
       },
       {
         field: 'angle',
-        label: <>Axis Angle <span className={styles.units}>[deg]</span></>,
+        title: <>Axis Angle <span className={styles.units}>[deg]</span></>,
         type: 'number',
         formatter: (value) => isNaN(value) || Number.isInteger(value) ? value : `${value.toFixed(5)}º`
       },
       {
         field: 'velocity',
-        label: <>Velocity <span className={styles.units}>[deg/s]</span></>,
+        title: <>Velocity <span className={styles.units}>[deg/s]</span></>,
         type: 'number',
         formatter: defaultFormatter
       },
       {
         field: 'measuredTorque',
-        label: <>Meas. Torque <span className={styles.units}>[A]</span></>,
+        title: <>Meas. Torque <span className={styles.units}>[A]</span></>,
         formatter: defaultFormatter
       },
       {
         field: 'torqueDemand',
-        label: <>Dem. Torque <span className={styles.units}>[A]</span></>,
+        title: <>Dem. Torque <span className={styles.units}>[A]</span></>,
         formatter: defaultFormatter
       },
       {
         field: 'motorEncoder',
-        label: 'Encoder',
+        title: 'Encoder',
         formatter: defaultFormatter
       },
       {
         field: 'motorEncoderRaw',
-        label: 'Encoder Raw',
+        title: 'Encoder Raw',
         formatter: defaultFormatter
       },
       {
         field: 'brakeStatus',
-        label: 'Brake status',
+        title: 'Brake status',
         className: styles.statusColumn,
         formatter: (value) => {
           const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
@@ -175,7 +175,7 @@ export default class MotorTable extends Component {
       },
       {
         field: 'driveStatus',
-        label: 'Drive status',
+        title: 'Drive status',
         formatter: (value) => {
           const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
           return (

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
@@ -23,7 +23,7 @@ const defaultSort = (row1, row2, sortingColumn, sortDirection) => {
   return 0;
 };
 
-const defaultColumnFilter = (filterString, value) => {
+const defaultColumnFilter = (filterString, value, row) => {
   try {
     const regexp = filterString === '' || filterString === undefined? new RegExp('(?:)') : new RegExp(filterString, 'i');
     return regexp.test(value);
@@ -128,7 +128,7 @@ const ActionableTable = function ({ data, headers }) {
           //   debugger;
           // }
           const filter = header.filter ?? defaultColumnFilter;
-          const filterResult = filter(filters[header.field], row[header.field]);
+          const filterResult = filter(filters[header.field], row[header.field], row);
           return prevBool && filterResult;
         }, true);
       })
@@ -170,7 +170,7 @@ ActionableTable.propTypes = {
       render: PropTypes.func,
       /** (Inherited from SimpleTable) className to be applied to the whole column */
       className: PropTypes.string,
-      /** Function to sort table rows.
+      /** Function to sort table rows. Defaults to regular (>, <, ===) comparison.
        * Its signature is `(row1, row2, sortingColumn, sortingDirection) => value` where:
        * (row1, row2)  are two rows of the `data` array to compare;
        * (sortingColumn) is the currently selected column that runs the sorting. Only one column at a time;
@@ -178,6 +178,14 @@ ActionableTable.propTypes = {
        * (value) is 1, 0 or -1, and passed to Array.Prototype.sort
        * */
       sort: PropTypes.func,
+      /** Function to filter table rows. Defaults to regexp comparison.
+       * Its signature is (filterString, value, row) => result where: 
+       * `filterString` is the input text in the filter textbox
+       * `value` is the value of the cell in the current row and column
+       * `row` is the complete data row from the `data` prop
+       * result: boolean, if any column result is false the row won't be displayed
+       */
+      filter: PropTypes.func
     }),
   ),
   /** Rows to be rendered in the table */

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
-import SimpleTable from '../SimpleTable/SimpleTable';
+import PaginatedTable from '../PaginatedTable/PaginatedTable';
 import styles from './ActionableTable.module.css';
 import FilterButton from '../../HealthStatusSummary/TelemetrySelectionTable/ColumnHeader/FilterButton/FilterButton';
 import FilterDialog from '../../HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog';
-import { ASCENDING, DESCENDING, UNSORTED } from '../../HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx'
+import {
+  ASCENDING,
+  DESCENDING,
+  UNSORTED,
+} from '../../HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx';
 
 /**
  * A table that can run actions over its data such as
@@ -11,126 +15,125 @@ import { ASCENDING, DESCENDING, UNSORTED } from '../../HealthStatusSummary/Telem
  * Default actions are sorting and filtering but can be overwritten.
  */
 const ActionableTable = function ({ data, headers }) {
+  const [activeFilterDialogIndex, setActiveFilterDialogIndex] = React.useState(null);
+  const [filters, setFilters] = React.useState({});
+  const [sortDirections, setSortDirections] = React.useState({});
+  const [sortingColumn, setSortingColumn] = React.useState(null);
 
-    const [activeFilterDialogIndex, setActiveFilterDialogIndex] = React.useState(null);
-    const [filters, setFilters] = React.useState({});
-    const [sortDirections, setSortDirections] = React.useState({});
-    const [sortingColumn, setSortingColumn] = React.useState(null);
+  React.useEffect(() => {
+    const initialFilters = headers.reduce((prevDict, header) => {
+      prevDict[header.field] = {
+        type: 'regexp',
+        value: new RegExp('(?:)'),
+      };
+      return prevDict;
+    }, {});
 
-    React.useEffect(() => {
-        const initialFilters = headers.reduce((prevDict, header) => {
-            prevDict[header.field] = {
-                type: 'regexp',
-                value: new RegExp('(?:)')
-            }
-            return prevDict;
-        }, {});
+    const initialSortDirections = headers.reduce((prevDict, header) => {
+      prevDict[header.field] = UNSORTED;
+      return prevDict;
+    }, {});
 
-        const initialSortDirections = headers.reduce((prevDict, header) => {
-            prevDict[header.field] = UNSORTED;
-            return prevDict;
-        }, {});
+    setFilters(initialFilters);
+    setSortDirections(initialSortDirections);
+  }, [headers]);
 
-        setFilters(initialFilters);
-        setSortDirections(initialSortDirections)
-    }, [headers]);
-
-    const columnOnClick = (ev, index) => {
-        if (activeFilterDialogIndex === index) {
-            setActiveFilterDialogIndex(null);
-            return;
-        }
-
-        setActiveFilterDialogIndex(index);
+  const columnOnClick = (ev, index) => {
+    if (activeFilterDialogIndex === index) {
+      setActiveFilterDialogIndex(null);
+      return;
     }
 
-    const changeFilter = (event, filterName) => {
-        try {
+    setActiveFilterDialogIndex(index);
+  };
 
-            const newFilter = event.target.value === '' ? new RegExp('(?:)') : new RegExp(event.target.value, 'i');
-            setFilters((filters) => {
-                return {
-                    ...filters,
-                    [filterName]: {
-                        ...filters[filterName],
-                        value: newFilter
-                    }
-                }
-            })
-
-        } catch (e) {
-            console.warn('Invalid filter', event?.target?.value);
-        }
-    }
-
-    const closeFilterDialogs = () => {
-        setActiveFilterDialogIndex(null);
-    }
-
-    const changeSortDirection = (direction, column) => {
-        console.log('direction,column', direction,column)
-        setSortDirections(sortDirections => ({
-            ...sortDirections,
-            [column]: direction
-        }));
-        setSortingColumn(column);
-    }
-
-    const newHeaders = headers.map((header, index) => {
-        const isFiltered = filters?.[header.field] ? filters?.[header.field].value.toString().substring(0, 6) !== '/(?:)/' : false;
+  const changeFilter = (event, filterName) => {
+    try {
+      const newFilter = event.target.value === '' ? new RegExp('(?:)') : new RegExp(event.target.value, 'i');
+      setFilters((filters) => {
         return {
-            ...header,
-            title: (
-                <div className={styles.columnHeader}>
-                    <span className={styles.primaryText}>{header.title}</span>
-                    <span className={styles.secondaryText}>{header.subtitle}</span>
-                    <FilterButton
-                        filterName={header.field}
-                        selected={activeFilterDialogIndex === index}
-                        isFiltered={isFiltered}
-                        columnOnClick={(ev) => columnOnClick(ev, index)}
-                        sortDirection={sortDirections[header.field]}
-                    />
-                    <FilterDialog
-                        show={activeFilterDialogIndex === index}
-                        changeFilter={(event) => changeFilter(event, header.field)}
-                        closeFilterDialogs={closeFilterDialogs}
-                        changeSortDirection={changeSortDirection}
-                        columnName={header.field}
-                        sortingColumn={sortingColumn}
-                    />
-                </div>
-            )
-        }
+          ...filters,
+          [filterName]: {
+            ...filters[filterName],
+            value: newFilter,
+          },
+        };
+      });
+    } catch (e) {
+      console.warn('Invalid filter', event?.target?.value);
+    }
+  };
+
+  const closeFilterDialogs = () => {
+    setActiveFilterDialogIndex(null);
+  };
+
+  const changeSortDirection = (direction, column) => {
+    console.log('direction,column', direction, column);
+    setSortDirections((sortDirections) => ({
+      ...sortDirections,
+      [column]: direction,
+    }));
+    setSortingColumn(column);
+  };
+
+  const newHeaders = headers.map((header, index) => {
+    const isFiltered = filters?.[header.field]
+      ? filters?.[header.field].value.toString().substring(0, 6) !== '/(?:)/'
+      : false;
+    return {
+      ...header,
+      title: (
+        <div className={styles.columnHeader}>
+          <span className={styles.primaryText}>{header.title}</span>
+          <span className={styles.secondaryText}>{header.subtitle}</span>
+          <FilterButton
+            filterName={header.field}
+            selected={activeFilterDialogIndex === index}
+            isFiltered={isFiltered}
+            columnOnClick={(ev) => columnOnClick(ev, index)}
+            sortDirection={sortDirections[header.field]}
+          />
+          <FilterDialog
+            show={activeFilterDialogIndex === index}
+            changeFilter={(event) => changeFilter(event, header.field)}
+            closeFilterDialogs={closeFilterDialogs}
+            changeSortDirection={changeSortDirection}
+            columnName={header.field}
+            sortingColumn={sortingColumn}
+          />
+        </div>
+      ),
+    };
+  });
+
+  const transformedData = data
+    .filter((row) => {
+      return headers.reduce((prevBool, header) => {
+        return prevBool && filters[header.field]?.value?.test(row[header.field]);
+      }, true);
+    })
+    .sort((row1, row2) => {
+      /** No sorting */
+      const sortDirection = sortDirections[sortingColumn];
+      if (sortDirection === UNSORTED) return 0;
+
+      /** No sorting column */
+      if (!sortingColumn) return 0;
+
+      /** No cell value */
+      const value1 = row1?.[sortingColumn];
+      const value2 = row2?.[sortingColumn];
+      if (value1 === undefined || value1 === null) return 0;
+      if (value2 === undefined || value2 === null) return 0;
+
+      const sortFactor = sortDirection === ASCENDING ? 1 : -1;
+      if (value1 < value2) return -1 * sortFactor;
+      if (value1 > value2) return 1 * sortFactor;
+      return 0;
     });
 
-    const transformedData = data.filter(row => {
-        return headers.reduce((prevBool, header) => {
-            return prevBool && filters[header.field]?.value?.test(row[header.field]);
-        }, true);
-    }).sort((row1, row2) => {
-        /** No sorting */
-        const sortDirection = sortDirections[sortingColumn];
-        if (sortDirection === UNSORTED) return 0;
-
-        /** No sorting column */
-        if (!sortingColumn) return 0;
-
-        /** No cell value */
-        const value1 = row1?.[sortingColumn];
-        const value2 = row2?.[sortingColumn];
-        if (value1 === undefined || value1 === null) return 0;
-        if (value2 === undefined || value2 === null) return 0;
-
-
-        const sortFactor = sortDirection === ASCENDING ? 1 : -1;
-        if (value1 < value2) return -1 * sortFactor;
-        if (value1 > value2) return 1 * sortFactor;
-        return 0;
-    })
-
-    return <SimpleTable data={transformedData} headers={newHeaders} />
-}
-
+  return <PaginatedTable data={transformedData} headers={newHeaders} />;
+};
 
 export default ActionableTable;

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import SimpleTable from '../SimpleTable/SimpleTable';
+import styles from './ActionableTable.module.css';
+import FilterButton from '../../HealthStatusSummary/TelemetrySelectionTable/ColumnHeader/FilterButton/FilterButton';
+import FilterDialog from '../../HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog';
+
+
+/**
+ * A table that can run actions over its data such as
+ * sorting and filtering from a dialog in its column header.
+ * Default actions are sorting and filtering but can be overwritten.
+ */
+const ActionableTable = function ({ data, headers }) {
+
+    const newHeaders = headers.map((header, index) => {
+
+        const sortDirection = 'ascending';
+        const isActive = index === 0;
+        const isFiltered = index === 1;
+        const columnOnClick = () => console.log('onclick');
+        const filterName = `filterName-${index}`;
+
+        const changeFilter = (filtername) => () => console.log('changing filter to', filtername);
+        /** To set no active filter dialog */
+        const closeFilterDialogs = () => console.log('adsfsadf')
+
+        const changeSortDirection = (direction, column) => console.log('direction, column', direction, column);
+
+        const sortingColumn = `filterName-0`;
+
+        return {
+            ...header,
+            title: (
+                <div className={styles.columnHeader}>
+                    <span className={styles.primaryText}>{header.title}</span>
+                    <span className={styles.secondaryText}>{header.subtitle}</span>
+                    <FilterButton
+                        filterName={filterName}
+                        selected={isActive}
+                        isFiltered={isFiltered}
+                        columnOnClick={columnOnClick}
+                        sortDirection={sortDirection}
+                    />
+                    <FilterDialog
+                        show={isActive}
+                        changeFilter={changeFilter(filterName)}
+                        closeFilterDialogs={closeFilterDialogs}
+                        changeSortDirection={changeSortDirection}
+                        columnName={filterName}
+                        sortingColumn={sortingColumn}
+                    />
+                </div>
+            )
+        }
+    });
+    
+    return <SimpleTable data={data} headers={newHeaders} />
+}
+
+
+export default ActionableTable;

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
@@ -25,7 +25,8 @@ const defaultSort = (row1, row2, sortingColumn, sortDirection) => {
 
 const defaultColumnFilter = (filterString, value, row) => {
   try {
-    const regexp = filterString === '' || filterString === undefined? new RegExp('(?:)') : new RegExp(filterString, 'i');
+    const regexp =
+      filterString === '' || filterString === undefined ? new RegExp('(?:)') : new RegExp(filterString, 'i');
     return regexp.test(value);
   } catch (e) {
     console.warn('Invalid filter value in regexp', value);
@@ -113,6 +114,8 @@ const ActionableTable = function ({ data, headers }) {
             changeSortDirection={changeSortDirection}
             columnName={header.field}
             sortingColumn={sortingColumn}
+            ascendingSortLabel={header.ascendingSortLabel}
+            descendingSortLabel={header.descendingSortLabel}
           />
         </div>
       ),
@@ -179,13 +182,17 @@ ActionableTable.propTypes = {
        * */
       sort: PropTypes.func,
       /** Function to filter table rows. Defaults to regexp comparison.
-       * Its signature is (filterString, value, row) => result where: 
+       * Its signature is (filterString, value, row) => result where:
        * `filterString` is the input text in the filter textbox
        * `value` is the value of the cell in the current row and column
        * `row` is the complete data row from the `data` prop
        * result: boolean, if any column result is false the row won't be displayed
        */
-      filter: PropTypes.func
+      filter: PropTypes.func,
+      /** Node for the "ascending order" option in the column menu  */
+      ascendingSortLabel: PropTypes.node,
+      /** Node for the "descending order" option in the column menu  */
+      descendingSortLabel: PropTypes.node,
     }),
   ),
   /** Rows to be rendered in the table */

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
@@ -3,16 +3,31 @@ import PaginatedTable from '../PaginatedTable/PaginatedTable';
 import styles from './ActionableTable.module.css';
 import FilterButton from '../../HealthStatusSummary/TelemetrySelectionTable/ColumnHeader/FilterButton/FilterButton';
 import FilterDialog from '../../HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog';
+import PropTypes from 'prop-types';
+
 import {
   ASCENDING,
   DESCENDING,
   UNSORTED,
 } from '../../HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx';
 
+const defaultSort = (row1, row2, sortingColumn, sortDirection) => {
+  const value1 = row1?.[sortingColumn];
+  const value2 = row2?.[sortingColumn];
+  if (value1 === undefined || value1 === null) return 0;
+  if (value2 === undefined || value2 === null) return 0;
+
+  const sortFactor = sortDirection === ASCENDING ? 1 : -1;
+  if (value1 < value2) return -1 * sortFactor;
+  if (value1 > value2) return 1 * sortFactor;
+  return 0;
+};
 /**
  * A table that can run actions over its data such as
  * sorting and filtering from a dialog in its column header.
  * Default actions are sorting and filtering but can be overwritten.
+ * 
+ * It is built with <a href="/#/API?id=simpletable">SimpleTable<a/>
  */
 const ActionableTable = function ({ data, headers }) {
   const [activeFilterDialogIndex, setActiveFilterDialogIndex] = React.useState(null);
@@ -69,7 +84,6 @@ const ActionableTable = function ({ data, headers }) {
   };
 
   const changeSortDirection = (direction, column) => {
-    console.log('direction,column', direction, column);
     setSortDirections((sortDirections) => ({
       ...sortDirections,
       [column]: direction,
@@ -107,33 +121,61 @@ const ActionableTable = function ({ data, headers }) {
     };
   });
 
-  const transformedData = data
-    .filter((row) => {
-      return headers.reduce((prevBool, header) => {
-        return prevBool && filters[header.field]?.value?.test(row[header.field]);
-      }, true);
-    })
-    .sort((row1, row2) => {
-      /** No sorting */
-      const sortDirection = sortDirections[sortingColumn];
-      if (sortDirection === UNSORTED) return 0;
-
-      /** No sorting column */
-      if (!sortingColumn) return 0;
-
-      /** No cell value */
-      const value1 = row1?.[sortingColumn];
-      const value2 = row2?.[sortingColumn];
-      if (value1 === undefined || value1 === null) return 0;
-      if (value2 === undefined || value2 === null) return 0;
-
-      const sortFactor = sortDirection === ASCENDING ? 1 : -1;
-      if (value1 < value2) return -1 * sortFactor;
-      if (value1 > value2) return 1 * sortFactor;
-      return 0;
-    });
+  const transformedData = React.useMemo(()=>{
+    const newData = data
+      .filter((row) => {
+        return headers.reduce((prevBool, header) => {
+          return prevBool && filters[header.field]?.value?.test(row[header.field]);
+        }, true);
+      })
+      .sort((row1, row2) => {
+        /** No sorting */
+        const sortDirection = sortDirections[sortingColumn];
+        if (sortDirection === UNSORTED) return 0;
+  
+        /** No sorting column */
+        if (!sortingColumn) return 0;
+  
+        /** No cell value */
+        const header = headers.find((header) => header.field === sortingColumn);
+  
+        const sort = header?.sort ?? defaultSort;
+  
+        return sort(row1, row2, sortingColumn, sortDirection);
+      });
+      return newData;
+  },[data, sortingColumn, sortDirections, filters])
 
   return <PaginatedTable data={transformedData} headers={newHeaders} />;
+};
+
+ActionableTable.propTypes = {
+  /** Array with properties of table columns and its headers.*/
+  headers: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** Function to sort table rows. 
+       * Its signature is `(row1, row2, sortingColumn, sortingDirection) => value` where:
+       * (row1, row2)  are two rows of the `data` array to compare; 
+       * (sortingColumn) is the currently selected column that runs the sorting. Only one column at a time; 
+       * (sortingDirection): indicates the user-selected sorting direction, can be 'ascending' or something else for descending
+       * (value) is 1, 0 or -1, and passed to Array.Prototype.sort
+       * */
+      sort: PropTypes.func,
+      /** (Inherited from SimpleTable) Property accessor of this column's value on each data row */
+      field: PropTypes.string,
+      /** (Inherited from SimpleTable)  Node to be rendered as header label */
+      title: PropTypes.node,
+      /** (Inherited from SimpleTable) Data type of this column: number, string, ... */
+      type: PropTypes.string,
+      /** (Inherited from SimpleTable) Callback that receives this column's value and should return a `node`.
+       * Use it customize how the cell's value is   */
+      render: PropTypes.func,
+      /** (Inherited from SimpleTable) className to be applied to the whole column */
+      className: PropTypes.string,
+    }),
+  ),
+  /** Rows to be rendered in the table */
+  data: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default ActionableTable;

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.jsx
@@ -12,12 +12,22 @@ import FilterDialog from '../../HealthStatusSummary/TelemetrySelectionTable/Filt
  */
 const ActionableTable = function ({ data, headers }) {
 
+    const [activeFilterDialogIndex, setActiveFilterDialogIndex] = React.useState(null);
+
+    const columnOnClick = (ev, index) => {
+        if (activeFilterDialogIndex === index) {
+            setActiveFilterDialogIndex(null);
+            return;
+        }
+
+        setActiveFilterDialogIndex(index);
+    }
+
+
     const newHeaders = headers.map((header, index) => {
 
         const sortDirection = 'ascending';
-        const isActive = index === 0;
         const isFiltered = index === 1;
-        const columnOnClick = () => console.log('onclick');
         const filterName = `filterName-${index}`;
 
         const changeFilter = (filtername) => () => console.log('changing filter to', filtername);
@@ -36,13 +46,13 @@ const ActionableTable = function ({ data, headers }) {
                     <span className={styles.secondaryText}>{header.subtitle}</span>
                     <FilterButton
                         filterName={filterName}
-                        selected={isActive}
+                        selected={activeFilterDialogIndex === index}
                         isFiltered={isFiltered}
-                        columnOnClick={columnOnClick}
+                        columnOnClick={(ev) => columnOnClick(ev, index)}
                         sortDirection={sortDirection}
                     />
                     <FilterDialog
-                        show={isActive}
+                        show={activeFilterDialogIndex === index}
                         changeFilter={changeFilter(filterName)}
                         closeFilterDialogs={closeFilterDialogs}
                         changeSortDirection={changeSortDirection}
@@ -53,7 +63,7 @@ const ActionableTable = function ({ data, headers }) {
             )
         }
     });
-    
+
     return <SimpleTable data={data} headers={newHeaders} />
 }
 

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -69,7 +69,7 @@ const headers = [
       const status = !!labelsDict[value] ? labelsDict[value] : 'invalid';
       return (
         <StatusText status={status}>
-          {status}-{value}
+          {`${status}-${value}`}
         </StatusText>
       );
     },

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -1,4 +1,4 @@
-Basic example with with a column with custom styles.
+Basic example.
 
 ```jsx
 const headers = [
@@ -69,14 +69,9 @@ const headers = [
       const status = !!labelsDict[value] ? labelsDict[value] : 'invalid';
       return <StatusText status={status}>{status}-{value}</StatusText>;
     },
-    sort: (row1, row2, sortingColumn, sortingDirection) => {
-      const v1 = row1[sortingColumn];
-      const v2 = row2[sortingColumn];
-      const status1 = !!labelsDict[v1] ? labelsDict[v1] : 'invalid';
-      const status2 = !!labelsDict[v2] ? labelsDict[v2] : 'invalid';
-
-      const sortingFactor = sortingDirection === 'ascending' ? 1 : -1;
-      console.log('sortingFactor, status1, status2', sortingFactor, status1, status2);
+    sort: (value1, value2, sortingFactor, row1, row2 ) => {
+      const status1 = !!labelsDict[value1] ? labelsDict[v1] : 'invalid';
+      const status2 = !!labelsDict[value2] ? labelsDict[v2] : 'invalid';
 
       if (status1 > status2) {
         return 1 * sortingFactor;
@@ -89,13 +84,13 @@ const headers = [
   },
 ];
 
-const data = new Array(100).fill(1).flatMap(() => [
+const data = new Array(1).fill(1).flatMap(() => [
   { position: NaN, description: 'asdf', level: 0 },
-  { position: 1.5, description: 'asdf', level: 1 },
-  { position: 2.2, description: 'asdf', level: 2 },
-  { position: 3.213, description: 'asdf', level: 23 },
-  { position: 5.23, description: 'asdf', level: 3 },
-  { position: 3.23, description: 'asdf', level: 4 },
+  { position: 1.5, description: 'bsdf', level: 1 },
+  { position: 2.2, description: 'csdf', level: 2 },
+  { position: 3.213, description: 'dsdf', level: 23 },
+  { position: 5.23, description: 'esdf', level: 3 },
+  { position: 3.23, description: 'fsdf', level: 4 },
 ]);
 
 <div style={{ width: '800px', background: 'black' }}>

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -1,0 +1,39 @@
+Basic example with with a column with custom styles.
+```jsx
+
+
+const headers = [
+  {
+    field: 'position',
+    title: 'Position',
+    type: 'number',
+    subtitle: 'subtitle1',
+    render: (value) => (isNaN(value) ? '-' : value.toFixed(3)),
+  },
+  {
+    field: 'description',
+    title: 'Descr.',
+    type: 'string',
+    subtitle: 'subtitle2',
+  },
+  {
+    field: 'level',
+    title: 'Severity',
+    type: 'number',
+    subtitle: 'subtitle3',
+  },
+];
+
+const data = [
+  { position: NaN, description: 'asdf', level: 0 },
+  { position: 1.5, description: 'asdf', level: 1 },
+  { position: 2.2, description: 'asdf', level: 2 },
+  { position: 3.213, description: 'asdf', level: 23 },
+  { position: 5.23, description: 'asdf', level: 3 },
+  { position: 3.23, description: 'asdf', level: 4 },
+];
+
+<div style={{ width: '800px' }}>
+  <ActionableTable data={data} headers={headers} />
+</div>;
+```

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -1,7 +1,6 @@
 Basic example with with a column with custom styles.
+
 ```jsx
-
-
 const headers = [
   {
     field: 'position',
@@ -33,7 +32,7 @@ const data = [
   { position: 3.23, description: 'zxczxc', level: 4 },
 ];
 
-<div style={{ width: '800px' }}>
+<div style={{ width: '800px', background: 'black' }}>
   <ActionableTable data={data} headers={headers} />
 </div>;
 ```

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -32,8 +32,71 @@ const data = new Array(100).fill(1).flatMap(() => [
   { position: 3.23, description: 'asdf', level: 4 },
 ]);
 
+<div style={{ width: '800px', background: 'black' }}>
+  <ActionableTable data={data} headers={headers} />
+</div>;
+```
 
+Custom sorting function
 
+```jsx
+import StatusText from '../StatusText/StatusText';
+
+const labelsDict = {
+  0: 'ok',
+  2: 'running',
+  3: 'warning',
+  4: 'critical',
+};
+
+const headers = [
+  {
+    field: 'position',
+    title: 'Position',
+    type: 'number',
+    render: (value) => (isNaN(value) ? '-' : value.toFixed(3)),
+  },
+  {
+    field: 'description',
+    title: 'Descr.',
+    type: 'string',
+  },
+  {
+    field: 'level',
+    title: 'Severity',
+    type: 'number',
+    render: (value) => {
+      const status = !!labelsDict[value] ? labelsDict[value] : 'invalid';
+      return <StatusText status={status}>{status}-{value}</StatusText>;
+    },
+    sort: (row1, row2, sortingColumn, sortingDirection) => {
+      const v1 = row1[sortingColumn];
+      const v2 = row2[sortingColumn];
+      const status1 = !!labelsDict[v1] ? labelsDict[v1] : 'invalid';
+      const status2 = !!labelsDict[v2] ? labelsDict[v2] : 'invalid';
+
+      const sortingFactor = sortingDirection === 'ascending' ? 1 : -1;
+      console.log('sortingFactor, status1, status2', sortingFactor, status1, status2);
+
+      if (status1 > status2) {
+        return 1 * sortingFactor;
+      }
+      if (status1 < status2) {
+        return -1 * sortingFactor;
+      }
+      return 0;
+    },
+  },
+];
+
+const data = new Array(100).fill(1).flatMap(() => [
+  { position: NaN, description: 'asdf', level: 0 },
+  { position: 1.5, description: 'asdf', level: 1 },
+  { position: 2.2, description: 'asdf', level: 2 },
+  { position: 3.213, description: 'asdf', level: 23 },
+  { position: 5.23, description: 'asdf', level: 3 },
+  { position: 3.23, description: 'asdf', level: 4 },
+]);
 
 <div style={{ width: '800px', background: 'black' }}>
   <ActionableTable data={data} headers={headers} />

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -67,11 +67,15 @@ const headers = [
     type: 'number',
     render: (value) => {
       const status = !!labelsDict[value] ? labelsDict[value] : 'invalid';
-      return <StatusText status={status}>{status}-{value}</StatusText>;
+      return (
+        <StatusText status={status}>
+          {status}-{value}
+        </StatusText>
+      );
     },
-    sort: (value1, value2, sortingFactor, row1, row2 ) => {
-      const status1 = !!labelsDict[value1] ? labelsDict[v1] : 'invalid';
-      const status2 = !!labelsDict[value2] ? labelsDict[v2] : 'invalid';
+    sort: (value1, value2, sortingFactor, row1, row2) => {
+      const status1 = !!labelsDict[value1] ? labelsDict[value1] : 'invalid';
+      const status2 = !!labelsDict[value2] ? labelsDict[value1] : 'invalid';
 
       if (status1 > status2) {
         return 1 * sortingFactor;
@@ -80,6 +84,19 @@ const headers = [
         return -1 * sortingFactor;
       }
       return 0;
+    },
+    filter: (filterString, value, row) => {
+      /** Test against the label {status}-{value}, not just the value **/
+      try {
+        const regexp =
+          filterString === '' || filterString === undefined ? new RegExp('(?:)') : new RegExp(filterString, 'i');
+        
+        const status = !!labelsDict[value] ? labelsDict[value] : 'invalid';
+        return regexp.test(`${status}-${value}`);
+      } catch (e) {
+        console.warn('Invalid filter value in regexp', value);
+      }
+      return true;
     },
   },
 ];

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -26,11 +26,11 @@ const headers = [
 
 const data = [
   { position: NaN, description: 'asdf', level: 0 },
-  { position: 1.5, description: 'asdf', level: 1 },
-  { position: 2.2, description: 'asdf', level: 2 },
-  { position: 3.213, description: 'asdf', level: 23 },
-  { position: 5.23, description: 'asdf', level: 3 },
-  { position: 3.23, description: 'asdf', level: 4 },
+  { position: 1.5, description: 'qwe', level: 1 },
+  { position: 2.2, description: 'sdsf', level: 2 },
+  { position: 3.213, description: 'azxc', level: 23 },
+  { position: 5.23, description: 'qwertf', level: 3 },
+  { position: 3.23, description: 'zxczxc', level: 4 },
 ];
 
 <div style={{ width: '800px' }}>

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -75,8 +75,8 @@ const headers = [
     },
     sort: (value1, value2, sortingFactor, row1, row2) => {
       const status1 = !!labelsDict[value1] ? labelsDict[value1] : 'invalid';
-      const status2 = !!labelsDict[value2] ? labelsDict[value1] : 'invalid';
-
+      const status2 = !!labelsDict[value2] ? labelsDict[value2] : 'invalid';
+      
       if (status1 > status2) {
         return 1 * sortingFactor;
       }
@@ -90,7 +90,7 @@ const headers = [
       try {
         const regexp =
           filterString === '' || filterString === undefined ? new RegExp('(?:)') : new RegExp(filterString, 'i');
-        
+
         const status = !!labelsDict[value] ? labelsDict[value] : 'invalid';
         return regexp.test(`${status}-${value}`);
       } catch (e) {
@@ -98,6 +98,8 @@ const headers = [
       }
       return true;
     },
+    ascendingSortLabel: 'Less critical first',
+    descendingSortLabel: 'More critical first',
   },
 ];
 

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.md
@@ -23,14 +23,17 @@ const headers = [
   },
 ];
 
-const data = [
+const data = new Array(100).fill(1).flatMap(() => [
   { position: NaN, description: 'asdf', level: 0 },
-  { position: 1.5, description: 'qwe', level: 1 },
-  { position: 2.2, description: 'sdsf', level: 2 },
-  { position: 3.213, description: 'azxc', level: 23 },
-  { position: 5.23, description: 'qwertf', level: 3 },
-  { position: 3.23, description: 'zxczxc', level: 4 },
-];
+  { position: 1.5, description: 'asdf', level: 1 },
+  { position: 2.2, description: 'asdf', level: 2 },
+  { position: 3.213, description: 'asdf', level: 23 },
+  { position: 5.23, description: 'asdf', level: 3 },
+  { position: 3.23, description: 'asdf', level: 4 },
+]);
+
+
+
 
 <div style={{ width: '800px', background: 'black' }}>
   <ActionableTable data={data} headers={headers} />

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.module.css
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.module.css
@@ -1,5 +1,4 @@
 .columnHeader {
-  text-transform: uppercase;
   padding: 0.75em 0em 0.4em;
   position: relative;
 }

--- a/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.module.css
+++ b/love/src/components/GeneralPurpose/ActionableTable/ActionableTable.module.css
@@ -1,0 +1,15 @@
+.columnHeader {
+  text-transform: uppercase;
+  padding: 0.75em 0em 0.4em;
+  position: relative;
+}
+
+.primaryText {
+  display: block;
+  width: 80%;
+}
+
+.secondaryText {
+  font-size: 0.65em;
+  color: var(--secondary-font-color);
+}

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
@@ -43,33 +43,33 @@ const PaginatedTable = ({ headers, data }) => {
   return (
     <div>
       <SimpleTable headers={headers} data={pageData} />
-      <div className={styles.paginationContainer}>
-        {feasibleItemsPerPage.length > 0 && (
+      {feasibleItemsPerPage.length > 0 && (
+        <div className={styles.paginationContainer}>
           <Select
             onChange={onSelectChange}
             controlClassName={styles.select}
             option={itemsPerPage}
             options={feasibleItemsPerPage.map((v) => v.toString())}
           />
-        )}
-        <Button status="transparent" onClick={goToFirst} className={styles.iconBtn}>
-          &#x21E4;
-        </Button>
-        <span className={styles.adjacentPageControl}>
-          <Button status="transparent" onClick={goToPrevious} className={styles.iconBtn}>
-            &#x2190;
+          <Button status="transparent" onClick={goToFirst} className={styles.iconBtn}>
+            &#x21E4;
           </Button>
-          <span className={styles.contentRange}>
-            {page * itemsPerPage + 1}-{(page + 1) * itemsPerPage} of {data.length}
+          <span className={styles.adjacentPageControl}>
+            <Button status="transparent" onClick={goToPrevious} className={styles.iconBtn}>
+              &#x2190;
+            </Button>
+            <span className={styles.contentRange}>
+              {page * itemsPerPage + 1}-{(page + 1) * itemsPerPage} of {data.length}
+            </span>
+            <Button status="transparent" onClick={goToNext} className={styles.iconBtn}>
+              &#x2192;
+            </Button>
           </span>
-          <Button status="transparent" onClick={goToNext} className={styles.iconBtn}>
-            &#x2192;
+          <Button status="transparent" onClick={goToLast} className={styles.iconBtn}>
+            &#x21E5;
           </Button>
-        </span>
-        <Button status="transparent" onClick={goToLast} className={styles.iconBtn}>
-          &#x21E5;
-        </Button>
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
@@ -4,59 +4,74 @@ import styles from './PaginatedTable.module.css';
 import Button from '../Button/Button';
 import Select from '../Select/Select';
 
-const AVAILABLE_ITEMS_PER_PAGE = [
-    10,
-    25,
-    50,
-    100
-]
+const AVAILABLE_ITEMS_PER_PAGE = [10, 25, 50, 100];
 /**
  * Adds pagination handler to #SimpleTable
  */
 const PaginatedTable = ({ headers, data }) => {
-    const [itemsPerPage, setItemsPerPage] = React.useState(AVAILABLE_ITEMS_PER_PAGE[0].toString());
-    const [page, setPage] = React.useState(0);
+  const [itemsPerPage, setItemsPerPage] = React.useState(AVAILABLE_ITEMS_PER_PAGE[0].toString());
+  const [page, setPage] = React.useState(0);
 
-    const lastPage = data.length % itemsPerPage === 0 ? Math.floor(data.length / itemsPerPage) - 1: Math.floor(data.length / itemsPerPage);
-    const pageData = data.slice(page * itemsPerPage, (page + 1) * itemsPerPage);
+  const lastPage =
+    data.length % itemsPerPage === 0
+      ? Math.floor(data.length / itemsPerPage) - 1
+      : Math.floor(data.length / itemsPerPage);
+  const pageData = data.slice(page * itemsPerPage, (page + 1) * itemsPerPage);
 
+  const goToFirst = () => {
+    setPage(0);
+  };
 
-    const goToFirst = () => {
-        setPage(0);
-    }
+  const goToLast = () => {
+    setPage(lastPage);
+  };
 
-    const goToLast = () => {
-        setPage(lastPage);
-    }
+  const goToNext = () => {
+    setPage((page) => Math.min(page + 1, lastPage));
+  };
 
-    const goToNext = () => {
-        setPage(page => Math.min(page + 1, lastPage));
-    }
+  const goToPrevious = () => {
+    setPage((page) => Math.max(page - 1, 0));
+  };
 
-    const goToPrevious = () => {
-        setPage(page => Math.max(page - 1, 0));
-    }
+  const onSelectChange = (option) => {
+    setItemsPerPage(option.value);
+    setPage(0);
+  };
 
-    const onSelectChange = (option) => {
-        setItemsPerPage(option.value);
-        setPage(0);
-    }
-
-    return (
-        <div>
-            <SimpleTable headers={headers} data={pageData} />
-            <div className={styles.paginationContainer}>
-                <Select onChange={onSelectChange} controlClassName={styles.select} option={itemsPerPage} options={AVAILABLE_ITEMS_PER_PAGE.map(v=>v.toString())}/>
-                <Button status="transparent" onClick={goToFirst} className={styles.iconBtn}> &#x21E4; </Button>
-                <span className={styles.adjacentPageControl}>
-                    <Button status="transparent" onClick={goToPrevious} className={styles.iconBtn}> &#x2190; </Button>
-                    <span className={styles.contentRange}>{page * itemsPerPage + 1}-{(page + 1) * itemsPerPage} of {data.length}</span>
-                    <Button status="transparent" onClick={goToNext} className={styles.iconBtn}> &#x2192; </Button>
-                </span>
-                <Button status="transparent" onClick={goToLast} className={styles.iconBtn}> &#x21E5;  </Button>
-            </div>
-        </div>
-    );
+  const feasibleItemsPerPage = AVAILABLE_ITEMS_PER_PAGE.filter((threshold) => data.length > threshold);
+  return (
+    <div>
+      <SimpleTable headers={headers} data={pageData} />
+      <div className={styles.paginationContainer}>
+        {feasibleItemsPerPage.length > 0 && (
+          <Select
+            onChange={onSelectChange}
+            controlClassName={styles.select}
+            option={itemsPerPage}
+            options={feasibleItemsPerPage.map((v) => v.toString())}
+          />
+        )}
+        <Button status="transparent" onClick={goToFirst} className={styles.iconBtn}>
+          &#x21E4;
+        </Button>
+        <span className={styles.adjacentPageControl}>
+          <Button status="transparent" onClick={goToPrevious} className={styles.iconBtn}>
+            &#x2190;
+          </Button>
+          <span className={styles.contentRange}>
+            {page * itemsPerPage + 1}-{(page + 1) * itemsPerPage} of {data.length}
+          </span>
+          <Button status="transparent" onClick={goToNext} className={styles.iconBtn}>
+            &#x2192;
+          </Button>
+        </span>
+        <Button status="transparent" onClick={goToLast} className={styles.iconBtn}>
+          &#x21E5;
+        </Button>
+      </div>
+    </div>
+  );
 };
 
 export default PaginatedTable;

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
@@ -6,7 +6,7 @@ import Select from '../Select/Select';
 
 const AVAILABLE_ITEMS_PER_PAGE = [10, 25, 50, 100];
 /**
- * Adds pagination handler to #SimpleTable
+ * Adds pagination handlers to #SimpleTable.
  */
 const PaginatedTable = ({ headers, data }) => {
   const [itemsPerPage, setItemsPerPage] = React.useState(AVAILABLE_ITEMS_PER_PAGE[0].toString());

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
@@ -2,12 +2,19 @@ import React from 'react';
 import SimpleTable from '../SimpleTable/SimpleTable';
 import styles from './PaginatedTable.module.css';
 import Button from '../Button/Button';
+import Select from '../Select/Select';
 
+const AVAILABLE_ITEMS_PER_PAGE = [
+    10,
+    25,
+    50,
+    100
+]
 /**
  * Adds pagination handler to #SimpleTable
  */
 const PaginatedTable = ({ headers, data }) => {
-    const itemsPerPage = 10;
+    const [itemsPerPage, setItemsPerPage] = React.useState(AVAILABLE_ITEMS_PER_PAGE[0].toString());
     const [page, setPage] = React.useState(0);
 
     const lastPage = data.length % itemsPerPage === 0 ? Math.floor(data.length / itemsPerPage) - 1: Math.floor(data.length / itemsPerPage);
@@ -30,10 +37,16 @@ const PaginatedTable = ({ headers, data }) => {
         setPage(page => Math.max(page - 1, 0));
     }
 
+    const onSelectChange = (option) => {
+        setItemsPerPage(option.value);
+        setPage(0);
+    }
+
     return (
         <div>
             <SimpleTable headers={headers} data={pageData} />
             <div className={styles.paginationContainer}>
+                <Select onChange={onSelectChange} controlClassName={styles.select} option={itemsPerPage} options={AVAILABLE_ITEMS_PER_PAGE.map(v=>v.toString())}/>
                 <Button status="transparent" onClick={goToFirst} className={styles.iconBtn}> &#x21E4; </Button>
                 <span className={styles.adjacentPageControl}>
                     <Button status="transparent" onClick={goToPrevious} className={styles.iconBtn}> &#x2190; </Button>

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import SimpleTable from '../SimpleTable/SimpleTable';
+import styles from './PaginatedTable.module.css';
+import Button from '../Button/Button';
+
+/**
+ * Adds pagination handler to #SimpleTable
+ */
+const PaginatedTable = ({ headers, data }) => {
+    const itemsPerPage = 10;
+    const [page, setPage] = React.useState(0);
+
+    const lastPage = data.length % itemsPerPage === 0 ? Math.floor(data.length / itemsPerPage) - 1: Math.floor(data.length / itemsPerPage);
+    const pageData = data.slice(page * itemsPerPage, (page + 1) * itemsPerPage);
+
+
+    const goToFirst = () => {
+        setPage(0);
+    }
+
+    const goToLast = () => {
+        setPage(lastPage);
+    }
+
+    const goToNext = () => {
+        setPage(page => Math.min(page + 1, lastPage));
+    }
+
+    const goToPrevious = () => {
+        setPage(page => Math.max(page - 1, 0));
+    }
+
+    return (
+        <div>
+            <SimpleTable headers={headers} data={pageData} />
+            <div className={styles.paginationContainer}>
+                <Button status="transparent" onClick={goToFirst} className={styles.iconBtn}> &#x21E4; </Button>
+                <span className={styles.adjacentPageControl}>
+                    <Button status="transparent" onClick={goToPrevious} className={styles.iconBtn}> &#x2190; </Button>
+                    <span className={styles.contentRange}>{page * itemsPerPage + 1}-{(page + 1) * itemsPerPage} of {data.length}</span>
+                    <Button status="transparent" onClick={goToNext} className={styles.iconBtn}> &#x2192; </Button>
+                </span>
+                <Button status="transparent" onClick={goToLast} className={styles.iconBtn}> &#x21E5;  </Button>
+            </div>
+        </div>
+    );
+};
+
+export default PaginatedTable;

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.md
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.md
@@ -1,0 +1,33 @@
+```jsx
+
+const headers = [
+  {
+    field: 'position',
+    title: 'Position',
+    type: 'number',
+  },
+  {
+    field: 'description',
+    title: 'Descr.',
+    type: 'string',
+  },
+  {
+    field: 'level',
+    title: 'Severity',
+    type: 'number',
+  },
+];
+
+const data =  new Array(100).fill(1).flatMap(() => ([
+  { position: NaN, description: 'asdf', level: 0 },
+  { position: 1.5, description: 'asdf', level: 1 },
+  { position: 2.2, description: 'asdf', level: 2 },
+  { position: 3.213, description: 'asdf', level: 23 },
+  { position: 5.23, description: 'asdf', level: 3 },
+  { position: 3.23, description: 'asdf', level: 4 },
+]));
+
+<div style={{ width: '400px' }}>
+  <PaginatedTable data={data} headers={headers} />
+</div>;
+```

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.md
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.md
@@ -27,7 +27,7 @@ const data =  new Array(100).fill(1).flatMap(() => ([
   { position: 3.23, description: 'asdf', level: 4 },
 ]));
 
-<div style={{ width: '400px' }}>
+<div style={{ width: '400px', background:'black' }}>
   <PaginatedTable data={data} headers={headers} />
 </div>;
 ```

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.md
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.md
@@ -1,5 +1,4 @@
 ```jsx
-
 const headers = [
   {
     field: 'position',
@@ -18,16 +17,16 @@ const headers = [
   },
 ];
 
-const data =  new Array(100).fill(1).flatMap(() => ([
+const data = new Array(100).fill(1).flatMap(() => [
   { position: NaN, description: 'asdf', level: 0 },
   { position: 1.5, description: 'asdf', level: 1 },
   { position: 2.2, description: 'asdf', level: 2 },
   { position: 3.213, description: 'asdf', level: 23 },
   { position: 5.23, description: 'asdf', level: 3 },
   { position: 3.23, description: 'asdf', level: 4 },
-]));
+]);
 
-<div style={{ width: '400px', background:'black' }}>
+<div style={{ width: '400px', background: 'black' }}>
   <PaginatedTable data={data} headers={headers} />
 </div>;
 ```

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.module.css
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.module.css
@@ -1,0 +1,23 @@
+.paginationContainer {
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 1rem;
+  margin-top: 0.5rem;
+}
+.adjacentPageControl {
+  margin-left: 1rem;
+  margin-right: urem;
+}
+
+.contentRange {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.iconBtn {
+  display: inline;
+  border-radius: 50%;
+  padding: 0.3em;
+  height: 2em;
+  width: 2em;
+}

--- a/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.module.css
+++ b/love/src/components/GeneralPurpose/PaginatedTable/PaginatedTable.module.css
@@ -3,6 +3,7 @@
   justify-content: flex-end;
   margin-right: 1rem;
   margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 .adjacentPageControl {
   margin-left: 1rem;
@@ -20,4 +21,8 @@
   padding: 0.3em;
   height: 2em;
   width: 2em;
+}
+
+.select {
+  background: none;
 }

--- a/love/src/components/GeneralPurpose/Select/Select.jsx
+++ b/love/src/components/GeneralPurpose/Select/Select.jsx
@@ -3,7 +3,6 @@ import Dropdown from 'react-dropdown';
 import 'react-dropdown/style.css';
 import styles from './Select.module.css';
 
-
 const Select = ({ options = [], small = false, onChange = () => {}, option = undefined, ...props }) => {
   const {
     className: propsClassName,

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
@@ -1,30 +1,34 @@
 import React from 'react';
-import styles from './SimpleTable.module.css';
+import { Table, Thead, Tr, Td, Th, Tbody } from './Table';
+export { Table, Thead, Tr, Td, Th, Tbody };
 
-export function Table({ children, className }) {
-  return <table className={[styles.common, styles.table, className].join(' ')}>{children}</table>;
-}
+export default function SimpleTable({ headers, data }) {
 
-export function Thead({ children, className }) {
-  return <thead className={[styles.common, styles.thead, className].join(' ')}>{children}</thead>;
-}
-
-export function Tbody({ children, className }) {
-  return <tbody className={[styles.common, styles.tbody, className].join(' ')}>{children}</tbody>;
-}
-
-export function Td({ children, isNumber, className }) {
   return (
-    <td className={[styles.common, styles.td, className, isNumber ? styles.number : styles.string].join(' ')}>
-      {children}
-    </td>
+    <Table>
+      <Thead>
+        <Tr>
+          {headers.map((header) => (
+            <Th key={header.field}>{header.label}</Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data.map((row, index) => {
+          return (
+            <Tr key={index}>
+              {headers.map((header) => {
+                const value = row[header.field];
+                return (
+                  <Td key={header.field} isNumber={header.type === 'number'}>
+                    {isNaN(value) || Number.isInteger(value) ? value : `${Math.round(value * 10000) / 10000}º`}
+                  </Td>
+                );
+              })}
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
   );
-}
-
-export function Th({ children, className }) {
-  return <th className={[styles.common, styles.th, className].join(' ')}>{children}</th>;
-}
-
-export function Tr({ children, className }) {
-  return <tr className={[styles.common, styles.tr, className].join(' ')}>{children}</tr>;
 }

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
@@ -8,7 +8,7 @@ export { Table, Thead, Tr, Td, Th, Tbody };
  */
 function SimpleTable({ headers, data }) {
 
-  const defaultFormatter = (value) => value;
+  const defaultRenderMethod = (value) => value;
 
   return (
     <Table>
@@ -24,11 +24,11 @@ function SimpleTable({ headers, data }) {
           return (
             <Tr key={index}>
               {headers.map((header) => {
-                const formatter = header.formatter || defaultFormatter;
+                const render = header.render || defaultRenderMethod;
                 const value = row[header.field];
                 return (
                   <Td key={header.field} isNumber={header.type === 'number'} className={header.className}>
-                    {formatter(value)}
+                    {render(value)}
                   </Td>
                 );
               })}
@@ -41,19 +41,22 @@ function SimpleTable({ headers, data }) {
 }
 
 SimpleTable.propTypes = {
-  /** Description of headers and columns content*/
-  headers: PropTypes.shape({
-    /** Property accessor of this column's value on each data row */
-    field: PropTypes.string,
-    /** Node to be rendered as header label */
-    label: PropTypes.node,
-    /** Data type of this column: number, string, ... */
-    type: PropTypes.string,
-    /** Callback that receives this column's value and should return a `node` */
-    formatter: PropTypes.func,
-    /** className to be applied to the whole column */
-    className: PropTypes.string
-  }),
+  /** Array with properties of table columns and its headers.*/
+  headers: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** Property accessor of this column's value on each data row */
+      field: PropTypes.string,
+      /** Node to be rendered as header label */
+      label: PropTypes.node,
+      /** Data type of this column: number, string, ... */
+      type: PropTypes.string,
+      /** Callback that receives this column's value and should return a `node`. 
+       * Use it customize how the cell's value is   */
+      render: PropTypes.func,
+      /** className to be applied to the whole column */
+      className: PropTypes.string
+    }),
+  ),
   /** Rows to be rendered in the table */
   data: PropTypes.arrayOf(PropTypes.object)
 }

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
@@ -7,6 +7,9 @@ export { Table, Thead, Tr, Td, Th, Tbody };
  * Renders a table from data configuration 
  */
 function SimpleTable({ headers, data }) {
+
+  const defaultFormatter = (value) => value;
+
   return (
     <Table>
       <Thead>
@@ -21,10 +24,11 @@ function SimpleTable({ headers, data }) {
           return (
             <Tr key={index}>
               {headers.map((header) => {
+                const formatter = header.formatter || defaultFormatter;
                 const value = row[header.field];
                 return (
                   <Td key={header.field} isNumber={header.type === 'number'}>
-                    {isNaN(value) || Number.isInteger(value) ? value : `${Math.round(value * 10000) / 10000}º`}
+                    {formatter(value)}
                   </Td>
                 );
               })}
@@ -44,7 +48,9 @@ SimpleTable.propTypes = {
     /** Node to be rendered as header label */
     label: PropTypes.node,
     /** Data type of this column: number, string, ... */
-    type: PropTypes.string
+    type: PropTypes.string,
+    /** Callback that receives this column's value and should return a `node` */
+    formatter: PropTypes.func
   }),
   /** Rows to be rendered in the table */
   data: PropTypes.arrayOf(PropTypes.object)

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Table, Thead, Tr, Td, Th, Tbody } from './Table';
 export { Table, Thead, Tr, Td, Th, Tbody };
 
-export default function SimpleTable({ headers, data }) {
-
+/**
+ * Renders a table from data configuration 
+ */
+function SimpleTable({ headers, data }) {
   return (
     <Table>
       <Thead>
@@ -32,3 +35,19 @@ export default function SimpleTable({ headers, data }) {
     </Table>
   );
 }
+
+SimpleTable.propTypes = {
+  /** Description of headers and columns content*/
+  headers: PropTypes.shape({
+    /** Property accessor of this column's value on each data row */
+    field: PropTypes.string,
+    /** Node to be rendered as header label */
+    label: PropTypes.node,
+    /** Data type of this column: number, string, ... */
+    type: PropTypes.string
+  }),
+  /** Rows to be rendered in the table */
+  data: PropTypes.arrayOf(PropTypes.object)
+}
+
+export default SimpleTable;

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
@@ -4,7 +4,7 @@ import { Table, Thead, Tr, Td, Th, Tbody } from './Table';
 export { Table, Thead, Tr, Td, Th, Tbody };
 
 /**
- * Renders a table from data configuration 
+ * Renders a table from data and headers configuration 
  */
 function SimpleTable({ headers, data }) {
 
@@ -15,7 +15,7 @@ function SimpleTable({ headers, data }) {
       <Thead>
         <Tr>
           {headers.map((header) => (
-            <Th key={header.field}>{header.label}</Th>
+            <Th key={header.field} className={header.className}>{header.label}</Th>
           ))}
         </Tr>
       </Thead>
@@ -27,7 +27,7 @@ function SimpleTable({ headers, data }) {
                 const formatter = header.formatter || defaultFormatter;
                 const value = row[header.field];
                 return (
-                  <Td key={header.field} isNumber={header.type === 'number'}>
+                  <Td key={header.field} isNumber={header.type === 'number'} className={header.className}>
                     {formatter(value)}
                   </Td>
                 );
@@ -50,7 +50,9 @@ SimpleTable.propTypes = {
     /** Data type of this column: number, string, ... */
     type: PropTypes.string,
     /** Callback that receives this column's value and should return a `node` */
-    formatter: PropTypes.func
+    formatter: PropTypes.func,
+    /** className to be applied to the whole column */
+    className: PropTypes.string
   }),
   /** Rows to be rendered in the table */
   data: PropTypes.arrayOf(PropTypes.object)

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.jsx
@@ -15,7 +15,7 @@ function SimpleTable({ headers, data }) {
       <Thead>
         <Tr>
           {headers.map((header) => (
-            <Th key={header.field} className={header.className}>{header.label}</Th>
+            <Th key={header.field} className={header.className}>{header.title}</Th>
           ))}
         </Tr>
       </Thead>
@@ -47,7 +47,7 @@ SimpleTable.propTypes = {
       /** Property accessor of this column's value on each data row */
       field: PropTypes.string,
       /** Node to be rendered as header label */
-      label: PropTypes.node,
+      title: PropTypes.node,
       /** Data type of this column: number, string, ... */
       type: PropTypes.string,
       /** Callback that receives this column's value and should return a `node`. 

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -8,7 +8,7 @@ const headers = [
     field: 'position',
     label: 'Position',
     type: 'number',
-    formatter: (value) => (isNaN(value) ? '-' : value.toFixed(3)),
+    render: (value) => (isNaN(value) ? '-' : value.toFixed(3)),
   },
   {
     field: 'description',

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -1,10 +1,14 @@
+Basic example with with a column with custom styles.
 ```jsx
+import styles from './examplestyle.module.css';
+import SimpleTable from './SimpleTable';
+
 const headers = [
   {
     field: 'position',
     label: 'Position',
     type: 'number',
-    formatter: (value) => isNaN(value) ? '-' : value.toFixed(3)
+    formatter: (value) => (isNaN(value) ? '-' : value.toFixed(3)),
   },
   {
     field: 'description',
@@ -15,6 +19,7 @@ const headers = [
     field: 'level',
     label: 'Severity',
     type: 'number',
+    className: styles.exampleClass,
   },
 ];
 
@@ -27,44 +32,7 @@ const data = [
   { position: 3.23, description: 'asdf', level: 4 },
 ];
 
-<div
-  style={{
-    width: '400px',
-  }}
->
+<div style={{ width: '400px' }}>
   <SimpleTable data={data} headers={headers} />
 </div>;
-
-// if (col === 'driveStatus') {
-//   const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
-//   return (
-//     <Td key={col} className={styles.statusColumn}>
-//       <StatusText small status={stateToStyleMotorDrive[driveStatus]}>
-//         {driveStatus}
-//       </StatusText>
-//     </Td>
-//   );
-// }
-// if (col === 'brakeStatus') {
-//   const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
-//   return (
-//     <Td key={col} className={styles.statusColumn}>
-//       <StatusText small status={stateToStyleMotorBrake[brakeStatus]}>
-//         {brakeStatus}
-//       </StatusText>
-//     </Td>
-//   );
-// }
-// if (isNaN(value)) {
-//   return (
-//     <Td isNumber key={col}>
-//       {value}
-//     </Td>
-//   );
-// }
-// return (
-//   <Td isNumber key={col}>
-//     {Number.isInteger(value) ? value : Math.round(value * 10000) / 10000}
-//   </Td>
-// );
 ```

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -1,0 +1,88 @@
+```jsx
+import { Thead, Tr, Td, Th, Tbody } from './SimpleTable';
+
+const headers = [
+  {
+    field: 'position',
+    label: 'Position',
+    type: 'number',
+  },
+  {
+    field: 'description',
+    label: 'Descr.',
+    type: 'string',
+  },
+  {
+    field: 'level',
+    label: 'Severity',
+    type: 'number',
+  },
+];
+
+const data = [
+  { position: 1, description: 'asdf', level: 0 },
+  { position: 1.5, description: 'asdf', level: 1 },
+  { position: 2.2, description: 'asdf', level: 2 },
+  { position: 3.213, description: 'asdf', level: 23 },
+  { position: 5.23, description: 'asdf', level: 3 },
+  { position: 3.23, description: 'asdf', level: 4 },
+];
+
+<Table>
+  <Thead>
+    <Tr>
+      {headers.map((header) => (
+        <Th key={header.field}>{header.label}</Th>
+      ))}
+    </Tr>
+  </Thead>
+  <Tbody>
+    {data.map((row, index) => {
+      return (
+        <Tr key={index}>
+          {headers.map((header) => {
+            const value = row[header.field];
+            return (
+              <Td key={header.field} isNumber={header.type === 'number'}>
+                {isNaN(value) || Number.isInteger(value) ? value : `${Math.round(value * 10000) / 10000}º`}
+              </Td>
+            );
+            // if (col === 'driveStatus') {
+            //   const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
+            //   return (
+            //     <Td key={col} className={styles.statusColumn}>
+            //       <StatusText small status={stateToStyleMotorDrive[driveStatus]}>
+            //         {driveStatus}
+            //       </StatusText>
+            //     </Td>
+            //   );
+            // }
+            // if (col === 'brakeStatus') {
+            //   const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
+            //   return (
+            //     <Td key={col} className={styles.statusColumn}>
+            //       <StatusText small status={stateToStyleMotorBrake[brakeStatus]}>
+            //         {brakeStatus}
+            //       </StatusText>
+            //     </Td>
+            //   );
+            // }
+            // if (isNaN(value)) {
+            //   return (
+            //     <Td isNumber key={col}>
+            //       {value}
+            //     </Td>
+            //   );
+            // }
+            // return (
+            //   <Td isNumber key={col}>
+            //     {Number.isInteger(value) ? value : Math.round(value * 10000) / 10000}
+            //   </Td>
+            // );
+          })}
+        </Tr>
+      );
+    })}
+  </Tbody>
+</Table>;
+```

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -1,5 +1,5 @@
 ```jsx
-import { Thead, Tr, Td, Th, Tbody } from './SimpleTable';
+import { Table, Thead, Tr, Td, Th, Tbody } from './SimpleTable';
 
 const headers = [
   {
@@ -28,61 +28,44 @@ const data = [
   { position: 3.23, description: 'asdf', level: 4 },
 ];
 
-<Table>
-  <Thead>
-    <Tr>
-      {headers.map((header) => (
-        <Th key={header.field}>{header.label}</Th>
-      ))}
-    </Tr>
-  </Thead>
-  <Tbody>
-    {data.map((row, index) => {
-      return (
-        <Tr key={index}>
-          {headers.map((header) => {
-            const value = row[header.field];
-            return (
-              <Td key={header.field} isNumber={header.type === 'number'}>
-                {isNaN(value) || Number.isInteger(value) ? value : `${Math.round(value * 10000) / 10000}º`}
-              </Td>
-            );
-            // if (col === 'driveStatus') {
-            //   const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
-            //   return (
-            //     <Td key={col} className={styles.statusColumn}>
-            //       <StatusText small status={stateToStyleMotorDrive[driveStatus]}>
-            //         {driveStatus}
-            //       </StatusText>
-            //     </Td>
-            //   );
-            // }
-            // if (col === 'brakeStatus') {
-            //   const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
-            //   return (
-            //     <Td key={col} className={styles.statusColumn}>
-            //       <StatusText small status={stateToStyleMotorBrake[brakeStatus]}>
-            //         {brakeStatus}
-            //       </StatusText>
-            //     </Td>
-            //   );
-            // }
-            // if (isNaN(value)) {
-            //   return (
-            //     <Td isNumber key={col}>
-            //       {value}
-            //     </Td>
-            //   );
-            // }
-            // return (
-            //   <Td isNumber key={col}>
-            //     {Number.isInteger(value) ? value : Math.round(value * 10000) / 10000}
-            //   </Td>
-            // );
-          })}
-        </Tr>
-      );
-    })}
-  </Tbody>
-</Table>;
+<div
+  style={{
+    width: '400px',
+  }}
+>
+  <SimpleTable data={data} headers={headers} />
+</div>;
+
+// if (col === 'driveStatus') {
+//   const driveStatus = value === 'Unknown' || value === '-' ? value : motorDriveStateMap[value];
+//   return (
+//     <Td key={col} className={styles.statusColumn}>
+//       <StatusText small status={stateToStyleMotorDrive[driveStatus]}>
+//         {driveStatus}
+//       </StatusText>
+//     </Td>
+//   );
+// }
+// if (col === 'brakeStatus') {
+//   const brakeStatus = value === 'Unknown' || value === '-' ? value : motorBrakeStateMap[value];
+//   return (
+//     <Td key={col} className={styles.statusColumn}>
+//       <StatusText small status={stateToStyleMotorBrake[brakeStatus]}>
+//         {brakeStatus}
+//       </StatusText>
+//     </Td>
+//   );
+// }
+// if (isNaN(value)) {
+//   return (
+//     <Td isNumber key={col}>
+//       {value}
+//     </Td>
+//   );
+// }
+// return (
+//   <Td isNumber key={col}>
+//     {Number.isInteger(value) ? value : Math.round(value * 10000) / 10000}
+//   </Td>
+// );
 ```

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -1,6 +1,4 @@
 ```jsx
-import { Table, Thead, Tr, Td, Th, Tbody } from './SimpleTable';
-
 const headers = [
   {
     field: 'position',

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -4,6 +4,7 @@ const headers = [
     field: 'position',
     label: 'Position',
     type: 'number',
+    formatter: (value) => isNaN(value) ? '-' : value.toFixed(3)
   },
   {
     field: 'description',
@@ -18,7 +19,7 @@ const headers = [
 ];
 
 const data = [
-  { position: 1, description: 'asdf', level: 0 },
+  { position: NaN, description: 'asdf', level: 0 },
   { position: 1.5, description: 'asdf', level: 1 },
   { position: 2.2, description: 'asdf', level: 2 },
   { position: 3.213, description: 'asdf', level: 23 },

--- a/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
+++ b/love/src/components/GeneralPurpose/SimpleTable/SimpleTable.md
@@ -1,4 +1,5 @@
 Basic example with with a column with custom styles.
+
 ```jsx
 import styles from './examplestyle.module.css';
 import SimpleTable from './SimpleTable';
@@ -6,18 +7,18 @@ import SimpleTable from './SimpleTable';
 const headers = [
   {
     field: 'position',
-    label: 'Position',
+    title: 'Position',
     type: 'number',
     render: (value) => (isNaN(value) ? '-' : value.toFixed(3)),
   },
   {
     field: 'description',
-    label: 'Descr.',
+    title: 'Descr.',
     type: 'string',
   },
   {
     field: 'level',
-    label: 'Severity',
+    title: 'Severity',
     type: 'number',
     className: styles.exampleClass,
   },

--- a/love/src/components/GeneralPurpose/SimpleTable/Table.jsx
+++ b/love/src/components/GeneralPurpose/SimpleTable/Table.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styles from './SimpleTable.module.css';
+
+
+export function Table({ children, className }) {
+    return <table className={[styles.common, styles.table, className].join(' ')}>{children}</table>;
+}
+
+export function Thead({ children, className }) {
+    return <thead className={[styles.common, styles.thead, className].join(' ')}>{children}</thead>;
+}
+
+export function Tbody({ children, className }) {
+    return <tbody className={[styles.common, styles.tbody, className].join(' ')}>{children}</tbody>;
+}
+
+export function Td({ children, isNumber, className }) {
+    return (
+        <td className={[styles.common, styles.td, className, isNumber ? styles.number : styles.string].join(' ')}>
+            {children}
+        </td>
+    );
+}
+
+export function Th({ children, className }) {
+    return <th className={[styles.common, styles.th, className].join(' ')}>{children}</th>;
+}
+
+export function Tr({ children, className }) {
+    return <tr className={[styles.common, styles.tr, className].join(' ')}>{children}</tr>;
+}

--- a/love/src/components/GeneralPurpose/SimpleTable/examplestyle.module.css
+++ b/love/src/components/GeneralPurpose/SimpleTable/examplestyle.module.css
@@ -1,0 +1,3 @@
+.exampleClass {
+    background: #475054;
+}

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx
@@ -17,7 +17,14 @@ export default class FilterDialog extends Component {
     changeSortDirection: PropTypes.func,
     closeFilterDialogs: PropTypes.func,
     changeFilter: PropTypes.func,
+    ascendingSortLabel: PropTypes.node,
+    descendingSortLabel: PropTypes.node,
   };
+
+  static defaultProps = {
+    ascendingSortLabel: 'A - Z',
+    descendingSortLabel: 'Z - A'
+  }
 
   constructor(props) {
     super(props);
@@ -81,13 +88,13 @@ export default class FilterDialog extends Component {
             <div className={styles.filterIconWrapper}>
               <ArrowIcon active={false} up />
             </div>
-            <span className={styles.sortOption}>A - Z</span>
+            <span className={styles.sortOption}>{this.props.ascendingSortLabel}</span>
           </div>
           <div onClick={this.sortDescending} className={styles.dialogRow}>
             <div className={styles.filterIconWrapper}>
               <ArrowIcon active={false} />
             </div>
-            <span className={styles.sortOption}>Z - A</span>
+            <span className={styles.sortOption}>{this.props.descendingSortLabel}</span>
           </div>
 
           <div className={styles.line}> </div>
@@ -97,11 +104,7 @@ export default class FilterDialog extends Component {
             </div>
             <span className={styles.filterText}>Filter...</span>
           </div>
-          <TextField
-            ref={this.textInput}
-            onChange={this.props.changeFilter}
-            onKeyUp={this.onInputKeyUp}
-          />
+          <TextField ref={this.textInput} onChange={this.props.changeFilter} onKeyUp={this.onInputKeyUp} />
         </div>
       </div>
     );

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx
@@ -32,12 +32,12 @@ export default class FilterDialog extends Component {
   shouldComponentUpdate = (nextProps) => nextProps.show !== this.props.show;
 
   sortAscending = () => {
-    this.props.changeSortDirection('ascending', this.props.columnName);
+    this.props.changeSortDirection(ASCENDING, this.props.columnName);
     this.props.closeFilterDialogs();
   };
 
   sortDescending = () => {
-    this.props.changeSortDirection('descending', this.props.columnName);
+    this.props.changeSortDirection(DESCENDING, this.props.columnName);
     this.props.closeFilterDialogs();
   };
 
@@ -56,7 +56,7 @@ export default class FilterDialog extends Component {
     this.textInput.current.value = '';
     this.props.changeFilter({ target: '' });
     if (this.props.columnName === this.props.sortingColumn) {
-      this.props.changeSortDirection('None', this.props.columnName);
+      this.props.changeSortDirection(UNSORTED, this.props.columnName);
     }
     this.props.closeFilterDialogs();
   };
@@ -97,7 +97,7 @@ export default class FilterDialog extends Component {
             </div>
             <span className={styles.filterText}>Filter...</span>
           </div>
-          <TextField 
+          <TextField
             ref={this.textInput}
             onChange={this.props.changeFilter}
             onKeyUp={this.onInputKeyUp}

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.jsx
@@ -5,6 +5,10 @@ import FilterIcon from '../../../icons/FilterIcon/FilterIcon';
 import ArrowIcon from '../../../icons/ArrowIcon/ArrowIcon';
 import TextField from '../../../TextField/TextField';
 
+export const ASCENDING = 'ascending';
+export const DESCENDING = 'descending';
+export const UNSORTED = 'None';
+
 export default class FilterDialog extends Component {
   static propTypes = {
     show: PropTypes.bool,
@@ -70,7 +74,6 @@ export default class FilterDialog extends Component {
             </div>
             <span className={styles.filterText}>Sort as...</span>
             <span className={styles.clearAll} onClick={this.clearAllOnClick}>
-              {' '}
               Clear all
             </span>
           </div>

--- a/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.module.css
+++ b/love/src/components/HealthStatusSummary/TelemetrySelectionTable/FilterDialog/FilterDialog.module.css
@@ -24,8 +24,6 @@
     display: none;
 }
 
-
-
 .filterText {
     vertical-align: text-top;
 }

--- a/love/src/components/Layout/XMLTable/XMLTable.jsx
+++ b/love/src/components/Layout/XMLTable/XMLTable.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ManagerInterface from '../../../Utils';
-import { Table, Thead, Tbody, Td, Tr, Th } from '../../GeneralPurpose/SimpleTable/SimpleTable';
+import SimpleTable, { Table, Thead, Tbody, Td, Tr, Th } from '../../GeneralPurpose/SimpleTable/SimpleTable';
 import styles from './XMLTable.module.css';
 
 export default class XMLTable extends Component {
@@ -17,32 +17,39 @@ export default class XMLTable extends Component {
   }
 
   render() {
-    return this.state.data ? (
-      <Table className={styles.table}>
-        <Thead>
-          <Tr className={styles.headerRow}>
-            <Th>Name</Th>
-            <Th>SAL version</Th>
-            <Th>XML version (LOVE)</Th>
-            <Th>XML version (reported)</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {Object.keys(this.state.data).map((key) => {
-            const csc = this.state.data[key];
-            return (
-              <Tr key={key}>
-                <Td>{key}</Td>
-                <Td isNumber>{csc?.['sal_version'] ?? 'Unkonwn'}</Td>
-                <Td isNumber>{csc?.['xml_version'] ?? 'Unkonwn'}</Td>
-                <Td isNumber>-</Td>
-              </Tr>
-            );
-          })}
-        </Tbody>
-      </Table>
-    ) : (
-      <span>Loading...</span>
-    );
+    const headers = [
+      {
+        field: 'name',
+        label: 'Name'
+      },
+      {
+        field: 'sal_version',
+        label: 'SAL version',
+      },
+      {
+        field: 'xml_version',
+        label: 'XML version (LOVE)'
+      },
+      {
+        field: 'xml_version_reported',
+        label: 'XML version (reported)'
+      }
+    ];
+
+    if (!this.state.data) {
+      return <span>Loading...</span>;
+    }
+
+    const data = this.state.data ? Object.entries(this.state.data).map(([key, data]) => {
+
+      return {
+        ...data,
+        name: key
+      }
+    }) : [];
+
+
+    return <SimpleTable headers={headers} data={data} />
+
   }
 }

--- a/love/src/components/Layout/XMLTable/XMLTable.jsx
+++ b/love/src/components/Layout/XMLTable/XMLTable.jsx
@@ -20,19 +20,19 @@ export default class XMLTable extends Component {
     const headers = [
       {
         field: 'name',
-        label: 'Name'
+        title: 'Name'
       },
       {
         field: 'sal_version',
-        label: 'SAL version',
+        title: 'SAL version',
       },
       {
         field: 'xml_version',
-        label: 'XML version (LOVE)'
+        title: 'XML version (LOVE)'
       },
       {
         field: 'xml_version_reported',
-        label: 'XML version (reported)'
+        title: 'XML version (reported)'
       }
     ];
 


### PR DESCRIPTION
Adds new generic table components:
- `SimpleTable`: for simple tables with headers
- `PaginatedTable`: A `SimpleTable` with controls to handle pagination
- `ActionableTable`: A `PaginatedTable` with configurable sort/filter controls.

Refactors `MotorsTable` and `XMLTable` to use `SimpleTable`.