### PR TITLE
Extend logs formatting to the rest of components

### DIFF
--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -322,8 +322,8 @@ export default class CSCExpanded extends PureComponent {
                         <div className={styles.timestamp} title="private_rcvStamp">
                           {formatTimestamp(msg.private_rcvStamp.value * 1000)}
                         </div>
-                        <div className={styles.messageText}>{msg.errorReport.value}</div>
-                        <div className={styles.messageTraceback}>{msg.traceback.value}</div>
+                        <pre className={styles.preText}>{msg.errorReport.value}</pre>
+                        <pre className={styles.preText}>{msg.traceback.value}</pre>
                       </div>
                     </div>
                   );

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
@@ -266,3 +266,7 @@
 .warningIcon svg {
   vertical-align: middle;
 }
+
+.preText {
+  white-space: pre-wrap;
+}

--- a/love/src/components/EventLog/EventLog.jsx
+++ b/love/src/components/EventLog/EventLog.jsx
@@ -206,8 +206,8 @@ export default class EventLog extends PureComponent {
               </div>
             </div>
             <Separator className={styles.innerSeparator} />
-            <div className={styles.messageText}>{msg.message.value}</div>
-            <div className={styles.messageTraceback}>{msg.traceback.value}</div>
+            <pre className={styles.preText}>{msg.message.value}</pre>
+            <pre className={styles.preText}>{msg.traceback.value}</pre>
           </div>
         </Card>
       )

--- a/love/src/components/EventLog/EventLog.module.css
+++ b/love/src/components/EventLog/EventLog.module.css
@@ -132,13 +132,8 @@
   user-select: none;
 }
 
-.messageText {
-  padding-bottom: 0.5em;
-  word-break: break-all;
-}
-
-.messageTraceback {
-  word-break: break-all;
+.preText {
+  white-space: pre-wrap;
 }
 
 .errorCodeContainer {

--- a/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
+++ b/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
@@ -69,7 +69,7 @@ function LogMessageDisplay({ logMessageData, clearCSCLogMessages }) {
                       {msg.ScriptID && <div className={styles.scriptID}>Script {msg.ScriptID?.value}</div>}
                       <pre className={styles.preText}>{msg.message?.value}</pre>
                     </div>
-                    <div className={styles.messageTraceback}>{msg.traceback.value}</div>
+                    <pre className={styles.preText}>{msg.traceback.value}</pre>
                   </div>
                 </div>
               );


### PR DESCRIPTION
This PR extends a missing functionality to the `EventLog` and `CSCExpanded` components. Now logs shown on those components will also be formatted to allow an easier monitoring.