### PR TITLE
Fix M2 Actuator position units from um to µm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,9 @@ Version History
 v5.25.3
 -------
 
-* Fix ESS component with the sorted sensors in cache `<https://github.com/lsst-ts/LOVE-frontend/pull/531>`
-* Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`
+* Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`_
+* Fix ESS component with the sorted sensors in cache `<https://github.com/lsst-ts/LOVE-frontend/pull/531>`_
+* Fix M2 Actuator position units from um to µm `<https://github.com/lsst-ts/LOVE-frontend/pull/528>`_
 
 v5.25.2
 -------

--- a/love/src/components/MainTel/M2/Actuators/Info/Info.jsx
+++ b/love/src/components/MainTel/M2/Actuators/Info/Info.jsx
@@ -212,10 +212,10 @@ export default class Info extends Component {
             <Value>{`${defaultNumberFormatter(selectedActuatorData.forceMeasured, 2)} N`}</Value>
 
             <Label>Actuator Steps</Label>
-            <Value>{`${defaultNumberFormatter(selectedActuatorData.actuatorStep, 2)} °`}</Value>
+            <Value>{`${defaultNumberFormatter(selectedActuatorData.actuatorStep, 2)}`}</Value>
 
             <Label>Position</Label>
-            <Value>{`${defaultNumberFormatter(selectedActuatorData.encoderPosition, 2)} um`}</Value>
+            <Value>{`${defaultNumberFormatter(selectedActuatorData.encoderPosition, 2)} µm`}</Value>
           </>
         ) : (
           <div className={styles.noActuator}>No actuator selected</div>


### PR DESCRIPTION
This PR updates some of the units for the M2 Actuators:

- Remove º from Actuator Steps since it's 'unitless'
- Change Actuator Position units from um to µm