### PR TITLE
Add environmental variable to avoid styleguide crash

### DIFF
--- a/love/package.json
+++ b/love/package.json
@@ -60,7 +60,7 @@
     "build": "npx react-scripts build",
     "test": "npx react-scripts test",
     "eject": "npx react-scripts eject",
-    "guide:start": "npx styleguidist server",
+    "guide:start": "FAST_REFRESH=false npx styleguidist server",
     "guide:build": "npx styleguidist build",
     "lint": "eslint src"
   },


### PR DESCRIPTION
This PR makes a minor change to the `package.json` file in order to avoid crashing the styleguide app.

The styleguide suddenly stopped working, this was due to the incorporation of a new library called `webpack` wich has a functionality of fast refresh (check more info here: https://github.com/styleguidist/react-styleguidist/issues/1705). The solution is to add an evironmental variable to the command that starts the styleguide server.