### PR TITLE
Simonyi LightPath Covers Hotfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Version History
 ===============
 
+v5.24.8
+--------
+* Simonyi LightPath Covers Hotfix `<https://github.com/lsst-ts/LOVE-frontend/pull/505>`_
+
 v5.24.7
 --------
 

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.24.7",
+  "version": "5.24.8",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/MainTel/LightPath/SimonyiLightPath.jsx
+++ b/love/src/components/MainTel/LightPath/SimonyiLightPath.jsx
@@ -247,8 +247,8 @@ export default class SimonyiLightPath extends Component {
 
     let mirrorWidth = 150;
 
-    if (mirrorCoverState === 0 || mirrorCoverState === 4) mirrorWidth = 150; // CLOSED
-    if (mirrorCoverState === 1) mirrorWidth = 20; // OPENED
+    if (mirrorCoverState === 1 || mirrorCoverState === 4) mirrorWidth = 150; // CLOSED
+    if (mirrorCoverState === 0) mirrorWidth = 20; // OPENED
     if (mirrorCoverState === 2 || mirrorCoverState === 3) mirrorWidth = 80; // IN MOTION
 
     return (
@@ -425,7 +425,7 @@ export default class SimonyiLightPath extends Component {
 
   render() {
     const showLightPath = this.props.lightPath;
-    const isM1M3CoverOpen = Math.max(...this.props.mirrorCoversState) === 1;
+    const isM1M3CoverOpen = Math.max(...this.props.mirrorCoversState) === 0;
 
     return (
       <div className={styles.container}>


### PR DESCRIPTION
Hotfix so that mirrorCoversMotionState 1  (Deployed), is read as vignetting the lightpath.