### PR TITLE
Update deprecated param for ScriptQueue_command_move

### DIFF
--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -436,7 +436,7 @@ export default class ScriptQueue extends Component {
     this.props.requestSALCommand({
       cmd: 'cmd_move',
       params: {
-        salIndex: scriptIndex,
+        scriptSalIndex: scriptIndex,
         location: location,
         locationSalIndex: locationSalIndex,
       },


### PR DESCRIPTION
This PR makes a micro change to update a deprecated parameter of the `ScriptQueue_command_move` command. Changed `salIndex` per `scriptSalIndex`.