### PR TITLE
Lovecsc observinglogs http refactor

### DIFF
--- a/love/package.json
+++ b/love/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.1.1",
-    "@testing-library/react": "^10.0.1",
+    "@testing-library/react": "^11.2.2",
     "cypress": "^4.1.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-plugin-only-warn": "^1.0.1",

--- a/love/src/components/ObservingLog/ObservingLogInput.container.jsx
+++ b/love/src/components/ObservingLog/ObservingLogInput.container.jsx
@@ -56,7 +56,7 @@ const mapDispatchToProps = (dispatch) => {
       subscriptions.forEach((stream) => dispatch(removeGroup(stream)));
     },
     sendMessage: (user, message) => {
-      return dispatch(sendLOVECscObservingLogs(user, message));
+      return dispatch(sendLOVECscObservingLogs({user, message}));
     },
   };
 };

--- a/love/src/components/ObservingLog/ObservingLogInput.jsx
+++ b/love/src/components/ObservingLog/ObservingLogInput.jsx
@@ -36,6 +36,13 @@ export default class ObservingLogInput extends Component {
     this.props.unsubscribeToStreams();
   };
 
+  sendMessage = (username, message) => {
+    this.props.sendMessage(this.props.username, this.state.message);
+    this.setState({
+      message: '',
+    })
+  }
+
   onTextChange = (content) => {
     this.setState({
       message: content,
@@ -52,7 +59,10 @@ export default class ObservingLogInput extends Component {
     this.setState((state) => ({
       ...state,
       keysDown: [...new Set([...state.keysDown, keyDown])],
-    }));
+    }), () => {
+      const keyCombinationPressed = ['Control', 'Enter'].every((key) => this.state.keysDown.includes(key));
+      if (keyCombinationPressed) this.sendMessage(this.props.username, this.state.message);
+    });
   };
 
   onKeyUp = (event) => {
@@ -64,16 +74,6 @@ export default class ObservingLogInput extends Component {
     }));
   };
 
-  componentDidUpdate = (prevState) => {
-    if (prevState.keysDown !== this.state.keysDown) {
-      const keyCombination1Pressed = ['Control', 'Enter'].every((key) => this.state.keysDown.includes(key));
-      const keyCombination2Pressed = ['Shift', 'Enter'].every((key) => this.state.keysDown.includes(key));
-      if(keyCombination1Pressed || keyCombination2Pressed){
-        this.props.sendMessage(this.props.username, this.state.message);
-      }
-    }
-  };
-
   render() {
     return (
       <div className={styles.container}>
@@ -83,9 +83,9 @@ export default class ObservingLogInput extends Component {
         </div>
         <div>
           <span className={styles.label}>Message:</span>
-          <TextArea callback={this.onTextChange} onKeyDown={this.onKeyDown} onKeyUp={this.onKeyUp}></TextArea>
+          <TextArea value={this.state.message} callback={this.onTextChange} onKeyDown={this.onKeyDown} onKeyUp={this.onKeyUp}></TextArea>
         </div>
-        <Button onClick={(e) => this.props.sendMessage(this.props.username, this.state.message)}>Save (Ctrl+Enter or Shift+Enter)</Button>
+        <Button onClick={(e) => this.sendMessage(this.props.username, this.state.message)}>Save (Ctrl+Enter)</Button>
       </div>
     );
   }

--- a/love/src/redux/actions/ws.js
+++ b/love/src/redux/actions/ws.js
@@ -480,7 +480,29 @@ export const _requestSALCommand = (data) => {
   };
 };
 
