### PR TITLE
Fix Auxtel Mount SummaryPanel

### DIFF
--- a/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.jsx
+++ b/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.jsx
@@ -206,7 +206,8 @@ export default class SummaryTable extends Component {
         </Value>
 
         <Label>Cell load</Label>
-        <Value>{this.props.loadCell === "Unknown" ? (this.props.loadCell) : (this.props.loadCell).toFixed(2) + ' kg' }</Value> 
+        {/* <Value>{this.props.loadCell === "Unknown" ? (this.props.loadCell) : (this.props.loadCell).toFixed(2) + ' kg' }</Value> */}
+        <Value>{this.props.loadCell}</Value>
         <Row>
             <Limits
               lowerLimit={ATPneumaticsLimits.cellLoad.min}
@@ -221,7 +222,8 @@ export default class SummaryTable extends Component {
         </Row>
 
         <Label>M1 Air pressure</Label>
-        <Value>{this.props.m1AirPressure === "Unknown" ? (this.props.m1AirPressure) : (this.props.m1AirPressure).toFixed(2) + ' Pa' }</Value>
+        {/* <Value>{this.props.m1AirPressure === "Unknown" ? (this.props.m1AirPressure) : (this.props.m1AirPressure).toFixed(2) + ' Pa' }</Value> */}
+        <Value>{this.props.m1AirPressure}</Value>
         <Row>
             <Limits
               lowerLimit={ATPneumaticsLimits.pressure.min}

--- a/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.jsx
+++ b/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.jsx
@@ -206,7 +206,6 @@ export default class SummaryTable extends Component {
         </Value>
 
         <Label>Cell load</Label>
-        {/* <Value>{this.props.loadCell === "Unknown" ? (this.props.loadCell) : (this.props.loadCell).toFixed(2) + ' kg' }</Value> */}
         <Value>{this.props.loadCell}</Value>
         <Row>
             <Limits
@@ -222,7 +221,6 @@ export default class SummaryTable extends Component {
         </Row>
 
         <Label>M1 Air pressure</Label>
-        {/* <Value>{this.props.m1AirPressure === "Unknown" ? (this.props.m1AirPressure) : (this.props.m1AirPressure).toFixed(2) + ' Pa' }</Value> */}
         <Value>{this.props.m1AirPressure}</Value>
         <Row>
             <Limits

--- a/love/src/components/GeneralPurpose/SummaryPanel/Value.jsx
+++ b/love/src/components/GeneralPurpose/SummaryPanel/Value.jsx
@@ -34,6 +34,7 @@ const Value = ({
    otherwise use the stringified version */
   if (typeof children === 'object' && !React.isValidElement(children)) {
     if (children.value !== undefined) parsedChild = children.value;
+    if (children.units !== undefined) parsedChild = `${parsedChild.toFixed(2)} ${children.units}`;
     else parsedChild = JSON.stringify(children);
   }
   /** Display array of values when children is an array */
@@ -51,7 +52,7 @@ const Value = ({
     );
   }
   /** Display strings and numbers. Truncate to 4 decimal places in the case of numbers */
-  return <span className={styles.value}>{parsedChild.toFixed ? parsedChild.toFixed(3) : parsedChild}</span>;
+  return <span className={styles.value}>{parsedChild}</span>;
 };
 
 export default Value;


### PR DESCRIPTION
This PR fix a small error regarding the use of the `Value` component. It was extended so it also shows the unit of the given value if the input is an object.