### PR TITLE
Fix clicking on dropdown menu on mobile devices

### DIFF
--- a/love/src/components/GeneralPurpose/DropdownMenu/DropdownMenu.jsx
+++ b/love/src/components/GeneralPurpose/DropdownMenu/DropdownMenu.jsx
@@ -11,12 +11,10 @@ export default class DropdownMenu extends PureComponent {
 
   componentDidMount() {
     document.addEventListener('click', this.handleDocumentClick, false);
-    document.addEventListener('touchend', this.handleDocumentClick, false);
   }
 
   componentWillUnmount() {
     document.removeEventListener('click', this.handleDocumentClick, false);
-    document.removeEventListener('touchend', this.handleDocumentClick, false);
   }
 
   toggleOpen = (event) => {
@@ -38,14 +36,15 @@ export default class DropdownMenu extends PureComponent {
     let children;
     if (this.props.children.length > 1) [firstChild, ...children] = this.props.children;
     else firstChild = this.props.children;
-    // console.log(this.props.children, firstChild);
     const { className } = this.props;
     return (
       <span className={[styles.refNode, className].join(' ')}>
         <span onClick={this.toggleOpen} ref={(node) => (this.refButtonNode = node)}>
           {firstChild}
         </span>
-        {this.state.isOpen && <div className={[styles.dropdown, this.state.isOpen ? styles.isOpen : ''].join(' ')}>{children}</div>}
+        {this.state.isOpen && (
+          <div className={[styles.dropdown, this.state.isOpen ? styles.isOpen : ''].join(' ')}>{children}</div>
+        )}
       </span>
     );
   }

--- a/love/src/components/GeneralPurpose/DropdownMenu/DropdownMenu.module.css
+++ b/love/src/components/GeneralPurpose/DropdownMenu/DropdownMenu.module.css
@@ -56,11 +56,10 @@
   max-height: 2em;
 }
 
-
 .iconBtn {
-    display: inline;
-    border-radius: 50%;
-    padding: 0.3em;
-    height: 2em;
-    width: 2em;
-  }
+  display: inline;
+  border-radius: 50%;
+  padding: 0.3em;
+  height: 2em;
+  width: 2em;
+}


### PR DESCRIPTION
Fix issue when clicking on a menu element of the DropdownMenu component on mobile devices did't work.

The problem was that the DropdownMenu listened to both `touchend` and click `events` in order to close the dropdown when the event's target was not the dropdown menu trigger button. Since the `touchend` occurred before, the dropdown was closed by the time the `click` was triggered.