### PR TITLE
Fix initial data to avoid errors after creating 1 narrative log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.20.0
 --------
 
+* Fix initial data to avoid errors after creating 1 narrative log `<https://github.com/lsst-ts/LOVE-frontend/pull/456>`_
 * Extend thumbnails query `<https://github.com/lsst-ts/LOVE-frontend/pull/455>`_
 * Refactor Watcher alarms handling `<https://github.com/lsst-ts/LOVE-frontend/pull/454>`_
 

--- a/love/src/components/GeneralPurpose/DateTimeRange/DateTimeRange.jsx
+++ b/love/src/components/GeneralPurpose/DateTimeRange/DateTimeRange.jsx
@@ -14,7 +14,7 @@ const DateTimeRange = ({
   label = '',
   onChange = () => {},
 }) => {
-  const [dateStart, setDateStart] = useState(startDate ?? new Date(Date.now() - 24 * 60 * 60 * 1000));
+  const [dateStart, setDateStart] = useState(startDate ?? new Date(Date.now() - 24 * 60 * 60 * 1000 + 37 * 1000)); // Add 37 seconds to comply with TAI
   const [dateEnd, setDateEnd] = useState(endDate ?? new Date(Date.now() + 37 * 1000)); // Add 37 seconds to comply with TAI
 
   // Effect used to update startDate and endDate
@@ -66,15 +66,9 @@ DateTimeRange.propTypes = {
   /** Classname of the component */
   className: PropTypes.string,
   /** Date for the datetime range start */
-  startDate: PropTypes.oneOfType([
-    PropTypes.instanceOf(Date),
-    PropTypes.instanceOf(Moment),
-  ]),
+  startDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.instanceOf(Moment)]),
   /** Date for the datetime range end */
-  endtDate: PropTypes.oneOfType([
-    PropTypes.instanceOf(Date),
-    PropTypes.instanceOf(Moment),
-  ]),
+  endtDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.instanceOf(Moment)]),
   /** Properties to add to the start DateTime component */
   startDateProps: PropTypes.object,
   /** Properties to add to the end DateTime component */
@@ -86,11 +80,13 @@ DateTimeRange.propTypes = {
 };
 
 const checkChangeProps = (prevProps, nextProps) => {
-  return prevProps.className === nextProps.className
-    && prevProps.startDate === nextProps.startDate
-    && prevProps.endDate === nextProps.endDate
-    && lodash.isEqual(prevProps.startDateProps, nextProps.startDateProps)
-    && lodash.isEqual(prevProps.endDateProps, nextProps.endDateProps)
-    && prevProps.label === nextProps.label;
+  return (
+    prevProps.className === nextProps.className &&
+    prevProps.startDate === nextProps.startDate &&
+    prevProps.endDate === nextProps.endDate &&
+    lodash.isEqual(prevProps.startDateProps, nextProps.startDateProps) &&
+    lodash.isEqual(prevProps.endDateProps, nextProps.endDateProps) &&
+    prevProps.label === nextProps.label
+  );
 };
 export default memo(DateTimeRange, checkChangeProps);

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -32,8 +32,8 @@ export default class NonExposureEdit extends Component {
     logEdit: {
       id: undefined,
       level: 0,
-      date_begin: undefined,
-      date_end: undefined,
+      date_begin: Moment().subtract(1, 'day'),
+      date_end: Moment(),
       systems: [],
       subsystems: [],
       cscs: [],
@@ -94,9 +94,11 @@ export default class NonExposureEdit extends Component {
   }
 
   cleanForm() {
+    // Reset multiselects values
     this.multiselectRefs.systems.current.resetSelectedValues();
     this.multiselectRefs.subsystems.current.resetSelectedValues();
     this.multiselectRefs.cscs.current.resetSelectedValues();
+
     this.setState({ logEdit: NonExposureEdit.defaultProps.logEdit });
   }
 
@@ -186,20 +188,25 @@ export default class NonExposureEdit extends Component {
     }
   }
 
+  handleTimeLost() {
+    const { date_begin, date_end } = this.state.logEdit;
+    const start = Moment(date_begin);
+    const end = Moment(date_end);
+    const duration_hr = end.diff(start, 'hours', true);
+    this.setState((prevState) => ({
+      logEdit: {
+        ...prevState.logEdit,
+        time_lost: duration_hr.toFixed(2),
+      },
+    }));
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if (
       prevState.logEdit?.date_begin !== this.state.logEdit?.date_begin ||
       prevState.logEdit?.date_end !== this.state.logEdit?.date_end
     ) {
-      const start = Moment(this.state.logEdit.date_begin);
-      const end = Moment(this.state.logEdit.date_end);
-      const duration_hr = end.diff(start, 'hours', true);
-      this.setState((prevState) => ({
-        logEdit: {
-          ...prevState.logEdit,
-          time_lost: duration_hr.toFixed(2),
-        },
-      }));
+      this.handleTimeLost();
     }
   }
 


### PR DESCRIPTION
This PR fix an error on the `CreateOLE` component: after creating 1 narrative log, if the user tries to generate a new one the UI doesn't allow to continue. Initial data was adjusted to avoid this error. Also `DateTimeRange` component extended to comply with TAI time.