### PR TITLE
Change Illinois timezone to California as USDF is at SLAC now

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.25.2
+-------
+
+* Change Illinois timezone to California as USDF is at SLAC now `<https://github.com/lsst-ts/LOVE-frontend/pull/521>`_
+
 v5.25.1
 -------
 

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.25.0",
+  "version": "5.25.2",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/Time/TimeDisplay.container.jsx
+++ b/love/src/components/Time/TimeDisplay.container.jsx
@@ -42,7 +42,7 @@ export const schema = {
         1. name: (string) name of the clock, to be displayed above it.
         2. hideAnalog: (boolean = false) flag to hide the analog clock.
         3. hideDate: (boolean = false) flag to hide the date.
-        4. hideOffset: (boolean = false) flag to hide the UTC offset, displayed at the right of the name
+        4. hideOffset: (boolean = false) flag to hide the UTC offset, displayed at the right of the name.
         5. timezone: timezone string used to configure which UTC offset to use. 'local' if current should be used. 'local' by default.
 
         The format for the timezone string can be a fixed string (for UTC or TAI); a fixed-offset string (e.g. UTC+5);
@@ -57,9 +57,10 @@ export const schema = {
         - For Observing Day use observing-day
         - For La Serena use America/Santiago
         - For Arizona use America/Phoenix
-        - For Illinois use America/Chicago
-        Note that not every city is available, check the IANA DB documentation for more info: https://www.iana.org/time-zones
-        See the default value as an example`,
+        - For California use America/Los_Angeles
+        Note that not every city is available, check the IANA DB documentation for more info: https://www.iana.org/time-zones.
+        https://time.is/ is a good website to check the current time in different timezones too.
+        See the default value as an example.`,
       isPrivate: false,
       default: [
         [
@@ -95,11 +96,11 @@ export const schema = {
               timezone: 'America/Phoenix',
             },
             {
-              name: 'Illinois',
+              name: 'California',
               hideAnalog: true,
               hideDate: false,
               hideOffset: false,
-              timezone: 'America/Chicago',
+              timezone: 'America/Los_Angeles',
             },
           ],
           [

--- a/love/src/components/Time/TimeDisplay.jsx
+++ b/love/src/components/Time/TimeDisplay.jsx
@@ -37,7 +37,7 @@ export default class TimeDisplay extends React.Component {
         1. name: (string) name of the clock, to be displayed above it.
         2. hideAnalog: (boolean = false) flag to hide the analog clock.
         3. hideDate: (boolean = false) flag to hide the date.
-        4. hideOffset: (boolean = false) flag to hide the UTC offset, displayed at the right of the name
+        4. hideOffset: (boolean = false) flag to hide the UTC offset, displayed at the right of the name.
         5. timezone: timezone string used to configure which UTC offset to use. 'local' if current should be used. 'local' by default.
 
         The format for the timezone string can be a fixed string (for UTC or TAI); a fixed-offset string (e.g. UTC+5);
@@ -52,9 +52,10 @@ export default class TimeDisplay extends React.Component {
         - For Observing Day use observing-day
         - For La Serena use America/Santiago
         - For Arizona use America/Phoenix
-        - For Illinois use America/Chicago
-        Note that not every city is available, check the IANA DB documentation for more info: https://www.iana.org/time-zones
-        See the default value as an example
+        - For California use America/Los_Angeles
+        Note that not every city is available, check the IANA DB documentation for more info: https://www.iana.org/time-zones.
+        https://time.is/ is a good website to check the current time in different timezones too.
+        See the default value as an example.
     */
     clocks_layout: PropTypes.array,
   };


### PR DESCRIPTION
This PR swaps the old Illinois timezone of the `TimeDisplay` component for the California timezone as the USDF is located at SLAC. The IANA time zone identifier for California is `America/Los_Angeles`.