### PR TITLE
Avoid horizontal scrolling on LogMessageDisplay component

### DIFF
--- a/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
+++ b/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
@@ -67,7 +67,7 @@ function LogMessageDisplay({ logMessageData, clearCSCLogMessages }) {
                     </div>
                     <div className={styles.messageText}>
                       {msg.ScriptID && <div className={styles.scriptID}>Script {msg.ScriptID?.value}</div>}
-                      <pre>{msg.message?.value}</pre>
+                      <pre className={styles.preText}>{msg.message?.value}</pre>
                     </div>
                     <div className={styles.messageTraceback}>{msg.traceback.value}</div>
                   </div>

--- a/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.module.css
+++ b/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.module.css
@@ -78,3 +78,7 @@
 .scriptID {
   color: var(--secondary-font-color);
 }
+
+.preText {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
This PR makes a minor change to avoid horizontal scrolling when there is a huge log in just one line.