### PR TITLE
Extend TimeSeriesPlot EFD Querying to support Influxdb arrays queries

### DIFF
--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -160,7 +160,6 @@ export default class ManagerInterface {
   static getXMLMetadata() {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}salinfo/metadata`;
@@ -169,11 +168,9 @@ export default class ManagerInterface {
       headers: this.getHeaders(),
     }).then((response) => {
       if (response.status >= 500) {
-        // console.error('Error communicating with the server.);
         return false;
       }
       if (response.status === 401 || response.status === 403) {
-        // console.log('Session expired. Logging out');
         ManagerInterface.removeToken();
         return false;
       }
@@ -186,7 +183,6 @@ export default class ManagerInterface {
   static getTopicData(categories = null) {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     let queryParam = null;
@@ -208,7 +204,6 @@ export default class ManagerInterface {
         return false;
       }
       if (response.status === 401 || response.status === 403) {
-        // console.log('Session expired. Logging out');
         ManagerInterface.removeToken();
         return false;
       }
@@ -293,7 +288,6 @@ export default class ManagerInterface {
   static getEmergencyContactList(/* index */) {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}emergencycontact`;
@@ -302,11 +296,9 @@ export default class ManagerInterface {
       headers: this.getHeaders(),
     }).then((response) => {
       if (response.status >= 500) {
-        // console.error('Error communicating with the server.);
         return false;
       }
       if (response.status === 401 || response.status === 403) {
-        // console.log('Session expired. Logging out');
         ManagerInterface.removeToken();
         return false;
       }
@@ -319,7 +311,6 @@ export default class ManagerInterface {
   static getEFDTimeseries(start_date, time_window, cscs, resample, efd_instance) {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}efd/timeseries`;
@@ -335,11 +326,9 @@ export default class ManagerInterface {
       }),
     }).then((response) => {
       if (response.status >= 500) {
-        // console.error('Error communicating with the server.);
         return false;
       }
       if (response.status === 401 || response.status === 403) {
-        // console.log('Session expired. Logging out');
         ManagerInterface.removeToken();
         return false;
       }
@@ -417,7 +406,6 @@ export default class ManagerInterface {
   static runATCSCommand(commandName, params = {}) {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}tcs/aux`;
@@ -453,7 +441,6 @@ export default class ManagerInterface {
   static getATCSDocstrings() {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}tcs/aux/docstrings`;
@@ -462,11 +449,9 @@ export default class ManagerInterface {
       headers: this.getHeaders(),
     }).then((response) => {
       if (response.status >= 500) {
-        // console.error('Error communicating with the server.);
         return false;
       }
       if (response.status === 401 || response.status === 403) {
-        // console.log('Session expired. Logging out');
         ManagerInterface.removeToken();
         return false;
       }
@@ -479,7 +464,6 @@ export default class ManagerInterface {
   static runMTCSCommand(commandName, params = {}) {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}tcs/main`;
@@ -515,7 +499,6 @@ export default class ManagerInterface {
   static getMTCSDocstrings() {
     const token = ManagerInterface.getToken();
     if (token === null) {
-      // console.log('Token not found during validation');
       return new Promise((resolve) => resolve(false));
     }
     const url = `${this.getApiBaseUrl()}tcs/main/docstrings`;
@@ -524,11 +507,9 @@ export default class ManagerInterface {
       headers: this.getHeaders(),
     }).then((response) => {
       if (response.status >= 500) {
-        // console.error('Error communicating with the server.);
         return false;
       }
       if (response.status === 401 || response.status === 403) {
-        // console.log('Session expired. Logging out');
         ManagerInterface.removeToken();
         return false;
       }
@@ -936,7 +917,9 @@ export const parsePlotInputs = (inputs) => {
       newIndexDict[input.topic].push(input.item);
       return;
     }
-    newIndexDict[input.topic] = [input.item];
+    // Next line was added to support EFD Querying for Array type items (influx)
+    newIndexDict[input.topic] = [`${input.item}${input.arrayIndex ?? ''}`];
+    // newIndexDict[input.topic] = [input.item]; // Original line
 
     newTopicDict = newIndexDict[input.topic];
     if (indexDict) {
@@ -980,7 +963,9 @@ export const parseCommanderData = (data, tsLabel = 'x', valueLabel = 'y') => {
     const newTopicData = {};
     Object.keys(topicData).forEach((propertyKey) => {
       const propertyDataArray = topicData[propertyKey];
-      newTopicData[propertyKey] = propertyDataArray.map((dataPoint) => {
+      // Next line was added to support EFD Querying for Array type items (influx)
+      const formattedPropertyKey = propertyKey.replace(/[\d\.]+$/, '');
+      newTopicData[formattedPropertyKey] = propertyDataArray.map((dataPoint) => {
         const tsString = dataPoint?.ts.split(' ').join('T');
         return { [tsLabel]: parseTimestamp(tsString), [valueLabel]: dataPoint?.value };
       });

--- a/love/src/components/GeneralPurpose/Plot/TimeSeriesConfig/TSCEntry/TSCInput/TSCInput.jsx
+++ b/love/src/components/GeneralPurpose/Plot/TimeSeriesConfig/TSCEntry/TSCInput/TSCInput.jsx
@@ -123,6 +123,28 @@ export default class TSCInput extends PureComponent {
           placeholder="Select an item"
           onChange={(selection) => this.onSelectChange(selection.value, 'item')}
         />
+        <div>
+          Is Array?
+          <Input
+            className={styles.checkboxInput}
+            type="checkbox"
+            checked={input?.isArray}
+            onChange={(ev) => this.onSelectChange(ev.target.checked, 'isArray')}
+          />
+          {input?.isArray && (
+            <>
+              Index &nbsp;&nbsp;
+              <Input
+                className={styles.input}
+                type="number"
+                min={0}
+                value={input?.arrayIndex ?? 0}
+                placeholder="Array index"
+                onChange={(ev) => this.onSelectChange(parseInt(ev.target.value), 'arrayIndex')}
+              />
+            </>
+          )}
+        </div>
         {/** DO NOT DELETE THIS COMMENTED CODE, IT WILL BE USED LATER */}
         {/* <Button className={styles.button} onClick={this.props.onGetName} disabled={this.props.onGetName === null}>
           Use as Name

--- a/love/src/components/GeneralPurpose/Plot/TimeSeriesConfig/TSCEntry/TSCInput/TSCInput.module.css
+++ b/love/src/components/GeneralPurpose/Plot/TimeSeriesConfig/TSCEntry/TSCInput/TSCInput.module.css
@@ -15,6 +15,10 @@
   margin-right: 0.5em;
 }
 
+.checkboxInput {
+  width: 5ch;
+}
+
 .select {
   width: 30ch;
   margin-right: 0.5em;

--- a/love/src/components/GeneralPurpose/Plot/TimeSeriesConfig/TimeSeriesConfig.jsx
+++ b/love/src/components/GeneralPurpose/Plot/TimeSeriesConfig/TimeSeriesConfig.jsx
@@ -75,6 +75,12 @@ export default class TimeSeriesConfig extends PureComponent {
       salindex: inputs?.[0]?.salindex,
       topic: inputs?.[0]?.topic,
       item: inputs?.[0]?.item,
+      isArray: inputs?.[0]?.isArray,
+      arrayIndex: inputs?.[0]?.arrayIndex,
+      color: inputs?.[0]?.color,
+      dash: inputs?.[0]?.dash,
+      shape: inputs?.[0]?.shape,
+      filled: inputs?.[0]?.filled,
       ...style,
     };
     this.setState({ entries: newEntries, changed: true });
@@ -105,7 +111,22 @@ export default class TimeSeriesConfig extends PureComponent {
         <div className={styles.content}>
           <div className={styles.list}>
             {this.state.entries.map((entry, index) => {
-              const { name, category, csc, salindex, topic, item, type, accessor, color, dash, shape, filled } = entry;
+              const {
+                name,
+                category,
+                csc,
+                salindex,
+                topic,
+                item,
+                isArray,
+                arrayIndex,
+                type,
+                accessor,
+                color,
+                dash,
+                shape,
+                filled,
+              } = entry;
               return (
                 <TSCEntry
                   key={index}
@@ -117,6 +138,8 @@ export default class TimeSeriesConfig extends PureComponent {
                       salindex: parseInt(salindex),
                       topic,
                       item,
+                      isArray,
+                      arrayIndex,
                       color: color ?? defaultStyles[index % (defaultStyles.length - 1)].color,
                       dash: dash ?? defaultStyles[index % (defaultStyles.length - 1)].dash,
                       shape: shape ?? defaultStyles[index % (defaultStyles.length - 1)].shape,


### PR DESCRIPTION
This PR makes an extension of the VegaTimeSeriesPlot EFD Querying feature in order to support the Influxdb format for Array type values. E.g. if a value is an array of 10 elements, then 10 individual fields must be created. This is currently done appending the index suffix to the name of the parameter to specify. This is shown on the following image:

![image](https://user-images.githubusercontent.com/5626266/178058636-39d5854a-699a-49f3-86f4-3aeed8c7e53b.png)
 