### PR TITLE
Extend mount azimuth plot accessor

### DIFF
--- a/love/src/components/AuxTel/Dome/Dome.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.jsx
@@ -103,7 +103,7 @@ export default class Dome extends Component {
       topic: 'mount_AzEl_Encoders',
       item: 'azimuthCalculatedAngle',
       type: 'line',
-      accessor: (x) => x[0],
+      accessor: (x) => (x[0] < 0 ? x[0] + 360 : x[0]),
       color: 'hsl(160, 70%, 40%)',
     },
     'Mount Target': {


### PR DESCRIPTION
This is small PR to adjust the calculation of the ATMCS azimuth on the ATDome plots section.