### PR TITLE
Extend getEFDLogs method to specify the timestamps scale

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ===============
 Version History
 ===============
+
+v5.23.1
+--------
+
+* Extend getEFDLogs method to specify the timestamps scale `<https://github.com/lsst-ts/LOVE-frontend/pull/484>`_
+
+
 v5.23.0
 --------
 

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -424,7 +424,7 @@ export default class ManagerInterface {
     });
   }
 
-  static getEFDLogs(start_date, end_date, cscs, efd_instance) {
+  static getEFDLogs(start_date, end_date, cscs, efd_instance, scale = 'utc') {
     const token = ManagerInterface.getToken();
     if (token === null) {
       return new Promise((resolve) => resolve(false));
@@ -438,6 +438,8 @@ export default class ManagerInterface {
         end_date,
         cscs,
         efd_instance,
+        /* If using timestamps from SAL topics the scale must be "tai", otherwise "utc" */
+        scale,
       }),
     }).then((response) => {
       if (response.status >= 500) {

--- a/love/src/components/ScriptQueue/Scripts/FinishedScript/FinishedScript.jsx
+++ b/love/src/components/ScriptQueue/Scripts/FinishedScript/FinishedScript.jsx
@@ -85,7 +85,7 @@ export default class FinishedScript extends PureComponent {
     };
     const startDateIso = new Date(start * 1000).toISOString();
     const endDateIso = new Date(end * 1000).toISOString();
-    ManagerInterface.getEFDLogs(startDateIso, endDateIso, cscs, efdInstance).then((res) => {
+    ManagerInterface.getEFDLogs(startDateIso, endDateIso, cscs, efdInstance, 'tai').then((res) => {
       if (!res) return;
       this.setState({
         logs: res[`Script-${scriptIndex}-logevent_logMessage`].map(parseToSALFormat),


### PR DESCRIPTION
This PR extends the `ManagerInterface.getEFDLogs` method in orther to be able to specify the tiemstamp scale to be used. When using timestamps retrieved from SAL topics it is necessary to make a transformation. This extensions allows that information to be sent to the LOVE-commander in order to use the correct scale: https://github.com/lsst-ts/LOVE-commander/pull/58.