### PR TITLE
Add formatting to log messages display

### DIFF
--- a/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
+++ b/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
@@ -67,7 +67,7 @@ function LogMessageDisplay({ logMessageData, clearCSCLogMessages }) {
                     </div>
                     <div className={styles.messageText}>
                       {msg.ScriptID && <div className={styles.scriptID}>Script {msg.ScriptID?.value}</div>}
-                      {msg.message?.value}
+                      <pre>{msg.message?.value}</pre>
                     </div>
                     <div className={styles.messageTraceback}>{msg.traceback.value}</div>
                   </div>

--- a/love/src/components/ScriptQueue/Scripts/ScriptDetails.jsx
+++ b/love/src/components/ScriptQueue/Scripts/ScriptDetails.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import scriptStyles from './Scripts.module.css';
-import CSCExpandedContainer from 'components/CSCSummary/CSCExpanded/CSCExpanded.container';
 
 const logLevelLabels = {
   '-1': '...',


### PR DESCRIPTION
This PR makes a small change to consider formatting characters such as: `\t` or `\n` inside the LogMessagesDisplay component. This will allow to show the log messages with the specified formatting.