### PR TITLE
Fix mirror covers values for LightPath component

### DIFF
--- a/love/src/components/AuxTel/Mount/LightPath.jsx
+++ b/love/src/components/AuxTel/Mount/LightPath.jsx
@@ -100,10 +100,11 @@ export default class LightPath extends Component {
     //ATPneumatics
     const m1CoverStateText = m1CoverStateStateMap[props.m1CoverState];
     const m1CoverLimitSwitches = props.m1CoverLimitSwitches;
+    console.log(m1CoverLimitSwitches);
     const getLimitSwitchStatus = (number) => {
-      if (!m1CoverLimitSwitches[`cover${number}ClosedActive`] && m1CoverLimitSwitches[`cover${number}OpenActive`])
+      if (!m1CoverLimitSwitches[`cover${number}ClosedActive`]?.value && m1CoverLimitSwitches[`cover${number}OpenedActive`]?.value)
         return m1CoverLimitSwitchesStateMap[1];
-      if (m1CoverLimitSwitches[`cover${number}ClosedActive`] && !m1CoverLimitSwitches[`cover${number}OpenActive`])
+      if (m1CoverLimitSwitches[`cover${number}ClosedActive`]?.value && !m1CoverLimitSwitches[`cover${number}OpenedActive`]?.value)
         return m1CoverLimitSwitchesStateMap[2];
       return m1CoverLimitSwitchesStateMap[0];
     };

--- a/love/src/components/AuxTel/Mount/LightPath.jsx
+++ b/love/src/components/AuxTel/Mount/LightPath.jsx
@@ -100,7 +100,6 @@ export default class LightPath extends Component {
     //ATPneumatics
     const m1CoverStateText = m1CoverStateStateMap[props.m1CoverState];
     const m1CoverLimitSwitches = props.m1CoverLimitSwitches;
-    console.log(m1CoverLimitSwitches);
     const getLimitSwitchStatus = (number) => {
       if (!m1CoverLimitSwitches[`cover${number}ClosedActive`]?.value && m1CoverLimitSwitches[`cover${number}OpenedActive`]?.value)
         return m1CoverLimitSwitchesStateMap[1];


### PR DESCRIPTION
This PR fixes a wrong behavior with the `LightPath` component. Mirror covers weren't showing the correct values, now they do.