-export const sendLOVECscObservingLogs = (user, message) => {
+/**
+ * Requests the LOVE-producer to send a command to the SAL (salobj)
+ * via an HTTP request through the LOVE-manager.
+ *
+ */
+export const sendLOVECscObservingLogs = (observingLogMsg) => {
+  return (dispatch, getState) => {
+    const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/`;
+
+    return fetch(url, {
+      method: 'POST',
+      body: JSON.stringify(observingLogMsg),
+      headers: ManagerInterface.getHeaders(),
+    })
+      .then(r => r.json())
+      .then(data => {
+        // TODO: confirmation to the user? what kind?
+        // console.log(data);
+      });
+  };
+};
+
+export const _sendLOVECscObservingLogs = (user, message) => {
   return (dispatch, getState) => {
     const state = getState();
     const connectionStatus = getConnectionStatus(state);

--- a/love/src/redux/actions/ws.js
+++ b/love/src/redux/actions/ws.js
@@ -487,7 +487,7 @@ export const _requestSALCommand = (data) => {
  */
 export const sendLOVECscObservingLogs = (observingLogMsg) => {
   return (dispatch, getState) => {
-    const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/`;
+    const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/observinglog`;
 
     return fetch(url, {
       method: 'POST',

--- a/love/src/redux/tests/cmd.test.js
+++ b/love/src/redux/tests/cmd.test.js
@@ -1,16 +1,14 @@
 import { createStore, applyMiddleware } from 'redux';
-import WS from 'jest-websocket-mock';
 import rootReducer from '../reducers';
 import thunkMiddleware from 'redux-thunk';
 import { requestSALCommand, SALCommandStatus } from '../actions/ws';
-import { doReceiveToken } from '../actions/auth';
 import { getLastSALCommand } from '../selectors';
 
 import ManagerInterface from '../../Utils';
-import fetchMock, { MATCHED } from 'fetch-mock';
+import fetchMock from 'fetch-mock';
 
 
-let store, server;
+let store;
 
 beforeEach(async () => {
   store = createStore(rootReducer, applyMiddleware(thunkMiddleware));

--- a/love/src/redux/tests/lovecsc.test.js
+++ b/love/src/redux/tests/lovecsc.test.js
@@ -1,0 +1,48 @@
+import { createStore, applyMiddleware } from 'redux';
+import rootReducer from '../reducers';
+import thunkMiddleware from 'redux-thunk';
+import { sendLOVECscObservingLogs } from '../actions/ws';
+
+import ManagerInterface from '../../Utils';
+import fetchMock from 'fetch-mock';
+
+
+let store;
+
+beforeAll(async () => {
+  // Arrange
+  const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/`;
+  fetchMock.mock(url, {
+    "status": 200,
+    "data": {
+      "ack": "Added new observing log to SAL"
+    }
+  });
+});
+
+beforeEach(async () => {
+  store = createStore(rootReducer, applyMiddleware(thunkMiddleware));
+});
+
+afterEach(() => {
+  fetchMock.reset();
+});
+
+
+it('Should send an observing log to the server, save it on the state properly ', async () => {
+  // Arrange 
+  const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/observinglog`;
+  const observingLogMsg = {
+    user: 'an user',
+    message: 'a message',
+  };
+
+  // Act
+  await store.dispatch(sendLOVECscObservingLogs({...observingLogMsg}));
+
+  // Assert request was sent
+  expect(fetchMock.called(url)).toBe(true);
+  const [, lastCall] = fetchMock.lastCall(url);
+  expect(lastCall.method).toEqual('POST');
+  expect(JSON.parse(lastCall.body)).toEqual(observingLogMsg);
+});

--- a/love/src/redux/tests/lovecsc.test.js
+++ b/love/src/redux/tests/lovecsc.test.js
@@ -11,7 +11,7 @@ let store;
 
 beforeAll(async () => {
   // Arrange
-  const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/`;
+  const url = `${ManagerInterface.getApiBaseUrl()}lovecsc/observinglog`;
   fetchMock.mock(url, {
     "status": 200,
     "data": {

--- a/love/src/redux/tests/observingLogs.test.js
+++ b/love/src/redux/tests/observingLogs.test.js
@@ -2,7 +2,7 @@ import { createStore, applyMiddleware } from 'redux';
 import WS from 'jest-websocket-mock';
 import rootReducer from '../reducers';
 import thunkMiddleware from 'redux-thunk';
-import { addGroup, sendLOVECscObservingLogs } from '../actions/ws';
+import { addGroup, _sendLOVECscObservingLogs } from '../actions/ws';
 import { doReceiveToken } from '../actions/auth';
 import { getObservingLogs } from '../selectors';
 
@@ -28,7 +28,7 @@ afterEach(() => {
 it('Should send an observingLog to the LOVE-Controller and the server should receive it properly', async () => {
   const user = 'an user';
   const message = 'a message';
-  await store.dispatch(sendLOVECscObservingLogs(user, message));
+  await store.dispatch(_sendLOVECscObservingLogs(user, message));
 
   await expect(server).toReceiveMessage({
     category: 'love_csc',

--- a/love/src/redux/tests/time.test.js
+++ b/love/src/redux/tests/time.test.js
@@ -9,8 +9,21 @@ import { clockStatuses, initialState } from '../reducers/time';
 import { connectionStates } from '../actions/ws';
 import { getConnectionStatus, getAllTime } from '../selectors';
 import { siderealSecond } from '../../Utils';
+import fetchMock from 'fetch-mock';
+import ManagerInterface from '../../Utils';
 
 let store, server;
+
+beforeAll(async () => {
+  // ARRANGE
+  const url = `${ManagerInterface.getApiBaseUrl()}logout/`;
+  fetchMock.mock(url, {
+    "status": 204,
+    "data": {
+      "detail": "Logout successful, Token succesfully deleted",
+    }
+  });
+});
 
 beforeEach(async () => {
   // ARRANGE


### PR DESCRIPTION
This PR makes a refactor to the LOVE-frontend in order to send observing log through an HTTP connection