### PR TITLE
Extend CommandPanel component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,12 @@ Version History
 v5.14.1
 -------
 
-* Add CloudMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/436>`_
+* Extend ``CommandPanel`` component `<https://github.com/lsst-ts/LOVE-frontend/pull/437>`_
+* Add ``CloudMap`` component `<https://github.com/lsst-ts/LOVE-frontend/pull/436>`_
 * Bump webpack from 5.74.0 to 5.76.1 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/435>`_
-* Fix styling issues and state mapping on M1M3 component `<https://github.com/lsst-ts/LOVE-frontend/pull/434>`_
+* Fix styling issues and state mapping on ``M1M3`` component `<https://github.com/lsst-ts/LOVE-frontend/pull/434>`_
 * Add repository version history `<https://github.com/lsst-ts/LOVE-frontend/pull/433>`_
-* Fix a state mapping of M1M3 `<https://github.com/lsst-ts/LOVE-frontend/pull/432>`_
+* Fix a state mapping of ``M1M3`` `<https://github.com/lsst-ts/LOVE-frontend/pull/432>`_
 * Fix LOVE Config Files component `<https://github.com/lsst-ts/LOVE-frontend/pull/431>`_
 * Bump vega from 5.22.1 to 5.23.0 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/430>`_
 * Bump vega-functions from 5.13.0 to 5.13.1 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/429>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Version History
 v5.14.1
 -------
 
+* Add CloudMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/436>`_
+* Bump webpack from 5.74.0 to 5.76.1 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/435>`_
 * Fix styling issues and state mapping on M1M3 component `<https://github.com/lsst-ts/LOVE-frontend/pull/434>`_
 * Add repository version history `<https://github.com/lsst-ts/LOVE-frontend/pull/433>`_
 * Fix a state mapping of M1M3 `<https://github.com/lsst-ts/LOVE-frontend/pull/432>`_

--- a/love/src/components/CommandPanel/CommandPanel.container.jsx
+++ b/love/src/components/CommandPanel/CommandPanel.container.jsx
@@ -20,12 +20,6 @@ export const schema = {
       isPrivate: true,
       default: false,
     },
-    // scriptQueueIndex: {
-    //   type: 'number',
-    //   description: 'Salindex of the ScriptQueue to listen events',
-    //   isPrivate: false,
-    //   default: 2,
-    // },
   },
 };
 

--- a/love/src/components/CommandPanel/CommandPanel.container.jsx
+++ b/love/src/components/CommandPanel/CommandPanel.container.jsx
@@ -20,12 +20,12 @@ export const schema = {
       isPrivate: true,
       default: false,
     },
-    scriptQueueIndex: {
-      type: 'number',
-      description: 'Salindex of the ScriptQueue to listen events',
-      isPrivate: false,
-      default: 1,
-    },
+    // scriptQueueIndex: {
+    //   type: 'number',
+    //   description: 'Salindex of the ScriptQueue to listen events',
+    //   isPrivate: false,
+    //   default: 2,
+    // },
   },
 };
 
