### PR TITLE
Fix a state mapping of M1M3

### DIFF
--- a/love/src/components/MainTel/M1M3/M1M3.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3.jsx
@@ -44,15 +44,30 @@ export default class M1M3 extends Component {
 
   static statesIlc = {
     0: {
-      name: 'WARNING',
+      name: 'STANDBY',
       class: styles.warning_summary,
       fill: styles.fill_warning_summary,
     },
     1: {
-      name: 'OK',
+      name: 'DISABLED',
+      class: styles.offline_summary,
+      fill: styles.fill_offline_summary,
+    },
+    2: {
+      name: 'ENABLED',
       class: styles.ok_summary,
       fill: styles.fill_ok_summary,
     },
+    3: {
+      name: 'FIRMWAREUPDATE',
+      class: styles.warning_summary,
+      fill: styles.fill_warning_summary,
+    },
+    4: {
+      name: 'OK',
+      class: styles.alert_summary,
+      fill: styles.fill_alert_summary,
+    }
   };
 
   static statesMotion = {

--- a/love/src/components/MainTel/M1M3/M1M3.module.css
+++ b/love/src/components/MainTel/M1M3/M1M3.module.css
@@ -49,6 +49,7 @@
 .state {
   display: flex;
   margin-right: 1em;
+  align-items: center;
 }
 
 .state :first-child {
@@ -59,8 +60,9 @@
   border-radius: 1rem;
   font-weight: 700;
   text-align: center;
-  width: 8em;
+  /* width: 8em; */
   margin-bottom: 2px;
+  padding: var(--small-padding);
 }
 
 .detailState {
@@ -281,6 +283,14 @@
 
 .fill_warning_summary {
   fill: var(--status-warning-dimmed-color-2);
+}
+
+.fill_offline_summary {
+  fill: var(--status-disabled-dimmed-color-2);
+}
+
+.fill_alert_summary {
+  fill: var(--status-alert-color);
 }
 
 /* detailed state classes */

--- a/love/src/components/MainTel/M1M3/M1M3.module.css
+++ b/love/src/components/MainTel/M1M3/M1M3.module.css
@@ -60,7 +60,6 @@
   border-radius: 1rem;
   font-weight: 700;
   text-align: center;
-  /* width: 8em; */
   margin-bottom: 2px;
   padding: var(--small-padding);
 }


### PR DESCRIPTION
This PR makes some changes to fix an issue with the M1M3 interface. The state mapping  `MTM1M3_logevent_hardpointActuatorState.ilcState` was incorrect. Also we fixed a couple styling issues.