### PR TITLE
Tickets/dm 34255

### DIFF
--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
@@ -29,8 +29,8 @@ export default class CSCDetail extends Component {
     onCSCClick: () => 0,
     heartbeatData: null,
     summaryStateData: undefined,
-    subscribeToStreams: () => {},
-    unsubscribeToStreams: () => {},
+    subscribeToStreams: () => { },
+    unsubscribeToStreams: () => { },
     embedded: false,
     shouldSubscribe: true,
     isRaw: false,
@@ -87,11 +87,12 @@ export default class CSCDetail extends Component {
     const { props } = this;
     let heartbeatStatus = 'unknown';
     let nLost = 0;
-    let timeDiff = -1;
+    let timeDiff = null;
+    let timeDiffText = 'No heartbeat from producer.';
+
     if (this.props.heartbeatData) {
       nLost = this.props.heartbeatData.lost;
-      if (this.props.heartbeatData.last_heartbeat_timestamp === -2) timeDiff = -2;
-      else if (this.props.heartbeatData.last_heartbeat_timestamp === -1) timeDiff = -1;
+      if (this.props.heartbeatData.last_heartbeat_timestamp === -1) timeDiff = -1;
       else timeDiff = Math.ceil(props.serverTime.tai * 1000 - this.props.heartbeatData.last_heartbeat_timestamp);
       heartbeatStatus = this.props.heartbeatData.lost > 0 || timeDiff < 0 ? 'alert' : 'ok';
     }
@@ -99,22 +100,18 @@ export default class CSCDetail extends Component {
       heartbeatStatus = 'ok';
     }
 
-    let timeDiffText = 'Unknown';
-
-    if (timeDiff === -2) {
-      timeDiffText = 'No heartbeat event in Remote.';
-    } else if (timeDiff === -1) {
+    if (timeDiff === -1) {
       timeDiffText = 'Never';
-    } else {
-      timeDiffText = timeDiff < 0 ? 'Never' : `${timeDiff} seconds ago`;
+    } else if (timeDiff !== null) {
+      timeDiffText = timeDiff < 0 ? 'Stale' : `${timeDiff} seconds ago`;
     }
 
     let title = `${cscText(this.props.name, this.props.salindex)} heartbeat\nLost: ${nLost}\n`;
 
-    if (timeDiff === -2) {
+    if (timeDiff === null) {
       title += `${timeDiffText}`;
     } else {
-      title += `Last seen: ${timeDiffText}`;
+      title += timeDiff < 0 ? `Last seen: ${timeDiffText}` : `${timeDiffText}`;
     }
     const summaryStateValue = this.props.summaryStateData ? this.props.summaryStateData.summaryState.value : 0;
     const summaryState = CSCDetail.states[summaryStateValue];

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import CSCExpanded from './CSCExpanded';
-import { addGroup, removeGroup } from '../../../redux/actions/ws';
+import { addGroup, removeGroup, requestSALCommand } from '../../../redux/actions/ws';
 import { removeCSCLogMessages, removeCSCErrorCodeData } from '../../../redux/actions/summaryData';
 import { getStreamData, getCSCHeartbeat, getCSCLogMessages, getCSCErrorCodeData } from '../../../redux/selectors';
 
@@ -55,6 +55,7 @@ const CSCExpandedContainer = ({
   onCSCClick,
   clearCSCErrorCodes,
   clearCSCLogMessages,
+  requestSALCommand,
   summaryStateData,
   softwareVersions,
   configurationsAvailable,
@@ -73,6 +74,7 @@ const CSCExpandedContainer = ({
       group={group}
       onCSCClick={onCSCClick}
       clearCSCErrorCodes={clearCSCErrorCodes}
+      requestSALCommand={requestSALCommand}
       errorCodeData={errorCodeData}
       summaryStateData={summaryStateData}
       softwareVersions={softwareVersions}
@@ -111,6 +113,15 @@ const mapDispatchToProps = (dispatch) => {
     },
     clearCSCErrorCodes: (csc, salindex) => {
       dispatch(removeCSCErrorCodeData(csc, salindex));
+    },
+    requestSALCommand: (cmd) => {
+      dispatch(
+        requestSALCommand(
+          {
+            ...cmd,
+          }
+        )
+      );
     },
   };
 };

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -137,9 +137,9 @@ const mapStateToProps = (state, ownProps) => {
   summaryStateData = summaryStateData ? summaryStateData : {};
 
   return {
-    summaryStateData: summaryStateData[0],
-    softwareVersions: softwareVersions ? softwareVersions[0] : undefined,
-    configurationsAvailable: configurationsAvailable ? configurationsAvailable[0] : undefined,
+    summaryStateData: summaryStateData ? summaryStateData?.[0] : undefined,
+    softwareVersions: softwareVersions ? softwareVersions?.[0] : undefined,
+    configurationsAvailable: configurationsAvailable ? configurationsAvailable?.[0] : undefined,
     heartbeatData,
     logMessageData,
     errorCodeData,

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -57,6 +57,7 @@ const CSCExpandedContainer = ({
   clearCSCLogMessages,
   summaryStateData,
   softwareVersions,
+  configurationsAvailable,
   logMessageData,
   errorCodeData,
   subscribeToStreams,
@@ -75,6 +76,7 @@ const CSCExpandedContainer = ({
       errorCodeData={errorCodeData}
       summaryStateData={summaryStateData}
       softwareVersions={softwareVersions}
+      configurationsAvailable={configurationsAvailable}
       subscribeToStreams={subscribeToStreams}
       unsubscribeToStreams={unsubscribeToStreams}
       logMessageData={logMessageData}
@@ -94,6 +96,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(addGroup(`event-${cscName}-${index}-logMessage`));
       dispatch(addGroup(`event-${cscName}-${index}-errorCode`));
       dispatch(addGroup(`event-${cscName}-${index}-softwareVersions`));
+      dispatch(addGroup(`event-${cscName}-${index}-configurationsAvailable`));
     },
     unsubscribeToStreams: (cscName, index) => {
       dispatch(removeGroup('event-Heartbeat-0-stream'));
@@ -101,6 +104,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(removeGroup(`event-${cscName}-${index}-logMessage`));
       dispatch(removeGroup(`event-${cscName}-${index}-errorCode`));
       dispatch(removeGroup(`event-${cscName}-${index}-softwareVersions`));
+      dispatch(removeGroup(`event-${cscName}-${index}-configurationsAvailable`));
     },
     clearCSCLogMessages: (csc, salindex) => {
       dispatch(removeCSCLogMessages(csc, salindex));
@@ -115,6 +119,7 @@ const mapStateToProps = (state, ownProps) => {
   let summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`);
   let heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
   let softwareVersions = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-softwareVersions`);
+  let configurationsAvailable = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-configurationsAvailable`);
 
   const logMessageData = getCSCLogMessages(state, ownProps.name, ownProps.salindex);
   const errorCodeData = getCSCErrorCodeData(state, ownProps.name, ownProps.salindex);
@@ -123,6 +128,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     summaryStateData: summaryStateData[0],
     softwareVersions: softwareVersions ? softwareVersions[0] : undefined,
+    configurationsAvailable: configurationsAvailable ? configurationsAvailable[0] : undefined,
     heartbeatData,
     logMessageData,
     errorCodeData,

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -56,6 +56,7 @@ const CSCExpandedContainer = ({
   clearCSCErrorCodes,
   clearCSCLogMessages,
   summaryStateData,
+  softwareVersions,
   logMessageData,
   errorCodeData,
   subscribeToStreams,
@@ -73,6 +74,7 @@ const CSCExpandedContainer = ({
       clearCSCErrorCodes={clearCSCErrorCodes}
       errorCodeData={errorCodeData}
       summaryStateData={summaryStateData}
+      softwareVersions={softwareVersions}
       subscribeToStreams={subscribeToStreams}
       unsubscribeToStreams={unsubscribeToStreams}
       logMessageData={logMessageData}
@@ -91,12 +93,14 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(addGroup(`event-${cscName}-${index}-summaryState`));
       dispatch(addGroup(`event-${cscName}-${index}-logMessage`));
       dispatch(addGroup(`event-${cscName}-${index}-errorCode`));
+      dispatch(addGroup(`event-${cscName}-${index}-softwareVersions`));
     },
     unsubscribeToStreams: (cscName, index) => {
       dispatch(removeGroup('event-Heartbeat-0-stream'));
       dispatch(removeGroup(`event-${cscName}-${index}-summaryState`));
       dispatch(removeGroup(`event-${cscName}-${index}-logMessage`));
       dispatch(removeGroup(`event-${cscName}-${index}-errorCode`));
+      dispatch(removeGroup(`event-${cscName}-${index}-softwareVersions`));
     },
     clearCSCLogMessages: (csc, salindex) => {
       dispatch(removeCSCLogMessages(csc, salindex));
@@ -110,6 +114,7 @@ const mapDispatchToProps = (dispatch) => {
 const mapStateToProps = (state, ownProps) => {
   let summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`);
   let heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
+  let softwareVersions = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-softwareVersions`);
 
   const logMessageData = getCSCLogMessages(state, ownProps.name, ownProps.salindex);
   const errorCodeData = getCSCErrorCodeData(state, ownProps.name, ownProps.salindex);
@@ -117,6 +122,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     summaryStateData: summaryStateData[0],
+    softwareVersions: softwareVersions ? softwareVersions[0] : undefined,
     heartbeatData,
     logMessageData,
     errorCodeData,

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -108,7 +108,7 @@ export default class CSCExpanded extends PureComponent {
   };
 
   setSummaryStateCommand(option) {
-    let configurationOverride = this.state.configurationOverride;
+    const { configurationOverride } = this.state;
     this.setState({
       summaryStateCommand: option,
       configurationOverride: configurationOverride,
@@ -116,7 +116,7 @@ export default class CSCExpanded extends PureComponent {
   };
 
   setConfigurationOverride(option) {
-    let summaryStateCommand = this.state.summaryStateCommand;
+    const { summaryStateCommand } = this.state;
     this.setState({
       summaryStateCommand: summaryStateCommand,
       configurationOverride: option,

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -139,6 +139,9 @@ export default class CSCExpanded extends PureComponent {
   render() {
     const summaryStateValue = this.props.summaryStateData ? this.props.summaryStateData.summaryState.value : 0;
     const cscVersion = this.props.softwareVersions ? this.props.softwareVersions.cscVersion.value : "Unknown";
+    const xmlVersion = this.props.softwareVersions ? this.props.softwareVersions.xmlVersion.value : "Unknown";
+    const salVersion = this.props.softwareVersions ? this.props.softwareVersions.salVersion.value : "Unknown";
+    const openSpliceVersion = this.props.softwareVersions ? this.props.softwareVersions.openSpliceVersion.value : "Unknown";
     const configurationsAvailable = this.props.configurationsAvailable ? this.props.configurationsAvailable.overrides.value.split(",") : null;
     const summaryState = CSCExpanded.states[summaryStateValue];
     const { props } = this;
@@ -219,7 +222,9 @@ export default class CSCExpanded extends PureComponent {
           <div className={styles.topBarContainerWrapper}>
             <div className={styles.topBarContainer}>
               <div className={styles.breadcrumContainer}>
-                <div>CSC Version: {cscVersion}</div>
+                <div className={styles.titlePadding}>
+                  Software Versions: csc={cscVersion}, xml={xmlVersion}, sal={salVersion}, openSplice={openSpliceVersion}
+                </div>
               </div>
             </div>
           </div>

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -1,12 +1,11 @@
 import React, { PureComponent } from 'react';
-import Dropdown from 'react-dropdown';
-import 'react-dropdown/style.css';
 import PropTypes from 'prop-types';
 import styles from './CSCExpanded.module.css';
 import HeartbeatIcon from '../../icons/HeartbeatIcon/HeartbeatIcon';
 import BackArrowIcon from '../../icons/BackArrowIcon/BackArrowIcon';
 import Button from '../../GeneralPurpose/Button/Button';
 import LogMessageDisplay from '../../GeneralPurpose/LogMessageDisplay/LogMessageDisplay';
+import Select from '../../GeneralPurpose/Select/Select';
 import { cscText, formatTimestamp } from '../../../Utils';
 
 export default class CSCExpanded extends PureComponent {
@@ -231,14 +230,8 @@ export default class CSCExpanded extends PureComponent {
           <div className={styles.topBarContainerWrapper}>
             <div className={styles.topBarContainer}>
               <div className={styles.breadcrumContainer}>
-                {/* <div>Configurations Available: {configurationsAvailable}</div> */}
-                {/* <Dropdown options={configurationsAvailableMenuOptions} onChange={this._onSelect} value="" placeholder="Configurations available" /> */}
-                Summary state command:
-                <Dropdown
-                  className={styles.dropDownClassName}
-                  controlClassName={styles.dropDownControlClassName}
-                  menuClassName={styles.dropDownMenuClassName}
-                  arrowClassName={styles.arrowClassName}
+                <div className={styles.titlePadding}>Summary state command:</div>
+                <Select
                   options={["start", "enable", "disable", "standby"]}
                   onChange={(option) => this.setSummaryStateCommand(option.value)}
                   value=""
@@ -247,12 +240,8 @@ export default class CSCExpanded extends PureComponent {
               </div>
               {configurationsAvailableMenuOptions !== null && this.state.summaryStateCommand === "start" ? (
                 <div className={styles.breadcrumContainer}>
-                  Configurations available:
-                  <Dropdown
-                    className={styles.dropDownClassName}
-                    controlClassName={styles.dropDownControlClassName}
-                    menuClassName={styles.dropDownMenuClassName}
-                    arrowClassName={styles.arrowClassName}
+                  <div className={styles.titlePadding}>Configurations available:</div>
+                  <Select
                     options={configurationsAvailableMenuOptions}
                     onChange={(option) => this.setConfigurationOverride(option.value)}
                     value=""

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -18,6 +18,7 @@ export default class CSCExpanded extends PureComponent {
     summaryStateData: PropTypes.object,
     logMessageData: PropTypes.array,
     errorCodeData: PropTypes.array,
+    softwareVersions: PropTypes.object,
     subscribeToStreams: PropTypes.func,
     unsubscribeToStreams: PropTypes.func,
   };
@@ -30,6 +31,7 @@ export default class CSCExpanded extends PureComponent {
     clearCSCErrorCodes: () => 0,
     clearCSCLogMessages: () => 0,
     summaryStateData: undefined,
+    softwareVersions: undefined,
     logMessageData: [],
     errorCodeData: [],
   };
@@ -90,6 +92,7 @@ export default class CSCExpanded extends PureComponent {
 
   render() {
     const summaryStateValue = this.props.summaryStateData ? this.props.summaryStateData.summaryState.value : 0;
+    const cscVersion = this.props.softwareVersions ? this.props.softwareVersions.cscVersion.value : "Unknown";
     const summaryState = CSCExpanded.states[summaryStateValue];
     const { props } = this;
 
@@ -162,6 +165,13 @@ export default class CSCExpanded extends PureComponent {
                   </div>
                 </div>
               )}
+            </div>
+          </div>
+          <div className={styles.topBarContainerWrapper}>
+            <div className={styles.topBarContainer}>
+              <div className={styles.breadcrumContainer}>
+                <div>CSC Version: {cscVersion}</div>
+              </div>
             </div>
           </div>
           {this.props.errorCodeData.length > 0 ? (

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
@@ -203,6 +203,10 @@
   color: var(--base-font-color);
 }
 
+.titlePadding {
+  padding: 0.5em;
+}
+
 .dropDownClassName {
   background-color: inherit;
   border-color: var(--primary-active-background-color);

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
@@ -49,7 +49,7 @@
   align-items: center;
 }
 
-.stateContainer > div {
+.stateContainer>div {
   padding-right: 0.5em;
 }
 
@@ -69,12 +69,11 @@
   width: 1.6em;
 }
 
-.heartbeatIconWrapper > svg {
+.heartbeatIconWrapper>svg {
   vertical-align: top;
 }
 
-.logContainerWrapper {
-}
+.logContainerWrapper {}
 
 .logContainerTopBar {
   display: flex;
@@ -149,11 +148,9 @@
   user-select: none;
 }
 
-.errorReport {
-}
+.errorReport {}
 
-.errorTraceback {
-}
+.errorTraceback {}
 
 .filtersContainer {
   display: flex;
@@ -194,4 +191,53 @@
 .heartbeatIcon {
   display: inline-block;
   margin: 0.2em;
+}
+
+.panel1 {
+  grid-column: 1 / 2;
+  grid-row: 1 / 3;
+}
+
+.title {
+  font-weight: bold;
+  color: var(--base-font-color);
+}
+
+.dropDownClassName {
+  background-color: inherit;
+  border-color: var(--primary-active-background-color);
+  color: inherit;
+  width: 15em;
+  margin: 0.2em 0 1em 0;
+  z-index: 100;
+}
+
+.dropDownControlClassName {
+  background-color: inherit;
+  border-color: inherit;
+  color: inherit;
+}
+
+.dropDownMenuClassName {
+  background-color: var(--primary-active-background-color);
+  border: 1px solid;
+  border-color: inherit;
+  color: inherit;
+}
+
+.unack {
+  background-color: var(--second-primary-background-color-dimmed);
+}
+
+.dropDownMenuClassName div {
+  color: inherit !important;
+  background-color: inherit !important;
+}
+
+.dropDownMenuClassName div:hover {
+  color: var(--base-font-color) !important;
+}
+
+.arrowClassName {
+  border-color: var(--primary-active-background-color) transparent transparent;
 }


### PR DESCRIPTION
This PR add 3 updates:
1 - Changes how the heartbeat message is handled in the `CSCDetail` view. It allows us to differentiate between the condition when there is not heartbeat from the producer (producer is not running), the producer does not receive a heartbeat from the CSC or the heartbeat from the producer is stale.
2 - Add the CSC version to the `CSCExpanded` view.
3 - Add the capability to send summary state commands (`start`, `enable`, `disable` and `standby`) from the `CSCExpanded` view as well as selecting a configuration for the `start` command when the CSC has options available. 