### PR TITLE
Fix scrolling behavior when content overflows on CSCGroup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.20.0
 --------
 
+* Fix scrolling behavior when content overflows on CSCGroup `<https://github.com/lsst-ts/LOVE-frontend/pull/457>`_
 * Fix initial data to avoid errors after creating 1 narrative log `<https://github.com/lsst-ts/LOVE-frontend/pull/456>`_
 * Extend thumbnails query `<https://github.com/lsst-ts/LOVE-frontend/pull/455>`_
 * Refactor Watcher alarms handling `<https://github.com/lsst-ts/LOVE-frontend/pull/454>`_

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
@@ -1,11 +1,11 @@
 .CSCGroupContainer {
+  overflow-y: scroll;
   display: flex;
   width: 100%;
   flex-grow: 1;
   flex-direction: column;
   padding: 1em 0em;
   background: var(--second-secondary-background-color);
-  overflow: auto;
 }
 
 .CSCExpandedContainer {
@@ -49,7 +49,7 @@
   align-items: center;
 }
 
-.stateContainer>div {
+.stateContainer > div {
   padding-right: 0.5em;
 }
 
@@ -69,11 +69,12 @@
   width: 1.6em;
 }
 
-.heartbeatIconWrapper>svg {
+.heartbeatIconWrapper > svg {
   vertical-align: top;
 }
 
-.logContainerWrapper {}
+.logContainerWrapper {
+}
 
 .logContainerTopBar {
   display: flex;
@@ -148,9 +149,11 @@
   user-select: none;
 }
 
-.errorReport {}
+.errorReport {
+}
 
-.errorTraceback {}
+.errorTraceback {
+}
 
 .filtersContainer {
   display: flex;

--- a/love/src/components/CSCSummary/CSCRealm/CSCRealm.module.css
+++ b/love/src/components/CSCSummary/CSCRealm/CSCRealm.module.css
@@ -8,6 +8,7 @@
 }
 
 .CSCGroupContainer {
+  overflow: auto;
   display: flex;
   flex-grow: 1;
   padding: 1em;


### PR DESCRIPTION
This PR fixes an issue when the content of the `CSCGroup` component overflowed its container. Before the content was cut off, now an internal scroll bar was added to allow content scrolling if it is cut off.