### PR TITLE
Scheduler accordion BlockList grid fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v5.25.3
 
 * Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`_
 * Fix ESS component with the sorted sensors in cache `<https://github.com/lsst-ts/LOVE-frontend/pull/531>`_
+* Scheduler accordion BlockList grid fix `<https://github.com/lsst-ts/LOVE-frontend/pull/529>`_
 * Fix M2 Actuator position units from um to µm `<https://github.com/lsst-ts/LOVE-frontend/pull/528>`_
 
 v5.25.2

--- a/love/src/components/Scheduler/AccordionSummary/AccordionSummary.module.css
+++ b/love/src/components/Scheduler/AccordionSummary/AccordionSummary.module.css
@@ -88,7 +88,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .predictedTargetsDiv {
   margin: 0.5em;
-  height: 200px;
+  height: 12em;
   overflow-x: hidden;
   overflow-y: auto;
   text-align: justify;
@@ -127,7 +127,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .blocksTargetsDiv {
   margin: 0.5em;
-  height: 200px;
+  height: 12em;
   overflow: hidden;
   text-align: justify;
   border: 1px solid var(--tertiary-background-color);
@@ -160,12 +160,13 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .blocksPanel {
   max-width: 100%;
   margin: 0 0.5em;
-  height: 200px;
+  height: 12em;
   overflow-x: hidden;
   overflow-y: auto;
   text-align: justify;
   border: 1px solid var(--tertiary-background-color);
   padding: var(--content-padding);
+  align-content: baseline !important;
 }
 
 .listOfBlocks {


### PR DESCRIPTION
This PR fixes an issue with the Sceduler accordion BlockList element, in which the grid alignment made it so some of the blocks became unaccessible. Changing this alignment from "Center" to "Baseline" fixes the issue, giving access to the whole range of listed blocks.

I also changed a css definition that was in px to em.