### PR TITLE
Fix error with not defined method on MTM2 component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.20.1
 --------
 
+* Fix error with not defined method on MTM2 component `<https://github.com/lsst-ts/LOVE-frontend/pull/462>`_
 * UI/UX improvements for MTM1M3 component `<https://github.com/lsst-ts/LOVE-frontend/pull/461>`_
 * Adjust GIS to comply with the latest GIS_logevent_rawStatus format `<https://github.com/lsst-ts/LOVE-frontend/pull/460>`_
 

--- a/love/src/components/MainTel/M2/Actuators/Inclinometer/Inclinometer.jsx
+++ b/love/src/components/MainTel/M2/Actuators/Inclinometer/Inclinometer.jsx
@@ -57,7 +57,7 @@ export default class Inclinometer extends Component {
         </svg>
         <div className={styles.inclinometerValues}>
           <span>Inclination</span>
-          <span className={styles.value}>{fixedFloat(zenithAngleMeasured, 2)}°</span>
+          <span className={styles.value}>{defaultNumberFormatter(zenithAngleMeasured, 2)}°</span>
           <span>Source</span>
           <span className={styles.value}>{inclinationTelemetrySourceValue}</span>
         </div>


### PR DESCRIPTION
This PR fixes an error on the `MTM2` component due to a not defined method. This bug was introduced after a big rebase we did.