### PR TITLE
Extend some OLE features

### DIFF
--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -25,11 +25,15 @@ export const SCRIPT_DOCUMENTATION_BASE_URL = 'https://ts-standardscripts.lsst.io
 
 // URL for external Cloud Map Service
 export const CLOUD_MAP_SERVICE = {
-  url: 'https://www.meteoblue.com/en/weather/maps/widget/-30.245N-70.749E2605_America%2FSantiago?windAnimation=0&gust=0&satellite=0&cloudsAndPrecipitation=0&cloudsAndPrecipitation=1&temperature=0&sunshine=0&extremeForecastIndex=0&geoloc=fixed&tempunit=C&windunit=km%252Fh&lengthunit=metric&zoom=9&autowidth=auto',
-  copyrigth: 'https://www.meteoblue.com/en/weather/maps/-30.245N-70.749E2605_America%2FSantiago?utm_source=weather_widget&utm_medium=linkus&utm_content=map&utm_campaign=Weather%2BWidget',
+  url:
+    'https://www.meteoblue.com/en/weather/maps/widget/-30.245N-70.749E2605_America%2FSantiago?windAnimation=0&gust=0&satellite=0&cloudsAndPrecipitation=0&cloudsAndPrecipitation=1&temperature=0&sunshine=0&extremeForecastIndex=0&geoloc=fixed&tempunit=C&windunit=km%252Fh&lengthunit=metric&zoom=9&autowidth=auto',
+  copyrigth:
+    'https://www.meteoblue.com/en/weather/maps/-30.245N-70.749E2605_America%2FSantiago?utm_source=weather_widget&utm_medium=linkus&utm_content=map&utm_campaign=Weather%2BWidget',
 };
 
 // Moment formats
+export const ISO_STIRNG_DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+export const ISO_STIRNG_DATE_FORMAT = 'YYYY-MM-DD';
 export const ISO_DATE_FORMAT = 'YYYY/MM/DD';
 export const ISO_INTEGER_DATE_FORMAT = 'YYYYMMDD';
 export const TIME_FORMAT = 'HH:mm:ss';
