### PR TITLE
Fix script configuration storing rendering constraints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Version History
 
 v5.24.8
 --------
+
 * Simonyi LightPath Covers Hotfix `<https://github.com/lsst-ts/LOVE-frontend/pull/505>`_
+* Fix script configuration storing rendering constraints `<https://github.com/lsst-ts/LOVE-frontend/pull/504>`_
 
 v5.24.7
 --------

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -454,9 +454,14 @@ export default class ConfigPanel extends Component {
     }
 
     if (
-      (configurationList.length > 0 &&
-        configurationList.findIndex((conf) => conf.config_name === inputConfigurationName) === -1) ||
-      (configurationList.length === 0 && inputConfigurationName !== DEFAULT_CONFIG_NAME)
+      inputConfigurationName !== DEFAULT_CONFIG_NAME &&
+      (
+        configurationList.length === 0 ||
+        (
+          configurationList.length > 0 &&
+          configurationList.findIndex((conf) => conf.config_name === inputConfigurationName) === -1
+        )
+      )
     ) {
       configurationNameChanged = true;
     }
@@ -496,9 +501,14 @@ export default class ConfigPanel extends Component {
           const scriptType = configPanel?.script?.type ?? '';
           const configName = inputConfigurationName;
           const configSchema = value;
-          if (configurationNameChanged) {
-            this.saveNewScriptSchema(scriptPath, scriptType, configName, configSchema);
-          } else if (configurationList.length === 0) {
+          if (
+            configurationNameChanged ||
+            (
+              configName === DEFAULT_CONFIG_NAME &&
+              configurationList.length >= 0 &&
+              configurationList.findIndex((conf) => conf.config_name === DEFAULT_CONFIG_NAME) === -1
+            )
+          ) {
             this.saveNewScriptSchema(scriptPath, scriptType, configName, configSchema);
           } else {
             this.updateScriptSchema(selectedConfiguration.value, configSchema);
@@ -565,7 +575,7 @@ export default class ConfigPanel extends Component {
         this.props.configPanel.script.type,
       ).then((data) => {
         const options = data.map((conf) => ({ label: conf.config_name, value: conf.id }));
-        const configuration = data.find((conf) => conf.config_name === 'last_script');
+        const configuration = data.find((conf) => conf.config_name === DEFAULT_CONFIG_NAME);
         this.setState((state) => ({
           configurationList: data,
           configurationOptions: options,


### PR DESCRIPTION
This PR fixes the function that renders the selectors to interact with the feature to store script configurations. A few edge cases were implemented:
- Allow creation of custom named script configurations if the default one, `last_script`, doesn't exist yet.
- Allow creation of `last_script` when it doesn't exist yet and other custom named configuration have been already saved.