### PR TITLE
Patch ScriptQueue ConfigPanel yaml strings parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.25.2
 -------
 
+* Patch ScriptQueue ConfigPanel yaml strings parsing `<https://github.com/lsst-ts/LOVE-frontend/pull/526>`_
 * Improvements for Plot component `<https://github.com/lsst-ts/LOVE-frontend/pull/525>`_
 * LOVE License `<https://github.com/lsst-ts/LOVE-frontend/pull/524>`_
 * Make CSCExpanded select inputs more clear `<https://github.com/lsst-ts/LOVE-frontend/pull/523>`_

--- a/love/package.json
+++ b/love/package.json
@@ -64,8 +64,7 @@
     "vega-embed": "^6.12.2",
     "vega-lib": "^4.4.0",
     "vega-lite": "^5.2.0",
-    "websocket-playback": "^1.0.0",
-    "yaml": "^2.2.2"
+    "websocket-playback": "^1.0.0"
   },
   "scripts": {
     "start": "npx react-scripts start",

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -21,7 +21,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
 import { Rnd } from 'react-rnd';
-import YAML from 'yaml';
 import yaml from 'js-yaml';
 import Form from '@rjsf/core';
 import rjsfValidator from '@rjsf/validator-ajv8';
@@ -286,7 +285,7 @@ export default class ConfigPanel extends Component {
         if (r.output) {
           this.setState({
             validationStatus: VALID,
-            autoFilledValue: YAML.stringify(r.output),
+            autoFilledValue: yaml.dump(r.output),
             configErrors: [],
             configErrorTitle: '',
             formData: r.output,
@@ -298,7 +297,7 @@ export default class ConfigPanel extends Component {
         /** Handle yaml syntax errors */
         if (r.error) {
           if (r.title === 'ERROR WHILE PARSING YAML STRING') {
-            const message = `${r.error.problem}\n ${YAML.stringify({
+            const message = `${r.error.problem}\n ${yaml.dump({
               line: r.error.problem_mark.line,
               column: r.error.problem_mark.column,
               pointer: r.error.problem_mark.pointer,
@@ -589,6 +588,7 @@ export default class ConfigPanel extends Component {
       ).then((data) => {
         const options = data.map((conf) => ({ label: conf.config_name, value: conf.id }));
         const configuration = data.find((conf) => conf.config_name === DEFAULT_CONFIG_NAME);
+
         this.setState((state) => ({
           configurationList: data,
           configurationOptions: options,

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -435,11 +435,19 @@ export default class ConfigPanel extends Component {
   selectConfiguration = (event) => {
     const { configurationList } = this.state;
     const configuration = configurationList.find((conf) => conf.id === event.value);
+
+    let yamlData;
+    try {
+      yamlData = configuration ? yaml.load(configuration.config_schema) : {};
+    } catch {
+      yamlData = {};
+    }
+
     this.setState({
       selectedConfiguration: event,
       value: configuration?.config_schema ?? '',
       inputConfigurationName: configuration?.config_name ?? '',
-      formData: yaml.load(configuration?.config_schema),
+      formData: yamlData,
     });
   };
 
@@ -589,13 +597,20 @@ export default class ConfigPanel extends Component {
         const options = data.map((conf) => ({ label: conf.config_name, value: conf.id }));
         const configuration = data.find((conf) => conf.config_name === DEFAULT_CONFIG_NAME);
 
+        let yamlData;
+        try {
+          yamlData = configuration ? yaml.load(configuration.config_schema) : {};
+        } catch {
+          yamlData = {};
+        }
+
         this.setState((state) => ({
           configurationList: data,
           configurationOptions: options,
           selectedConfiguration: configuration ? { label: configuration.config_name, value: configuration.id } : null,
           value: configuration?.config_schema ?? DEFAULT_CONFIG_VALUE,
           inputConfigurationName: configuration?.config_name ?? DEFAULT_CONFIG_NAME,
-          formData: configuration ? yaml.load(configuration.config_schema) : null,
+          formData: yamlData,
         }));
       });
     }
@@ -643,7 +658,13 @@ export default class ConfigPanel extends Component {
     const configPanelBarClassName = 'configPanelBar';
 
     // RJSF variables
-    const rjsfSchema = yamlSchema ? yaml.load(yamlSchema) : {};
+    let rjsfSchema;
+    try {
+      rjsfSchema = yamlSchema ? yaml.load(yamlSchema) : {};
+    } catch {
+      rjsfSchema = {};
+    }
+
     const rjsfWidgets = {
       SelectWidget: this.CustomSelect,
       TextWidget: this.CustomInput,

--- a/love/src/components/UIF/ComponentIndex.jsx
+++ b/love/src/components/UIF/ComponentIndex.jsx
@@ -258,16 +258,6 @@ export const observatoryIndex = {
       },
     },
   },
-  Dynalene: {
-    component: require('../MainTel/Dynalene/Dynalene.container').default,
-    schema: {
-      ...require('../MainTel/Dynalene/Dynalene.container').schema,
-      props: {
-        ...defaultSchemaProps,
-        ...require('../MainTel/Dynalene/Dynalene.container').schema.props,
-      },
-    },
-  },
   WeatherForecast: {
     component: require('../WeatherForecast/WeatherForecast.container').default,
     schema: {


### PR DESCRIPTION
This PR makes a patch to those methods that parses yaml string in order to avoid UI crashes when a malformated yaml string is tried to be loaded. Some Try catch blocks were added to avoid errors. Also a duplicated yaml library was removed.