### PR TITLE
Add error fedback to the user when a date input is not valid for OLE component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.20.2
+--------
+
+* Add error fedback to the user when a date input is not valid for OLE component `<https://github.com/lsst-ts/LOVE-frontend/pull/465>`_
+
 v5.20.1
 --------
 

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -371,3 +371,8 @@ th.tableHead {
 .divExportBtn {
   margin-left: auto;
 }
+
+.inputError {
+  margin-top: var(--small-padding);
+  color: var(--status-alert-color);
+}

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -77,6 +77,7 @@ export default class NonExposureEdit extends Component {
       confirmationModalShown: false,
       confirmationModalText: '',
       savingLog: false,
+      datesAreValid: true,
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -206,13 +207,24 @@ export default class NonExposureEdit extends Component {
       prevState.logEdit?.date_begin !== this.state.logEdit?.date_begin ||
       prevState.logEdit?.date_end !== this.state.logEdit?.date_end
     ) {
-      this.handleTimeLost();
+      try {
+        this.state.logEdit.date_begin.toISOString();
+        this.state.logEdit.date_end.toISOString();
+        this.setState({
+          datesAreValid: true,
+        });
+        this.handleTimeLost();
+      } catch (error) {
+        this.setState({
+          datesAreValid: false,
+        });
+      }
     }
   }
 
   render() {
     const { back, isLogCreate, isMenu } = this.props;
-    const { confirmationModalShown, confirmationModalText } = this.state;
+    const { confirmationModalShown, confirmationModalText, datesAreValid } = this.state;
 
     const view = this.props.view ?? NonExposureEdit.defaultProps.view;
     const systemOptions = LSST_SYSTEMS;
@@ -380,6 +392,9 @@ export default class NonExposureEdit extends Component {
                         className={styles.dateTimeRangeStyle}
                         onChange={(date, type) => this.handleTimeOfIncident(date, type)}
                       />
+                      {!datesAreValid && (
+                        <div className={styles.inputError}>Error: dates must be input in valid ISO format</div>
+                      )}
                     </span>
                     <span className={styles.label}>Obs. Time Loss (hours)</span>
                     <span className={styles.value}>
@@ -415,6 +430,9 @@ export default class NonExposureEdit extends Component {
                           className={styles.dateTimeRangeStyle}
                           onChange={(date, type) => this.handleTimeOfIncident(date, type)}
                         />
+                        {!datesAreValid && (
+                          <div className={styles.inputError}>Error: dates must be input in valid ISO format</div>
+                        )}
                       </span>
                       <span className={styles.label}>Obs. Time Loss (hours)</span>
                       <span className={styles.value}>
@@ -528,7 +546,7 @@ export default class NonExposureEdit extends Component {
                 ) : (
                   <></>
                 )}
-                <Button type="submit">
+                <Button disabled={!datesAreValid} type="submit">
                   <span className={styles.title}>Upload Log</span>
                 </Button>
               </span>


### PR DESCRIPTION
This PR adds extends the `NonExposureEdit` component in order to avoid errors when an user inputs an invalid date. Also a feedback error message was added so the user knows when this situation happens.