### PR TITLE
Set narrativelog date selector to work between startOfDay and endOfDay

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,15 +2,12 @@
 Version History
 ===============
 
-v5.24.11
----------
-
-* Fix GIS data expunge `<https://github.com/lsst-ts/LOVE-frontend/pull/513>`_
-* Various ATDome updates `<https://github.com/lsst-ts/LOVE-frontend/pull/512>`_
-
 v5.24.10
 ---------
 
+* Set narrativelog date selector to work between startOfDay and endOfDay `<https://github.com/lsst-ts/LOVE-frontend/pull/514>`_
+* Fix GIS data expunge `<https://github.com/lsst-ts/LOVE-frontend/pull/513>`_
+* Various ATDome updates `<https://github.com/lsst-ts/LOVE-frontend/pull/512>`_
 * Highlight block when is selected `<https://github.com/lsst-ts/LOVE-frontend/pull/511>`_
 * Bump @adobe/css-tools from 4.0.1 to 4.3.1 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/508>`_
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -41,7 +41,7 @@ export const EUIs = {
 
 // Moment formats
 export const ISO_STRING_DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
-export const ISO_STIRNG_DATE_FORMAT = 'YYYY-MM-DD';
+export const ISO_STRING_DATE_FORMAT = 'YYYY-MM-DD';
 export const ISO_DATE_FORMAT = 'YYYY/MM/DD';
 export const ISO_INTEGER_DATE_FORMAT = 'YYYYMMDD';
 export const TIME_FORMAT = 'HH:mm:ss';

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -230,8 +230,8 @@ export default class NonExposure extends Component {
 
   queryNarrativeLogs() {
     const { selectedDayNarrativeStart, selectedDayNarrativeEnd } = this.props;
-    const dateFrom = selectedDayNarrativeStart.format(ISO_STRING_DATE_TIME_FORMAT);
-    const dateTo = selectedDayNarrativeEnd.format(ISO_STRING_DATE_TIME_FORMAT);
+    const dateFrom = Moment(selectedDayNarrativeStart).utc().startOf('day').format(ISO_STRING_DATE_TIME_FORMAT);
+    const dateTo = Moment(selectedDayNarrativeEnd).utc().endOf('day').format(ISO_STRING_DATE_TIME_FORMAT);
 
     // Get list of narrative logs
     this.setState({ updatingLogs: true });

--- a/love/src/components/OLE/OLE.jsx
+++ b/love/src/components/OLE/OLE.jsx
@@ -25,16 +25,16 @@ export default class OLE extends Component {
       selectedTab: props.tabs[0].value,
       clickNewLog: false,
       // Non Exposure filters
-      selectedDayNarrativeStart: Moment(Date.now() + 37 * 1000).subtract(1, 'days'),
-      selectedDayNarrativeEnd: Moment(Date.now() + 37 * 1000),
+      selectedDayNarrativeStart: Moment().subtract(1, 'days'),
+      selectedDayNarrativeEnd: Moment(),
       selectedCommentType: OLE_COMMENT_TYPE_OPTIONS[0],
       selectedSystem: 'all',
       selectedObsTimeLoss: false,
       // Exposure filters
       instruments: [],
       selectedInstrument: null,
-      selectedDayExposureStart: Moment(Date.now() + 37 * 1000).subtract(1, 'days'),
-      selectedDayExposureEnd: Moment(Date.now() + 37 * 1000),
+      selectedDayExposureStart: Moment().subtract(1, 'days'),
+      selectedDayExposureEnd: Moment(),
       selectedExposureType: 'all',
       registryMap: {},
     };


### PR DESCRIPTION
This PR improves the date selector handling in order to fix inconsistencies between input dates and search results. The date params of the narrativelog query were adjusted to use the start of the day for the initial date (00:00:00) and the end of the day for the end date (23:59:59). This will fix the issue when searching for narrativelogs on specific dates.