### PR TITLE
Add optional chainning to avoid errors when user logouts

### DIFF
--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -136,7 +136,7 @@ class Layout extends Component {
 
   componentDidUpdate = (prevProps, prevState) => {
     if (!isEqual(this.props.config?.content?.alarms, prevProps.config?.content?.alarms)) {
-      const minSeverityNotification = this.props.config.content.alarms.minSeverityNotification?.trim().toLowerCase();
+      const minSeverityNotification = this.props.config?.content.alarms.minSeverityNotification?.trim().toLowerCase();
       if (!minSeverityNotification || minSeverityNotification === 'mute' || minSeverityNotification === 'muted') {
         // If minSeverityNotification is null or "mute" or "muted", then do not play any sound
         this.setState({ minSeverityNotification: severityEnum.critical + 1 });


### PR DESCRIPTION
This PR makes a small change in order to avoid null evaluations when the user logouts.