### PR TITLE
Feature/new config file

### DIFF
--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -124,9 +124,12 @@ class Layout extends Component {
   };
 
   componentDidUpdate = (prevProps, prevState) => {
-    if (this.props.config?.alarms !== prevProps.config?.alarms) {
-      const minSeverityNotification = this.props.config?.alarms?.minSeverityNotification?.trim().toLowerCase();
-      if (minSeverityNotification) {
+    if (this.props.config?.alarms && this.props.config.alarms !== prevProps.config?.alarms) {
+      const minSeverityNotification = this.props.config.alarms.minSeverityNotification?.trim().toLowerCase();
+      if (!minSeverityNotification || minSeverityNotification === 'mute' || minSeverityNotification === 'muted') {
+        // If minSeverityNotification is null or "mute" or "muted", then do not play any sound
+        this.setState({ minSeverityNotification: severityEnum.critical + 1 });
+      } else {
         this.setState({ minSeverityNotification: severityEnum[minSeverityNotification] });
       }
     }

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -29,6 +29,7 @@ import XMLTable from './XMLTable/XMLTable';
 import ConfigPanel from './ConfigPanel/ConfigPanel';
 import UserDetails from './UserDetails/UserDetails';
 import UserSwapContainer from '../Login/UserSwap.container';
+import { severityEnum } from '../../Config';
 
 const BREAK_1 = 865;
 const BREAK_2 = 630;
@@ -82,6 +83,7 @@ class Layout extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      minSeverityNotification: severityEnum.warning,
       collapsedLogo: false,
       viewOnNotch: true,
       toolbarOverflow: false,
@@ -122,6 +124,13 @@ class Layout extends Component {
   };
 
   componentDidUpdate = (prevProps, prevState) => {
+    if (this.props.config?.alarms !== prevProps.config?.alarms) {
+      const minSeverityNotification = this.props.config?.alarms?.minSeverityNotification?.trim().toLowerCase();
+      if (minSeverityNotification) {
+        this.setState({ minSeverityNotification: severityEnum[minSeverityNotification] });
+      }
+    }
+
     if (this.state.toolbarOverflow !== prevState.toolbarOverflow) {
       this.moveCustomTopbar();
     }
@@ -425,7 +434,10 @@ class Layout extends Component {
   };
 
   render() {
-    const filteredAlarms = this.props.alarms.filter((a) => isActive(a) && !isAcknowledged(a) && !isMuted(a));
+    const filteredAlarms = this.props.alarms.filter(
+      (a) =>
+        isActive(a) && !isAcknowledged(a) && !isMuted(a) && a.severity?.value >= this.state.minSeverityNotification,
+    );
     return (
       <>
         <AlarmAudioContainer />

--- a/love/src/components/Scheduler/Scheduler.container.jsx
+++ b/love/src/components/Scheduler/Scheduler.container.jsx
@@ -25,7 +25,7 @@ export const schema = {
       type: 'string',
       description: 'Name to identify the live view server',
       isPrivate: false,
-      default: 'all_sky',
+      default: 'allSky',
     },
   },
 };

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.container.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { getAllAlarms, getLastestAlarms, getConfig } from '../../../redux/selectors';
+import { getAllAlarms, getLastestAlarms, getConfig, getAlarmConfig } from '../../../redux/selectors';
 import { addGroup, removeGroup } from '../../../redux/actions/ws';
 import AlarmAudio from './AlarmAudio';
 
@@ -11,11 +11,11 @@ const AlarmAudioContainer = ({ ...props }) => {
 const mapStateToProps = (state) => {
   const alarms = getAllAlarms(state);
   const newAlarms = getLastestAlarms(state);
-  const config = getConfig(state);
+  const alarmsConfig = getAlarmConfig(state);
   return {
     alarms,
     newAlarms,
-    config,
+    alarmsConfig,
   };
 };
 

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.container.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { getAllAlarms, getLastestAlarms, getConfig, getAlarmConfig } from '../../../redux/selectors';
+import { getAllAlarms, getLastestAlarms, getAlarmConfig } from '../../../redux/selectors';
 import { addGroup, removeGroup } from '../../../redux/actions/ws';
 import AlarmAudio from './AlarmAudio';
 

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -41,11 +41,6 @@ export default class AlarmAudio extends Component {
     unsubscribeToStreams: () => {},
   };
 
-  /** A conservative default configuration, all alarms sound... */
-  defaultConf = {
-    minSeveritySound: 'serious',
-  };
-
   constructor(props) {
     super(props);
     this.state = {

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -153,9 +153,12 @@ export default class AlarmAudio extends Component {
   };
 
   componentDidUpdate = (prevProps, _prevState) => {
-    if (this.props.alarmsConfig !== prevProps.alarmsConfig) {
-      const minSeveritySound = this.props.alarmsConfig?.minSeveritySound?.trim().toLowerCase();
-      if (minSeveritySound) {
+    if (this.props.alarmsConfig && this.props.alarmsConfig !== prevProps.alarmsConfig) {
+      const minSeveritySound = this.props.alarmsConfig.minSeveritySound?.trim().toLowerCase();
+      if (!minSeveritySound || minSeveritySound === 'mute' || minSeveritySound === 'muted') {
+        // If minSeveritySound is null or "mute" or "muted", then do not play any sound
+        this.setState({ minSeveritySound: severityEnum.critical + 1 });
+      } else {
         this.setState({ minSeveritySound: severityEnum[minSeveritySound] });
       }
     }

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -16,6 +16,8 @@ export const getConfig = (state) => (state.auth.config ? { ...state.auth.config 
 
 export const getCamFeeds = (state) => getConfig(state)?.camFeeds;
 
+export const getAlarmConfig = (state) => getConfig(state)?.alarms;
+
 export const getAllTime = (state) => ({ ...state.time });
 
 export const getClock = (state) => ({ ...state.time.clock });

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -14,7 +14,7 @@ export const getServerTime = (state) => ({ ...state.time.server_time });
 
 export const getConfig = (state) => (state.auth.config ? { ...state.auth.config } : null);
 
-export const getCamFeeds = (state) => getConfig(state)?.cam_feeds;
+export const getCamFeeds = (state) => getConfig(state)?.camFeeds;
 
 export const getAllTime = (state) => ({ ...state.time });
 

--- a/love/src/redux/tests/auth.test.js
+++ b/love/src/redux/tests/auth.test.js
@@ -35,18 +35,16 @@ const mockServerTime = {
 };
 
 const initialMockConfig = {
-  alarm_sounds: {
-    critical: 1,
-    serious: 0,
-    warning: 0,
+  setting1: {
+    setting11: 0,
+    setting12: 0,
   },
 };
 
 const mockConfig = {
-  alarm_sounds: {
-    critical: 1,
-    serious: 1,
-    warning: 0,
+  setting1: {
+    setting11: 1,
+    setting12: 2,
   },
 };
 


### PR DESCRIPTION
- Use new config file with entries `minSeveritySound` and `minSeverityNotification` to define the minimum severity for sounds and notifications in the topbar, respectively.
- Allow values null, "mute or "muted" to mute all sounds and/or notifications