### PR TITLE
Fix LATISS and ATCamera state mappings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.17.2
+--------
+
+* Fix LATISS and ATCamera state mappingse `<https://github.com/lsst-ts/LOVE-frontend/pull/445>`_
+
 v5.17.1
 --------
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -447,6 +447,40 @@ export const defaultCSCList = [
   { name: 'WeatherStation', salindex: 1 },
 ];
 
+// ATCamera status to styles mappings
+export const cameraStates = {
+  raftsDetailedState: {
+    1: 'NEEDS_CLEAR',
+    2: 'CLEARING',
+    3: 'INTEGRATING',
+    4: 'READING_OUT',
+    5: 'QUIESCENT',
+  },
+  imageReadinessDetailedState: {
+    1: 'READY',
+    2: 'NOT_READY',
+    3: 'GETTING_READY',
+  },
+  calibrationDetailedState: {
+    1: 'DISABLED',
+    2: 'ENABLED',
+    3: 'INTEGRATING',
+  },
+  shutterDetailedState: {
+    1: 'CLOSED',
+    2: 'OPEN',
+    3: 'CLOSING',
+    4: 'OPENING',
+  },
+};
+
+export const imageStates = {
+  INTEGRATING: 'INTEGRATING',
+  READING_OUT: 'READING_OUT',
+  END_READOUT: 'END_READOUT',
+  END_TELEMETRY: 'END_TELEMETRY',
+};
+
 export const getCameraStatusStyle = (status) => {
   if (!status) return '';
   if (status.toLowerCase() === 'integrating') return 'running';

--- a/love/src/Constants.js
+++ b/love/src/Constants.js
@@ -4,36 +4,3 @@ export const AUTHLIST_REQUEST_PENDING = 'Pending';
 export const AUTHLIST_REQUEST_ACCEPTED = 'Authorized';
 export const AUTHLIST_REQUEST_DENIED = 'Denied';
 export const LOG_LEVELS = { debug: 10, info: 20, warning: 30, error: 40 };
-
-export const cameraStates = {
-  raftsDetailedState: {
-    0: 'NEEDS_CLEAR',
-    1: 'CLEARING',
-    2: 'INTEGRATING',
-    3: 'READING_OUT',
-    4: 'QUIESCENT',
-  },
-  imageReadinessDetailedState: {
-    0: 'READY',
-    1: 'NOT_READY',
-    2: 'GETTING_READY',
-  },
-  calibrationDetailedState: {
-    0: 'DISABLED',
-    1: 'ENABLED',
-    2: 'INTEGRATING',
-  },
-  shutterDetailedState: {
-    0: 'CLOSED',
-    1: 'OPEN',
-    2: 'CLOSING',
-    3: 'OPENING',
-  },
-};
-
-export const imageStates = {
-  INTEGRATING: 'INTEGRATING',
-  READING_OUT: 'READING_OUT',
-  END_READOUT: 'END_READOUT',
-  END_TELEMETRY: 'END_TELEMETRY',
-};

--- a/love/src/components/AuxTel/Camera/Camera.jsx
+++ b/love/src/components/AuxTel/Camera/Camera.jsx
@@ -66,6 +66,11 @@ export default class Camera extends Component {
   };
 
   render() {
+    const imageIds = Object.keys(this.props.imageSequence?.images ?? {});
+    const orederedImages = imageIds.sort((a, b) => {
+      return this.props.imageSequence.images[b].timestamp - this.props.imageSequence.images[a].timestamp;
+    });
+
     return (
       <div className={styles.cameraContainer}>
         <div className={styles.statesContainer}>
@@ -107,8 +112,8 @@ export default class Camera extends Component {
                 </tr>
               </thead>
               <tbody>
-                {this.props.imageSequence.images &&
-                  Object.keys(this.props.imageSequence.images).map((imageName) => {
+                {orederedImages &&
+                  orederedImages.map((imageName) => {
                     const image = this.props.imageSequence.images[imageName];
                     const imageKey = `${this.props.imageSequence.name}-${imageName}`;
                     const isIntegrating = image.state === 'INTEGRATING';

--- a/love/src/redux/actions/camera.js
+++ b/love/src/redux/actions/camera.js
@@ -1,5 +1,5 @@
 import { RECEIVE_IMAGE_SEQUENCE_DATA, RECEIVE_CAMERA_STATE_DATA, RECEIVE_READOUT_DATA } from './actionTypes';
-import { imageStates } from '../../Constants';
+import { imageStates } from 'Config';
 
 export const receiveImageSequenceData = (data) => {
   let imageState;

--- a/love/src/redux/reducers/camera.js
+++ b/love/src/redux/reducers/camera.js
@@ -1,5 +1,5 @@
 import { RECEIVE_IMAGE_SEQUENCE_DATA, RECEIVE_CAMERA_STATE_DATA, RECEIVE_READOUT_DATA } from '../actions/actionTypes';
-import { cameraStates } from '../../Constants';
+import { cameraStates } from 'Config';
 
 const initialState = {
   raftsDetailedState: 'UNKNOWN',

--- a/love/src/redux/selectors.test.js
+++ b/love/src/redux/selectors.test.js
@@ -13,7 +13,7 @@ import {
 import rootReducer from './reducers';
 import { doReceiveToken } from './actions/auth';
 import { addGroup } from './actions/ws';
-import { cameraStates, imageStates } from '../Constants';
+import { cameraStates, imageStates } from 'Config';
 
 let store;
 let server;


### PR DESCRIPTION
Tihs PR makes some adjustments to the status mappings of the `ATCamera`. Deprecated values were changed by the new ones. Also the exposures list was adjusted so it shows most recent images first.