### PR TITLE
Flush elapsed time after script is finished

### DIFF
--- a/love/src/components/ScriptQueue/Scripts/CurrentScript/CurrentScript.jsx
+++ b/love/src/components/ScriptQueue/Scripts/CurrentScript/CurrentScript.jsx
@@ -68,8 +68,10 @@ export default class CurrentScript extends Component {
   };
 
   animateProgress = () => {
-    if (this.props.index === undefined) return;
-
+    if (this.props.index === undefined){
+      this.setState({ elapsedTime: 0 });
+      return; 
+    }
     if (this.props.scriptState !== 'RUNNING' && this.props.processState !== 'RUNNING') {
       requestAnimationFrame(this.animateProgress);
       return;


### PR DESCRIPTION
This is a small PR that fixes an issue related to the empty current script container. After the current script is finished and removed from the current script sections, the elapsed time must come back to 0 value