### PR TITLE
Fix parameter name on ATCamera component

### DIFF
--- a/love/src/redux/reducers/camera.js
+++ b/love/src/redux/reducers/camera.js
@@ -21,12 +21,11 @@ export default function (state = initialState, action) {
         imageSequence.name = data?.imageSequenceName?.value;
         imageSequence.imagesInSequence = data?.imagesInSequence?.value;
         imageSequence.images[data?.imageName?.value] = {
-          timeStamp: data.timeStamp?.value,
+          timeStamp: data.timestampAcquisitionStart?.value,
           imageIndex: data.imageIndex?.value,
           exposureTime: data.exposureTime?.value ?? 0,
           state: action.imageState,
         };
-        imageSequence.name = data.imageSequenceName?.value;
         return { ...state, imageSequence };
       }, state);
     }

--- a/love/src/redux/selectors.test.js
+++ b/love/src/redux/selectors.test.js
@@ -227,7 +227,7 @@ describe('Test image sequence data passes correctly to component', () => {
         value: 1,
         dataType: 'Int',
       },
-      timeStamp: {
+      timestampAcquisitionStart: {
         value: 1558368052.999,
         dataType: 'Float',
       },
@@ -257,7 +257,7 @@ describe('Test image sequence data passes correctly to component', () => {
         value: 1,
         dataType: 'Int',
       },
-      timeStamp: {
+      timestampAcquisitionStart: {
         value: 1558568052.999,
         dataType: 'Float',
       },
@@ -392,7 +392,7 @@ it('Append readout parameters to image', async () => {
           value: 1,
           dataType: 'Int',
         },
-        timeStamp: {
+        timestampAcquisitionStart: {
           value: 1558368052.999,
           dataType: 'Float',
         },


### PR DESCRIPTION
This PR updates a parameter of the topics `ATCamera_logevent_startIntegration`, `ATCamera_logevent_startReadout`, `ATCamera_logevent_endReadout`, `ATCamera_logevent_endOfImageTelemetry`:

- `timeStamp` is changed to `timestampAcquisitionStart`