@@ -973,12 +977,12 @@ export const mtMountMirrorCoversStateMap = {
 };
 
 export const stateToStyleMTMountMirrorCoversState = {
-  'UNKNOWN': 'undefined',
-  'RETRACTED': 'ok',
-  'DEPLOYED': 'ok',
-  'RETRACTING': 'warning',
-  'DEPLOYING': 'warning',
-  'LOST': 'alert',
+  UNKNOWN: 'undefined',
+  RETRACTED: 'ok',
+  DEPLOYED: 'ok',
+  RETRACTING: 'warning',
+  DEPLOYING: 'warning',
+  LOST: 'alert',
 };
 
 export const motorBrakeStateMap = {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1,10 +1,8 @@
-
 import html2canvas from 'html2canvas';
 import { DateTime } from 'luxon';
 import { toast } from 'react-toastify';
 import Moment from 'moment';
 import { WEBSOCKET_SIMULATION } from 'Config.js';
-
 
 /* Backwards compatibility of Array.flat */
 if (Array.prototype.flat === undefined) {
@@ -88,11 +86,10 @@ export const sockette = (url, optsPar) => {
   return $;
 };
 
-
 /**
  * LOVE-manager interface
  * It is used to connect to the implemented endpoints
-*/
+ */
 export default class ManagerInterface {
   constructor() {
     this.callback = null;
@@ -317,23 +314,25 @@ export default class ManagerInterface {
 
   static getEFDStatus(url) {
     if (!url) {
-      return new Promise(function(resolve, _) {
-        resolve({label: "EFD Status URL is not present in LOVE Configuration File", style: "invalid"});
+      return new Promise(function (resolve, _) {
+        resolve({ label: 'EFD Status URL is not present in LOVE Configuration File', style: 'invalid' });
       });
     }
-    return fetchWithTimeout(url, {method: 'GET'}).then(result => {
-      if (result.status == 200) {
-        return {label: "EFD Healthy Status Pass", style: "ok"};
-      }
-      if (result.status === 503) {
-        return {label: "EFD Healthy Status Fail", style: "alert"};
-      }
-      result.json().then((resp) => {
-        return {label: "EFD Healthy Status Unknown", style: "alert", response: resp};
+    return fetchWithTimeout(url, { method: 'GET' })
+      .then((result) => {
+        if (result.status == 200) {
+          return { label: 'EFD Healthy Status Pass', style: 'ok' };
+        }
+        if (result.status === 503) {
+          return { label: 'EFD Healthy Status Fail', style: 'alert' };
+        }
+        result.json().then((resp) => {
+          return { label: 'EFD Healthy Status Unknown', style: 'alert', response: resp };
+        });
+      })
+      .catch((err) => {
+        return { label: 'EFD Healthy Status Fail', style: 'alert', error: err };
       });
-    }).catch(err => {
-      return {label: "EFD Healthy Status Fail", style: "alert", error: err};
-    });
   }
 
   // EFD APIs
@@ -661,7 +660,9 @@ export default class ManagerInterface {
     if (token === null) {
       return new Promise((resolve) => resolve(false));
     }
-    const url = `${this.getApiBaseUrl()}ole/exposurelog/exposures?instrument=${instrument}&registry=2&order_by=-obs_id&limit=1500${obsDay ? `&min_day_obs=${obsDay}&max_day_obs=${obsDay+1}` : ''}`;
+    const url = `${this.getApiBaseUrl()}ole/exposurelog/exposures?instrument=${instrument}&registry=2&order_by=-obs_id&limit=1500${
+      obsDay ? `&min_day_obs=${obsDay}&max_day_obs=${obsDay + 1}` : ''
+    }`;
     return fetch(url, {
       method: 'GET',
       headers: ManagerInterface.getHeaders(),
@@ -684,7 +685,9 @@ export default class ManagerInterface {
     if (token === null) {
       return new Promise((resolve) => resolve(false));
     }
-    const url = `${this.getApiBaseUrl()}ole/exposurelog/messages/?order_by=-date_added&limit=1000${obsDay ? `&min_day_obs=${obsDay}&max_day_obs=${obsDay+1}` : ''}`;
+    const url = `${this.getApiBaseUrl()}ole/exposurelog/messages/?order_by=-date_added&limit=1000${
+      obsDay ? `&min_day_obs=${obsDay}&max_day_obs=${obsDay + 1}` : ''
+    }`;
     return fetch(url, {
       method: 'GET',
       headers: ManagerInterface.getHeaders(),
@@ -875,12 +878,14 @@ export default class ManagerInterface {
     });
   }
 
-  static getListMessagesNarrativeLogs() {
+  static getListMessagesNarrativeLogs(from, to) {
     const token = ManagerInterface.getToken();
     if (token === null) {
       return new Promise((resolve) => resolve(false));
     }
-    const url = `${this.getApiBaseUrl()}ole/narrativelog/messages/?order_by=-date_added`;
+    const url = `${this.getApiBaseUrl()}ole/narrativelog/messages/?order_by=-date_added&limit=500${
+      from ? `&min_date_added=${from}` : ''
+    }${to ? `&max_date_added=${to}` : ''}`;
     return fetch(url, {
       method: 'GET',
       headers: ManagerInterface.getHeaders(),
@@ -1037,12 +1042,12 @@ export default class ManagerInterface {
  * @param {object} options - Options to be added to the request
  * @param {number} timeout - Timeout of the request
  */
- function fetchWithTimeout(url, options={}, timeout=2000) {
+function fetchWithTimeout(url, options = {}, timeout = 2000) {
   return Promise.race([
     fetch(url, options),
     new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('timeout')), timeout)
-    })
+      setTimeout(() => reject(new Error('timeout')), timeout);
+    }),
   ]);
 }
 
@@ -1112,7 +1117,7 @@ export const getNotificationMessage = (salCommand) => {
     cmd_mute: 'muted',
     cmd_unmute: 'unmuted',
   };
-  
+
   const watcherErrorCmds = {
     cmd_acknowledge: 'acknowledging',
     cmd_mute: 'muting',
@@ -1236,7 +1241,6 @@ export const getStringRegExp = (str) => {
     return new RegExp('');
   }
 };
-
 
 /**
  * Function to take screenshots using html2canvas
@@ -1425,7 +1429,7 @@ export function getUserHost(user, host) {
 export function closestEquivalentAngle(from, to) {
   const delta = ((((to - from) % 360) + 540) % 360) - 180;
   return from + delta;
-};
+}
 
 /**
  * Function used to open new tabs from a url.

--- a/love/src/components/OLE/Exposure/Exposure.jsx
+++ b/love/src/components/OLE/Exposure/Exposure.jsx
@@ -377,7 +377,7 @@ export default class Exposure extends Component {
             className={styles.select}
           />
           <div className={styles.divExportBtn}>
-            <CSVLink data={csvData} headers={csvHeaders} filename="exposureLogMessages.csv">
+            <CSVLink data={csvData} headers={csvHeaders} filename={`exposures_obsday_${selectedDayExposure.format(ISO_INTEGER_DATE_FORMAT)}.csv`}>
               <Hoverable top={true} left={true} center={true} inside={true}>
                 <span className={styles.infoIcon}>
                   <DownloadIcon className={styles.iconCSV} />

--- a/love/src/components/OLE/Exposure/Exposure.jsx
+++ b/love/src/components/OLE/Exposure/Exposure.jsx
@@ -311,10 +311,15 @@ export default class Exposure extends Component {
     // Obtain headers to create csv report
     let csvHeaders = null;
     let csvData =  "There aren't exposures created for the current search...";
+    let csvTitle = 'exposure.csv'
     if (filteredData.length > 0) {
       const logExampleKeys = Object.keys(filteredData[0] ?? {});
       csvHeaders = logExampleKeys.map((key) => ({ label: key, key }));
       csvData = filteredData;
+    }
+
+    if (selectedDayExposure) {
+      csvTitle = `exposures_obsday_${Moment(selectedDayExposure).format(ISO_INTEGER_DATE_FORMAT)}.csv`;
     }
 
     return modeView && !modeAdd ? (
@@ -377,7 +382,7 @@ export default class Exposure extends Component {
             className={styles.select}
           />
           <div className={styles.divExportBtn}>
-            <CSVLink data={csvData} headers={csvHeaders} filename={`exposures_obsday_${selectedDayExposure.format(ISO_INTEGER_DATE_FORMAT)}.csv`}>
+            <CSVLink data={csvData} headers={csvHeaders} filename={csvTitle}>
               <Hoverable top={true} left={true} center={true} inside={true}>
                 <span className={styles.infoIcon}>
                   <DownloadIcon className={styles.iconCSV} />

--- a/love/src/components/OLE/OLE.jsx
+++ b/love/src/components/OLE/OLE.jsx
@@ -24,16 +24,15 @@ export default class OLE extends Component {
       selectedTab: props.tabs[0].value,
       clickNewLog: false,
       // Non Exposure filters
+      selectedDayNarrative: Moment(Date.now() + 37 * 1000),
       selectedCommentType: { value: 'all', label: 'All comment types' },
       selectedSystem: 'all',
       selectedObsTimeLoss: false,
-      selectedDateStartNonExposure: new Date() - 24 * 60 * 60 * 1000,
-      selectedDateEndNonExposure: new Date(Date.now() + 37 * 1000), // Add 37 seconds to comply with TAI
       // Exposure filters
-      selectedInstrument: null,
       instruments: [],
+      selectedInstrument: null,
+      selectedDayExposure: Moment(),
       selectedExposureType: 'all',
-      selectedDayExposure: new Date(),
     };
   }
 
@@ -47,6 +46,11 @@ export default class OLE extends Component {
 
   componentWillUnmount() {
     this.props.unsubscribeToStreams();
+  }
+
+  changeDayNarrative(day) {
+    const dayObs = Moment(day).format('YYYYMMDD');
+    this.setState({ selectedDayNarrative: day });
   }
 
   changeCommentTypeSelect(value) {
@@ -72,18 +76,6 @@ export default class OLE extends Component {
   changeDayExposure(day) {
     const dayObs = Moment(day).format('YYYYMMDD');
     this.setState({ selectedDayExposure: day });
-  }
-
-  changeDayOrRangeSelect(value) {
-    this.setState({ selectedDayOrRange: value });
-  }
-
-  handleDateTimeRangeNonExposure(date, type) {
-    if (type === 'start') {
-      this.setState({ selectedDateStartNonExposure: date });
-    } else if (type === 'end') {
-      this.setState({ selectedDateEndNonExposure: date });
-    }
   }
 
   changeTab(tab) {
@@ -131,9 +123,8 @@ export default class OLE extends Component {
         return (
           <NonExposure
             props={this.props}
-            selectedDateStart={this.state.selectedDateStartNonExposure}
-            selectedDateEnd={this.state.selectedDateEndNonExposure}
-            handleDateTimeRange={(date, type) => this.handleDateTimeRangeNonExposure(date, type)}
+            selectedDayNarrative={this.state.selectedDayNarrative}
+            changeDayNarrative={(day) => this.changeDayNarrative(day)}
             selectedCommentType={this.state.selectedCommentType}
             changeCommentTypeSelect={(value) => this.changeCommentTypeSelect(value)}
             selectedSystem={this.state.selectedSystem}


### PR DESCRIPTION
This PR makes some improvements to the OLE components:

- Now the `ExposureAdd` component can be filtered by day of observation to get respective exposures.
- Now the `NonExposure` component can be filtered by day of creation go get the respective narrative logs.
- Adjusted naming convention for csv reports.