### PR TITLE
Fix generic camera image generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.24.3
+--------
+
+* Fix generic camera image generation `<https://github.com/lsst-ts/LOVE-frontend/pull/492>`_
+
 v5.24.2
 --------
 

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.24.1",
+  "version": "5.24.3",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/GenericCamera/CameraUtils.js
+++ b/love/src/components/GenericCamera/CameraUtils.js
@@ -27,7 +27,8 @@ export const getHeaderInfo = (arrayBuffer) => {
   // const encodedBuffer =  encoder.encode(buffer.join(''));
   // const encodedBuffer =  encoder.encode(buffer);
   // 10 is for the \r\n chars
-  const offset = 10 + START.length + widthString.length + heightString.length + lengthString.length + isJPEGString.length;
+  const offset =
+    10 + START.length + widthString.length + heightString.length + lengthString.length + isJPEGString.length;
   const length = parseInt(lengthString, 10);
   const encodedBuffer = new Uint8Array(arrayBuffer.slice(offset, offset + length));
   // 7 is the \r\n[END] size
@@ -60,8 +61,6 @@ export const draw = (array, canvas) => {
   ctx.fillStyle = 'white';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-  // const data = new Uint8ClampedArray([...array].flatMap(v => [v,v,v, 255]));
-  // const imageData = new ImageData(data, 1024, 1024);
   const imageData = ctx.getImageData(0, 0, canvasWidth, canvasHeight);
   const pixels = imageData.data;
 
@@ -69,7 +68,7 @@ export const draw = (array, canvas) => {
     pixels[index * 4] = val;
     pixels[index * 4 + 1] = val;
     pixels[index * 4 + 2] = val;
-    pixels[index * 4 + 3] = val;
+    pixels[index * 4 + 3] = 255;
   });
 
   ctx.putImageData(imageData, 0, 0);

--- a/love/src/components/GenericCamera/GenericCameraControls.jsx
+++ b/love/src/components/GenericCamera/GenericCameraControls.jsx
@@ -186,16 +186,6 @@ export default function GenericCameraControls({
     //
   }, [imageWidth, imageHeight, containerWidth, containerHeight, error, initialLoading, canvasRef]);
 
-  // if (error !== null) {
-  //   return (
-  //     <div className={styles.errorContainer}>
-  //       <p>Fetching stream from {feedUrl}, please wait.</p>
-  //       <p>{`ERROR: ${error.message}`}</p>
-  //       <span>Retrying {`(${retryCount})`} </span>
-  //     </div>
-  //   );
-  // }
-
   const imageAspectRatio = imageWidth / imageHeight;
 
   return (
@@ -217,32 +207,41 @@ export default function GenericCameraControls({
           {runLiveView ? <p>Fetching stream from {feedUrl}, please wait.</p> : <p>Live view not started</p>}
         </div>
       ) : (
-        <div className={styles.cameraContainer}>
-          {healpixOverlays.map((overlay, index) => {
-            return (
-              overlay.display && (
-                <HealpixOverlay
-                  key={index}
+        <>
+          {error ? (
+            <div className={syles.errorContainer}>
+              <p>{`ERROR: ${error.message}`}</p>
+              <span>Retrying {`(${retryCount})`} </span>
+            </div>
+          ) : (
+            <div className={styles.cameraContainer}>
+              {healpixOverlays.map((overlay, index) => {
+                return (
+                  overlay.display && (
+                    <HealpixOverlay
+                      key={index}
+                      width={Math.min(containerWidth, imageAspectRatio * containerHeight)}
+                      height={Math.min(containerHeight, (1 / imageAspectRatio) * containerWidth)}
+                      selectedCell={selectedCell}
+                      {...overlay}
+                      onLayerClick={onLayerClick}
+                    ></HealpixOverlay>
+                  )
+                );
+              })}
+              {targetOverlay?.data?.length > 0 && targetOverlay?.display && (
+                <TargetLayer
                   width={Math.min(containerWidth, imageAspectRatio * containerHeight)}
                   height={Math.min(containerHeight, (1 / imageAspectRatio) * containerWidth)}
-                  selectedCell={selectedCell}
-                  {...overlay}
                   onLayerClick={onLayerClick}
-                ></HealpixOverlay>
-              )
-            );
-          })}
-          {targetOverlay?.data?.length > 0 && targetOverlay?.display && (
-            <TargetLayer
-              width={Math.min(containerWidth, imageAspectRatio * containerHeight)}
-              height={Math.min(containerHeight, (1 / imageAspectRatio) * containerWidth)}
-              onLayerClick={onLayerClick}
-              selectedCell={selectedCell}
-              {...targetOverlay}
-            ></TargetLayer>
+                  selectedCell={selectedCell}
+                  {...targetOverlay}
+                ></TargetLayer>
+              )}
+              <canvas ref={onCanvasRefChange}></canvas>
+            </div>
           )}
-          <canvas ref={onCanvasRefChange}></canvas>
-        </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
This PR makes a small change to the pixel generation of the image stream from the generic camera services. The current implementation was setting RGBA pixels with the alpha value with the same value as the pixel. This was changed to set an alpha value of 255 for full opacity of the image pixels.
Also the `GenericCameraControls` component was refactored to display errors when fetching the generic camera stream.