### PR TITLE
Extend thumbnails query

### DIFF
--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -101,7 +101,7 @@ export default class ManagerInterface {
   }
 
   static getMediaBaseUrl() {
-    return `http://${window.location.host}/manager`;
+    return `http://${window.location.host}/manager/media/`;
   }
 
   static getApiBaseUrl() {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -101,7 +101,7 @@ export default class ManagerInterface {
   }
 
   static getMediaBaseUrl() {
-    return `http://${window.location.host}/manager/media/`;
+    return `http://${window.location.host}/manager/`;
   }
 
   static getApiBaseUrl() {

--- a/love/src/components/UIF/ViewsIndex/ViewsIndex.jsx
+++ b/love/src/components/UIF/ViewsIndex/ViewsIndex.jsx
@@ -102,7 +102,16 @@ class ViewsIndex extends Component {
           {this.props.views.length > 0 &&
             this.props.views.map((view, index) => {
               let viewName = view.name.replace(/[a-z\s]/g, '').substring(0, 6);
-              let imgURL = view.thumbnail ? `${ManagerInterface.getMediaBaseUrl()}${view.thumbnail}` : '';
+
+              let imgURL = '';
+              if (view.thumbnail) {
+                if (view.thumbnail.startsWith('http')) {
+                  imgURL = view.thumbnail;
+                } else {
+                  imgURL = `${ManagerInterface.getMediaBaseUrl()}${view.thumbnail}`;
+                }
+              }
+
               if (viewName === '') viewName = view.name.substring(0, 3).toUpperCase();
               return (
                 (this.state.filter === '' || new RegExp(this.state.filter, 'i').test(view.name)) && (


### PR DESCRIPTION
This PR extends the querying of the LOVE views thumbnails in order to comply with the new Remote Storage feature (see https://github.com/lsst-ts/LOVE-manager/pull/184 & https://github.com/lsst-ts/LOVE-commander/pull/56).