### PR TITLE
Fix missing parameter to be read when getting alarm configurations

### DIFF
--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -131,8 +131,8 @@ class Layout extends Component {
   };
 
   componentDidUpdate = (prevProps, prevState) => {
-    if (this.props.config?.alarms && this.props.config.alarms !== prevProps.config?.alarms) {
-      const minSeverityNotification = this.props.config.alarms.minSeverityNotification?.trim().toLowerCase();
+    if (this.props.config?.content?.alarms !== prevProps.config?.content?.alarms) {
+      const minSeverityNotification = this.props.config.content.alarms.minSeverityNotification?.trim().toLowerCase();
       if (!minSeverityNotification || minSeverityNotification === 'mute' || minSeverityNotification === 'muted') {
         // If minSeverityNotification is null or "mute" or "muted", then do not play any sound
         this.setState({ minSeverityNotification: severityEnum.critical + 1 });
@@ -222,8 +222,11 @@ class Layout extends Component {
       const componentHeartbeat = this.props.getLastComponentHeartbeat(heartbeatSource);
       const lastComponentHeartbeat = this.state.heartbeatInfo[heartbeatSource];
       const componentHeartbeatStatus =
-        lastComponentHeartbeat?.data.timestamp !== componentHeartbeat?.data.timestamp ? 'ok' : 
-        componentHeartbeat && !lastComponentHeartbeat ? 'ok' : 'alert';
+        lastComponentHeartbeat?.data.timestamp !== componentHeartbeat?.data.timestamp
+          ? 'ok'
+          : componentHeartbeat && !lastComponentHeartbeat
+          ? 'ok'
+          : 'alert';
 
       heartbeatInfo[heartbeatSource] = componentHeartbeat;
       heartbeatStatus[heartbeatSource] = componentHeartbeatStatus;

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -15,9 +15,9 @@ export const getServerTime = (state) => ({ ...state.time.server_time });
 
 export const getConfig = (state) => (state.auth.config ? state.auth.config : null);
 
-export const getCamFeeds = (state) => getConfig(state)?.camFeeds;
+export const getCamFeeds = (state) => getConfig(state)?.content?.camFeeds;
 
-export const getAlarmConfig = (state) => getConfig(state)?.alarms;
+export const getAlarmConfig = (state) => getConfig(state)?.content?.alarms;
 
 export const getEfdConfig = (state) => getConfig(state)?.content?.efd;
 


### PR DESCRIPTION
This PR makes a small fix to read correctly the LOVE Config File parameteres related to Watcher alarms configurations.