### PR TITLE
Move Authlist components to Observatory index

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 ===============
 Version History
 ===============
+v5.22.1
+--------
+
+* Move Authlist components to Observatory index `<https://github.com/lsst-ts/LOVE-frontend/pull/480>`_
 
 v5.22.0
 --------

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.22.0",
+  "version": "5.22.1",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/UIF/ComponentIndex.jsx
+++ b/love/src/components/UIF/ComponentIndex.jsx
@@ -149,6 +149,26 @@ export const observatoryIndex = {
       },
     },
   },
+  SummaryAuthList: {
+    component: require('../AuthList/SummaryAuthList/SummaryAuthList.container').default,
+    schema: {
+      ...require('../AuthList/SummaryAuthList/SummaryAuthList.container').schema,
+      props: {
+        ...defaultSchemaProps,
+        ...require('../AuthList/SummaryAuthList/SummaryAuthList.container').schema.props,
+      },
+    },
+  },
+  AdminAuthList: {
+    component: require('../AuthList/AdminAuthList/AdminAuthList.container').default,
+    schema: {
+      ...require('../AuthList/AdminAuthList/AdminAuthList.container').schema,
+      props: {
+        ...defaultSchemaProps,
+        ...require('../AuthList/AdminAuthList/AdminAuthList.container').schema.props,
+      },
+    },
+  },
   Scheduler: {
     component: require('../Scheduler/Scheduler.container').default,
     schema: {
@@ -514,29 +534,6 @@ const environmentIndex = {
   },
 };
 
-export const authlistIndex = {
-  SummaryAuthList: {
-    component: require('../AuthList/SummaryAuthList/SummaryAuthList.container').default,
-    schema: {
-      ...require('../AuthList/SummaryAuthList/SummaryAuthList.container').schema,
-      props: {
-        ...defaultSchemaProps,
-        ...require('../AuthList/SummaryAuthList/SummaryAuthList.container').schema.props,
-      },
-    },
-  },
-  AdminAuthList: {
-    component: require('../AuthList/AdminAuthList/AdminAuthList.container').default,
-    schema: {
-      ...require('../AuthList/AdminAuthList/AdminAuthList.container').schema,
-      props: {
-        ...defaultSchemaProps,
-        ...require('../AuthList/AdminAuthList/AdminAuthList.container').schema.props,
-      },
-    },
-  },
-};
-
 export const utilitiesIndex = {
   LabeledStatusText: {
     component: require('../GeneralPurpose/LabeledStatusText/LabeledStatusText.container').default,
@@ -671,10 +668,6 @@ export const indexes = [
     index: environmentIndex,
   },
   {
-    name: 'Authlist',
-    index: authlistIndex,
-  },
-  {
     name: 'Utilities',
     index: utilitiesIndex,
   },
@@ -689,7 +682,6 @@ export default {
   ...auxtelIndex,
   ...mainIndex,
   ...environmentIndex,
-  ...authlistIndex,
   ...utilitiesIndex,
   ...internalIndex,
 };


### PR DESCRIPTION
This PR moves Authlist  components to the "Observatory" category.