### PR TITLE
Fix Scheduler subscription for Layout component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.24.5
+--------
+
+* Fix Scheduler subscription for Layout component `<https://github.com/lsst-ts/LOVE-frontend/pull/498>`_
+
 v5.24.4
 --------
 

--- a/love/src/components/Layout/Layout.container.jsx
+++ b/love/src/components/Layout/Layout.container.jsx
@@ -81,11 +81,11 @@ const mapDispatchToProps = (dispatch) => {
     'event-Watcher-0-stream',
     /* Simonyi states */
     'event-Scheduler-1-observingMode',
-    'event-Scheduler-1-observatoryState',
+    'telemetry-Scheduler-1-observatoryState',
     'event-MTPtg-0-currentTarget',
     /* Auxtel states */
     'event-Scheduler-2-observingMode',
-    'event-Scheduler-2-observatoryState',
+    'telemetry-Scheduler-2-observatoryState',
     'event-ATPtg-0-currentTarget',
   ];
   return {


### PR DESCRIPTION
This PR makes a minor fix to the `Layout.container.jsx` component. Changes: `event-Scheduler-1-observatoryState` and `event-Scheduler-2-observatoryState` to `telemetry-Scheduler-1-observatoryState` and `telemetry-Scheduler-2-observatoryState`.