@@ -34,7 +34,10 @@ const CommandPanelContainer = ({ ...props }) => {
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  const subscriptions = [`event-ScriptQueueState-${ownProps.scriptQueueIndex}-stream`];
+  const subscriptions = [
+    `event-ScriptQueueState-1-stream`,
+    `event-ScriptQueueState-2-stream`,
+  ];
   return {
     subscriptions,
     subscribeToStreams: () => {
@@ -51,10 +54,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
 const mapStateToProps = (state, ownProps) => {
   const commandExecutePermission = getPermCmdExec(state);
-  const queueState = getScriptQueueState(state, ownProps.scriptQueueIndex);
+  const mainQueueState = getScriptQueueState(state, 1);
+  const auxQueueState = getScriptQueueState(state, 2);
   return {
     commandExecutePermission,
-    queueState,
+    auxQueueState,
+    mainQueueState,
   };
 };
 

--- a/love/src/components/CommandPanel/CommandPanel.jsx
+++ b/love/src/components/CommandPanel/CommandPanel.jsx
@@ -1,14 +1,25 @@
 import React, { Component } from 'react';
 // import DomeCloseButton from './DomeCloseButton/DomeCloseButton';
 import StopAllTSCButton from './StopAllTSCButton/StopAllTSCButton';
+import ManagerInterface from 'Utils';
 import styles from './CommandPanel.module.css';
 
 export default class CommandPanel extends Component {
   render() {
+    const { commandExecutePermission, mainQueueState, auxQueueState } = this.props;
     return (
       <div className={styles.container}>
         {/* <DomeCloseButton {...this.props}></DomeCloseButton> */}
-        <StopAllTSCButton {...this.props}></StopAllTSCButton>
+        <StopAllTSCButton
+          title="MTCS Stop All"
+          commandExecutePermission={commandExecutePermission}
+          queueState={mainQueueState}
+          command={() => ManagerInterface.runMTCSCommand('stop_all')}/>
+        <StopAllTSCButton
+          title="ATCS Stop All"
+          commandExecutePermission={commandExecutePermission}
+          queueState={auxQueueState}
+          command={() => ManagerInterface.runATCSCommand('stop_all')}/>
       </div>
     );
   }

--- a/love/src/components/CommandPanel/CommandPanel.jsx
+++ b/love/src/components/CommandPanel/CommandPanel.jsx
@@ -5,6 +5,15 @@ import ManagerInterface from 'Utils';
 import styles from './CommandPanel.module.css';
 
 export default class CommandPanel extends Component {
+
+  componentDidMount() {
+    this.props.subscribeToStreams();
+  }
+
+  componentWillUnmount() {
+    this.props.unsubscribeToStreams();
+  }
+
   render() {
     const { commandExecutePermission, mainQueueState, auxQueueState } = this.props;
     return (

--- a/love/src/components/CommandPanel/StopAllTSCButton/StopAllTSCButton.jsx
+++ b/love/src/components/CommandPanel/StopAllTSCButton/StopAllTSCButton.jsx
@@ -6,23 +6,26 @@ import ManagerInterface from 'Utils';
 export default class StopAllTSCButton extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
   }
 
   callTSCStopAll() {
-    // TODO: Reference command from variable
-    ManagerInterface.runATCSCommand('stop_all');
+    this.props.command();
+  }
+
+  static defaultProps = {
+    title: 'TSC STOP ALL',
   }
 
   render() {
-    const isAvailable = this.props.commandExecutePermission && this.props.queueState.state !== 'Running';
+    const { title, commandExecutePermission, queueState } = this.props;
+    const isAvailable = commandExecutePermission && queueState.state !== 'Running';
     return (
       <div className={styles.buttonWrapper}>
         <button
           className={styles.button}
           title={
             isAvailable
-              ? 'ATCS stop_all() implementation'
+              ? title
               : "Command is not allowed while queue is running either you don't have command execution permissions"
           }
           disabled={!isAvailable}
@@ -35,7 +38,7 @@ export default class StopAllTSCButton extends Component {
               transform="translate(-0.08 -0.62)"
             />
           </svg>
-          <span className={styles.buttonLabel}>TSC STOP ALL</span>
+          <span className={styles.buttonLabel}>{title}</span>
         </button>
       </div>
     );

--- a/love/src/components/CommandPanel/StopAllTSCButton/StopAllTSCButton.jsx
+++ b/love/src/components/CommandPanel/StopAllTSCButton/StopAllTSCButton.jsx
@@ -18,7 +18,6 @@ export default class StopAllTSCButton extends Component {
 
   render() {
     const { title, commandExecutePermission, queueState } = this.props;
-    console.log(title, queueState);
     const isAvailable = commandExecutePermission && queueState.state !== 'Running';
     return (
       <div className={styles.buttonWrapper}>

--- a/love/src/components/CommandPanel/StopAllTSCButton/StopAllTSCButton.jsx
+++ b/love/src/components/CommandPanel/StopAllTSCButton/StopAllTSCButton.jsx
@@ -18,6 +18,7 @@ export default class StopAllTSCButton extends Component {
 
   render() {
     const { title, commandExecutePermission, queueState } = this.props;
+    console.log(title, queueState);
     const isAvailable = commandExecutePermission && queueState.state !== 'Running';
     return (
       <div className={styles.buttonWrapper}>


### PR DESCRIPTION
This PR refactors the `CommandPanel` component in order to provide direct actions for two methods:

- [lsst.ts.observatory.control.auxtel.ATCS.stop_all](https://ts-observatory-control.lsst.io/py-api/lsst.ts.observatory.control.auxtel.ATCS.html#lsst.ts.observatory.control.auxtel.ATCS.stop_all)
- [lsst.ts.observatory.control.maintel.MTCS.stop_all](https://ts-observatory-control.lsst.io/py-api/lsst.ts.observatory.control.maintel.MTCS.html#lsst.ts.observatory.control.maintel.MTCS.stop_all)