### PR TITLE
Add throtle to alarm notification checking to avoid annoying sound alarms

### DIFF
--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -166,6 +166,11 @@ export default class AlarmAudio extends Component {
       this.props.alarms &&
       (!isEqual(this.props.alarms, prevProps.alarms) || this.state.minSeveritySound !== prevState.minSeveritySound)
     ) {
+      const difference = this.props.alarms.filter((x) => prevProps.alarms.findIndex((y) => x.name === y.name) === -1);
+      // Don't play sound for new OK alarm
+      if (difference.length === 1 && difference[0].severity.value === 1) {
+        return;
+      }
       this.throtCheckAndNotifyAlarms(this.props.alarms, prevProps.alarms);
     }
   };

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Howl } from 'howler';
 import isEqual from 'lodash/isEqual';
+import { throttle } from 'lodash';
 
 import { severityEnum } from '../../../Config';
 import { isAcknowledged, isMuted, isMaxCritical, isCritical } from '../AlarmUtils';
@@ -165,7 +166,7 @@ export default class AlarmAudio extends Component {
       this.props.alarms &&
       (!isEqual(this.props.alarms, prevProps.alarms) || this.state.minSeveritySound !== prevState.minSeveritySound)
     ) {
-      this.checkAndNotifyAlarms(this.props.alarms, prevProps.alarms);
+      this.throtCheckAndNotifyAlarms(this.props.alarms, prevProps.alarms);
     }
   };
 
@@ -233,6 +234,11 @@ export default class AlarmAudio extends Component {
       this.playSound(newHighestAlarm.severity, newHighestAlarm.type);
     }
   };
+
+  /**
+   * Throtle checkAndNotifyAlarms
+   */
+  throtCheckAndNotifyAlarms = throttle(this.checkAndNotifyAlarms, 3000);
 
   playSound = (severity, type) => {
     if (severity < this.state.minSeveritySound) {


### PR DESCRIPTION
This PR makes a small change to add throttling to the `checkAndNotifyAlarms` method of the `AlarmAudio` component. This way will avoid annoying sounding alarms when receiving several alarms concurrently.