### PR TITLE
Facility map has poorly rendered text possibly on Mac pcs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Version History
 
 v5.25.3
 -------
+
 * Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.25.3
+-------
+* Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`_
+
+
 v5.25.2
 -------
 

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.25.2",
+  "version": "5.25.3",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/Facility/FacilityMap.jsx
+++ b/love/src/components/Facility/FacilityMap.jsx
@@ -19,11 +19,10 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { isArray } from 'lodash';
 
 import styles from './FacilityMap.module.css';
-import Badge from '../GeneralPurpose/Badge/Badge';
 import Map from './Map/Map.jsx';
-import Device from './Map/Device.jsx';
 import EyeIcon from '../icons/EyeIcon/EyeIcon';
 import SimpleArrowIcon from '../icons/SimpleArrowIcon/SimpleArrowIcon';
 import { thresholdScott } from 'd3';
@@ -172,6 +171,14 @@ export default class FacilityMap extends Component {
     return <EyeIcon active={!active} />;
   };
 
+  checkArray(ctx) {
+    if (isArray(ctx)) {
+      return ctx[0];
+    } else {
+      return ctx;
+    }
+  }
+
   hideHVAC = () => {
     this.setState((prevState) => ({
       showHVAC: !prevState.showHVAC,
@@ -197,21 +204,21 @@ export default class FacilityMap extends Component {
   render() {
     const { showHVAC, showPower } = this.state;
     const HVACDataLevel1 = {
-      compressorInfo1: this.props.compressorInfo1,
-      connectionStatus1: this.props.connectionStatus1,
-      errors1: this.props.errors1,
-      status1: this.props.status1,
-      timerInfo1: this.props.timerInfo1,
-      warnings1: this.props.warnings1,
-      analogData1: this.props.analogData1,
+      compressorInfo1: this.checkArray(this.props.compressorInfo1),
+      connectionStatus1: this.checkArray(this.props.connectionStatus1),
+      errors1: this.checkArray(this.props.errors1),
+      status1: this.checkArray(this.props.status1),
+      timerInfo1: this.checkArray(this.props.timerInfo1),
+      warnings1: this.checkArray(this.props.warnings1),
+      analogData1: this.checkArray(this.props.analogData1),
 
-      compressorInfo2: this.props.compressorInfo2,
-      connectionStatus2: this.props.connectionStatus2,
-      errors2: this.props.errors2,
-      status2: this.props.status2,
-      timerInfo2: this.props.timerInfo2,
-      warnings2: this.props.warnings2,
-      analogData2: this.props.analogData2,
+      compressorInfo2: this.checkArray(this.props.compressorInfo2),
+      connectionStatus2: this.checkArray(this.props.connectionStatus2),
+      errors2: this.checkArray(this.props.errors2),
+      status2: this.checkArray(this.props.status2),
+      timerInfo2: this.checkArray(this.props.timerInfo2),
+      warnings2: this.checkArray(this.props.warnings2),
+      analogData2: this.checkArray(this.props.analogData2),
 
       bombaAguaFriaP01: this.props.bombaAguaFriaP01,
       chiller01P01: this.props.chiller01P01,

--- a/love/src/components/Facility/Map/Levels/Level1.jsx
+++ b/love/src/components/Facility/Map/Levels/Level1.jsx
@@ -69,6 +69,14 @@ export default class Level1 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   checkArray(ctx) {
     if (isArray(ctx)) {
       return ctx[0];
@@ -1554,6 +1562,7 @@ export default class Level1 extends Component {
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -1606,7 +1615,7 @@ export default class Level1 extends Component {
                 <circle className={styles.cls4} cx="689.69" cy="402.69" r="11.16" />
               </g>
             </g>
-            <g id="MoveableWall" className={styles.cls45}>
+            <g id="MoveableWall" className={styles.opacity50}>
               <g>
                 <polyline className={styles.cls10} points="747.25 259.28 747.25 260.78 744.61 260.78 744.61 259.28" />
                 <line className={styles.cls11} x1="744.61" y1="256.82" x2="744.61" y2="105.28" />
@@ -1668,7 +1677,7 @@ export default class Level1 extends Component {
               />
               <rect className={styles.cls5} x="795.92" y="78.47" width="1.81" height="23.67" />
             </g>
-            <g id="ClosedSection" className={styles.cls45}>
+            <g id="ClosedSection" className={styles.opacity50}>
               <path className={styles.cls18} d="m692.47,181.25h-56.19v2.64h56.19v-2.64Z" />
               <path className={styles.cls18} d="m721.03,101.45h-80.79v2.64h80.79v-2.64Z" />
               <path className={styles.cls18} d="m694.85,83.93v49.23h2.64v-49.23h-2.64Z" />
@@ -1845,9 +1854,9 @@ export default class Level1 extends Component {
           </g>
           <g id="text">
             <g id="t1">
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(655.89 60.51)">
-                  <tspan className={styles.cls42} x="0" y="0">
+              <g>
+                <text className={styles.smallText} transform="translate(655.89 60.51)">
+                  <tspan x="0" y="0">
                     Camera
                   </tspan>
                   <tspan x="-7.91" y="7.2">
@@ -1856,7 +1865,7 @@ export default class Level1 extends Component {
                   <tspan x="-8.13" y="14.4">
                     Refrigeration
                   </tspan>
-                  <tspan className={styles.cls16} x="-6.33" y="21.6">
+                  <tspan x="-6.33" y="21.6">
                     Compressor
                   </tspan>
                   <tspan x="2.74" y="28.8">
@@ -1864,8 +1873,8 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(751.25 193.67)">
+              <g>
+                <text className={styles.smallText} transform="translate(751.25 193.67)">
                   <tspan x="0" y="0">
                     Mechanical
                   </tspan>
@@ -1877,8 +1886,8 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(721.67 68.98)">
+              <g>
+                <text className={styles.smallText} transform="translate(721.67 68.98)">
                   <tspan x="0" y="0">
                     Entry
                   </tspan>
@@ -1887,8 +1896,8 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(658.91 128.19)">
+              <g>
+                <text className={styles.smallText} transform="translate(658.91 128.19)">
                   <tspan x="0" y="0">
                     Utility
                   </tspan>
@@ -1897,8 +1906,8 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(655.67 223.64)">
+              <g>
+                <text className={styles.smallText} transform="translate(655.67 223.64)">
                   <tspan x="0" y="0">
                     Electrical
                   </tspan>
@@ -1910,8 +1919,8 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(647.23 296.73)">
+              <g>
+                <text className={styles.smallText} transform="translate(647.23 296.73)">
                   <tspan className={styles.cls38} x="0" y="0">
                     Transformer
                   </tspan>
@@ -1920,9 +1929,9 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(632.94 373.41)">
-                  <tspan className={styles.cls16} x="0" y="0">
+              <g>
+                <text className={styles.smallText} transform="translate(632.94 373.41)">
+                  <tspan x="0" y="0">
                     Coatingg
                   </tspan>
                   <tspan className={styles.cls46} x="-5.28" y="7.2">
@@ -1933,65 +1942,65 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls20} transform="translate(722.96 28.63)">
-                  <tspan className={styles.cls33} x="0" y="0">
+              <g>
+                <text className={styles.smallText} transform="translate(722.96 28.63)">
+                  <tspan x="0" y="0">
                     Vestibule
                   </tspan>
                 </text>
               </g>
             </g>
-            <g id="t2" className={styles.cls45}>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(852.29 228.04) rotate(-90)">
+            <g id="t2" className={styles.opacity50}>
+              <g>
+                <text className={styles.text} transform="translate(852.29 228.04) rotate(-90)">
                   <tspan x="0" y="0">
                     Chiller 3
                   </tspan>
                 </text>
-                <text className={styles.cls21} transform="translate(852.29 228.04) rotate(-90)">
+                <text className={styles.text} transform="translate(852.29 228.04) rotate(-90)">
                   <tspan x="0" y="0">
                     Chiller 3
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(792.82 211.19)">
-                  <tspan className={styles.cls16} x="0" y="0">
+              <g>
+                <text className={styles.text} transform="translate(792.82 211.19)">
+                  <tspan x="0" y="0">
                     Process Air
                   </tspan>
-                  <tspan className={styles.cls26} x="-2.1" y="4.8">
+                  <tspan x="-2.1" y="4.8">
                     Compressors
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(774.92 59.94)">
-                  <tspan className={styles.cls28} x="0" y="0">
+              <g>
+                <text className={styles.text} transform="translate(774.92 59.94)">
+                  <tspan x="0" y="0">
                     Wet Shaft
                   </tspan>
                 </text>
               </g>
               <g>
-                <text className={styles.cls21} transform="translate(771.05 162.47)">
+                <text className={styles.text} transform="translate(771.05 162.47)">
                   <tspan x="0" y="0">
                     OSS Equip
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(852.29 85.68) rotate(-90)">
+              <g>
+                <text className={styles.text} transform="translate(852.29 85.68) rotate(-90)">
                   <tspan x="0" y="0">
                     Chiller 1
                   </tspan>
                 </text>
-                <text className={styles.cls21} transform="translate(852.29 85.68) rotate(-90)">
+                <text className={styles.text} transform="translate(852.29 85.68) rotate(-90)">
                   <tspan x="0" y="0">
                     Chiller 1
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(802.06 92.28)">
+              <g>
+                <text className={styles.text} transform="translate(802.06 92.28)">
                   <tspan x="0" y="0">
                     Dry
                   </tspan>
@@ -2000,30 +2009,30 @@ export default class Level1 extends Component {
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(774.48 87.54)">
+              <g>
+                <text className={styles.text} transform="translate(774.48 87.54)">
                   <tspan x="0" y="0">
                     Elev. 1
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(711.54 176.07) rotate(-90)">
+              <g>
+                <text className={styles.text} transform="translate(711.54 176.07) rotate(-90)">
                   <tspan x="0" y="0">
                     Service Air
                   </tspan>
-                  <tspan className={styles.cls26} x="-1.61" y="4.8">
+                  <tspan x="-1.61" y="4.8">
                     Compressor
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls47}>
-                <text className={styles.cls21} transform="translate(852.29 152.06) rotate(-90)">
+              <g>
+                <text className={styles.text} transform="translate(852.29 152.06) rotate(-90)">
                   <tspan x="0" y="0">
                     Chiller 2
                   </tspan>
                 </text>
-                <text className={styles.cls21} transform="translate(852.29 152.06) rotate(-90)">
+                <text className={styles.text} transform="translate(852.29 152.06) rotate(-90)">
                   <tspan x="0" y="0">
                     Chiller 2
                   </tspan>
@@ -2036,6 +2045,16 @@ export default class Level1 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level1.module.css
+++ b/love/src/components/Facility/Map/Levels/Level1.module.css
@@ -16,6 +16,139 @@ This program is distributed in the hope that it will be useful,but WITHOUT ANY
 You should have received a copy of the GNU General Public License along with 
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
 
 .cls1 {
   stroke-dasharray: 0 0 0 0 3.02 2.52 0 0;
@@ -86,25 +219,9 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 }
 
 .cls19,
-.cls20,
-.cls21 {
+.smallText,
+.text {
   fill: #788f9b;
-}
-
-.cls22 {
-  letter-spacing: 0em;
-}
-
-.cls23 {
-  letter-spacing: 0.03em;
-}
-
-.cls24 {
-  letter-spacing: 0.01em;
-}
-
-.cls25 {
-  letter-spacing: 0em;
 }
 
 .cls3 {
@@ -126,67 +243,19 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   stroke-dasharray: 0 0 0 0 3.02 2.52 0 0;
 }
 
-.cls26 {
-  letter-spacing: 0.02em;
-}
-
-.cls27 {
-  letter-spacing: 0.08em;
-}
-
-.cls28 {
-  letter-spacing: 0.05em;
-}
-
-.cls20 {
+.smallText {
   font-size: 6px;
 }
 
-.cls20,
-.cls21 {
-  font-family: MontserratRegular, Montserrat;
+.smallText,
+.zoomOutText,
+.text {
+  font-family: 'Montserrat', sans-serif;
 }
-
-.cls29 {
-  letter-spacing: 0em;
-}
-
-.cls30 {
-  letter-spacing: 0em;
-}
-
-.cls31 {
-  letter-spacing: 0em;
-}
-
 .cls14 {
   stroke: #788f9b;
   stroke-miterlimit: 10;
   stroke-width: 0.75px;
-}
-
-.cls32 {
-  letter-spacing: 0em;
-}
-
-.cls33 {
-  letter-spacing: 0.06em;
-}
-
-.cls34 {
-  letter-spacing: 0em;
-}
-
-.cls35 {
-  letter-spacing: 0.01em;
-}
-
-.cls36 {
-  letter-spacing: 0em;
-}
-
-.cls37 {
-  letter-spacing: 0em;
 }
 
 .cls7 {
@@ -201,8 +270,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   opacity: 0.5;
 }
 
-.cls21 {
-  font-size: 4px;
+.text {
+  font-size: 0.3em;
 }
 
 .cls11 {
@@ -211,4 +280,17 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .background {
   fill: var(--second-secondary-background-color);
+}
+
+.zoomOut {
+  cursor: pointer;
+}
+
+.zoomOutButton {
+  fill: var(--default-background-color);
+}
+
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
 }

--- a/love/src/components/Facility/Map/Levels/Level2.jsx
+++ b/love/src/components/Facility/Map/Levels/Level2.jsx
@@ -69,6 +69,14 @@ export default class Level2 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   getDevices() {
     const {
       crack01P02,
@@ -1416,6 +1424,7 @@ export default class Level2 extends Component {
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -2075,6 +2084,16 @@ export default class Level2 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level2.jsx
+++ b/love/src/components/Facility/Map/Levels/Level2.jsx
@@ -1936,521 +1936,135 @@ export default class Level2 extends Component {
           </g>
           <g id="text">
             <g id="t1">
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(649.42 81.67)">
+              <g>
+                <text className={styles.svgText} transform="translate(649.42 81.67)">
                   <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    ompu
-                  </tspan>
-                  <tspan className={styles.cls2} x="22.41" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls24} x="24.73" y="0">
-                    er
-                  </tspan>
-                  <tspan x="6.27" y="7.2">
-                    Room
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(649.42 81.67)">
-                  <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    ompu
-                  </tspan>
-                  <tspan className={styles.cls2} x="22.41" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls24} x="24.73" y="0">
-                    er
+                    Computer
                   </tspan>
                   <tspan x="6.27" y="7.2">
                     Room
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(755.06 234.13)">
+              <g>
+                <text className={styles.svgText} transform="translate(755.06 234.13)">
                   <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    ont
-                  </tspan>
-                  <tspan className={styles.cls37} x="14.44" y="0">
-                    r
-                  </tspan>
-                  <tspan x="16.76" y="0">
-                    ol Room
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(755.06 234.13)">
-                  <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    ont
-                  </tspan>
-                  <tspan className={styles.cls37} x="14.44" y="0">
-                    r
-                  </tspan>
-                  <tspan x="16.76" y="0">
-                    ol Room
+                    Control Room
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(749.6 144.61)">
+              <g>
+                <text className={styles.svgText} transform="translate(749.6 144.61)">
                   <tspan x="0" y="0">
                     Open
                   </tspan>
                   <tspan x="-10.58" y="7.2">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x=".61" y="7.2">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="3.94" y="7.2">
-                    e S
-                  </tspan>
-                  <tspan className={styles.cls22} x="12.82" y="7.2">
-                    p
-                  </tspan>
-                  <tspan className={styles.cls26} x="16.87" y="7.2">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls23} x="20.42" y="7.2">
-                    c
-                  </tspan>
-                  <tspan x="23.75" y="7.2">
-                    e
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(749.6 144.61)">
-                  <tspan x="0" y="0">
-                    Open
-                  </tspan>
-                  <tspan x="-10.58" y="7.2">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x=".61" y="7.2">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="3.94" y="7.2">
-                    e S
-                  </tspan>
-                  <tspan className={styles.cls22} x="12.82" y="7.2">
-                    p
-                  </tspan>
-                  <tspan className={styles.cls26} x="16.87" y="7.2">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls23} x="20.42" y="7.2">
-                    c
-                  </tspan>
-                  <tspan x="23.75" y="7.2">
-                    e
+                    Office Space
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(823.54 77.69)">
+              <g>
+                <text className={styles.svgText} transform="translate(823.54 77.69)">
                   <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    on
-                  </tspan>
-                  <tspan className={styles.cls18} x="12" y="0">
-                    f
-                  </tspan>
-                  <tspan x="13.98" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls37} x="17.6" y="0">
-                    r
-                  </tspan>
-                  <tspan x="19.93" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls26} x="23.56" y="0">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls23} x="27.63" y="0">
-                    c
-                  </tspan>
-                  <tspan x="30.95" y="0">
-                    e
-                  </tspan>
-                  <tspan x="8.18" y="7.2">
-                    Room
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(823.54 77.69)">
-                  <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    on
-                  </tspan>
-                  <tspan className={styles.cls18} x="12" y="0">
-                    f
-                  </tspan>
-                  <tspan x="13.98" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls37} x="17.6" y="0">
-                    r
-                  </tspan>
-                  <tspan x="19.93" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls26} x="23.56" y="0">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls23} x="27.63" y="0">
-                    c
-                  </tspan>
-                  <tspan x="30.95" y="0">
-                    e
+                    Conference
                   </tspan>
                   <tspan x="8.18" y="7.2">
                     Room
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(829.58 133.44)">
+              <g>
+                <text className={styles.svgText} transform="translate(829.58 133.44)">
                   <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="14.52" y="0">
-                    e 1
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(829.58 133.44)">
-                  <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="14.52" y="0">
-                    e 1
+                    Office 1
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(828.96 162.18)">
+              <g>
+                <text className={styles.svgText} transform="translate(828.96 162.18)">
                   <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="14.52" y="0">
-                    e 2
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(828.96 162.18)">
-                  <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="14.52" y="0">
-                    e 2
+                    Office 2
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(828.97 191.69)">
+              <g>
+                <text className={styles.svgText} transform="translate(828.97 191.69)">
                   <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="14.52" y="0">
-                    e 3
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(828.97 191.69)">
-                  <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls18} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls24} x="14.52" y="0">
-                    e 3
+                    Office 3
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(652.87 157.69)">
+              <g>
+                <text className={styles.svgText} transform="translate(652.87 157.69)">
                   <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    ompu
-                  </tspan>
-                  <tspan className={styles.cls2} x="22.41" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls24} x="24.73" y="0">
-                    er
+                    Computer
                   </tspan>
                   <tspan className={styles.cls36} x="9.8" y="7.2">
-                    L
-                  </tspan>
-                  <tspan x="13.35" y="7.2">
-                    ab
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(652.87 157.69)">
-                  <tspan className={styles.cls3} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.18" y="0">
-                    ompu
-                  </tspan>
-                  <tspan className={styles.cls2} x="22.41" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls24} x="24.73" y="0">
-                    er
-                  </tspan>
-                  <tspan className={styles.cls36} x="9.8" y="7.2">
-                    L
-                  </tspan>
-                  <tspan x="13.35" y="7.2">
-                    ab
+                    Lab
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(654.04 213.18)">
+              <g>
+                <text className={styles.svgText} transform="translate(654.04 213.18)">
                   <tspan x="0" y="0">
-                    B
-                  </tspan>
-                  <tspan className={styles.cls38} x="4.52" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls30} x="6.85" y="0">
-                    e
-                  </tspan>
-                  <tspan x="10.39" y="0">
-                    ak
-                  </tspan>
-                  <tspan x="-.35" y="7.2">
-                    Room
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(654.04 213.18)">
-                  <tspan x="0" y="0">
-                    B
-                  </tspan>
-                  <tspan className={styles.cls38} x="4.52" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls30} x="6.85" y="0">
-                    e
-                  </tspan>
-                  <tspan x="10.39" y="0">
-                    ak
+                    Break
                   </tspan>
                   <tspan x="-.35" y="7.2">
                     Room
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls16} transform="translate(657.85 296.73)">
+              <g>
+                <text className={styles.svgText} transform="translate(657.85 296.73)">
                   <tspan x="0" y="0">
-                    De
-                  </tspan>
-                  <tspan className={styles.cls32} x="8.58" y="0">
-                    c
-                  </tspan>
-                  <tspan x="11.91" y="0">
-                    k
-                  </tspan>
-                </text>
-                <text className={styles.cls16} transform="translate(657.85 296.73)">
-                  <tspan x="0" y="0">
-                    De
-                  </tspan>
-                  <tspan className={styles.cls32} x="8.58" y="0">
-                    c
-                  </tspan>
-                  <tspan x="11.91" y="0">
-                    k
+                    Deck
                   </tspan>
                 </text>
               </g>
             </g>
-            <g id="t2" className={styles.cls29}>
-              <g className={styles.cls33}>
-                <text className={styles.cls17} transform="translate(774.92 59.94)">
+            <g id="t2" className={styles.opacity50}>
+              <g>
+                <text className={styles.svgTextSmall} transform="translate(774.92 59.94)">
                   <tspan className={styles.cls21} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    et Shaft
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(774.92 59.94)">
-                  <tspan className={styles.cls21} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    et Shaft
+                    Wet Shaft
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls17} transform="translate(802.06 92.28)">
+              <g>
+                <text className={styles.svgTextSmall} transform="translate(802.06 92.28)">
                   <tspan x="0" y="0">
-                    D
-                  </tspan>
-                  <tspan className={styles.cls27} x="3.3" y="0">
-                    r
-                  </tspan>
-                  <tspan x="4.97" y="0">
-                    y
-                  </tspan>
-                  <tspan x="-1.69" y="4.8">
-                    Shaft
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(802.06 92.28)">
-                  <tspan x="0" y="0">
-                    D
-                  </tspan>
-                  <tspan className={styles.cls27} x="3.3" y="0">
-                    r
-                  </tspan>
-                  <tspan x="4.97" y="0">
-                    y
+                    Dry
                   </tspan>
                   <tspan x="-1.69" y="4.8">
                     Shaft
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls17} transform="translate(774.48 87.54)">
+              <g>
+                <text className={styles.svgTextSmall} transform="translate(774.48 87.54)">
                   <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls19} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls28} x="8.16" y="0">
-                    . 1
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(774.48 87.54)">
-                  <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls19} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls28} x="8.16" y="0">
-                    . 1
+                    Elev. 1
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls17} transform="translate(733.96 91.3)">
+              <g>
+                <text className={styles.svgTextSmall} transform="translate(733.96 91.3)">
                   <tspan x="0" y="0">
-                    Hall
-                  </tspan>
-                  <tspan className={styles.cls35} x="7.76" y="0">
-                    w
-                  </tspan>
-                  <tspan className={styles.cls34} x="11.22" y="0">
-                    a
-                  </tspan>
-                  <tspan x="13.54" y="0">
-                    y
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(733.96 91.3)">
-                  <tspan x="0" y="0">
-                    Hall
-                  </tspan>
-                  <tspan className={styles.cls35} x="7.76" y="0">
-                    w
-                  </tspan>
-                  <tspan className={styles.cls34} x="11.22" y="0">
-                    a
-                  </tspan>
-                  <tspan x="13.54" y="0">
-                    y
+                    Hallway
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls17} transform="translate(697.97 60.77)">
+              <g>
+                <text className={styles.svgTextSmall} transform="translate(697.97 60.77)">
                   <tspan x="0" y="0">
-                    Bath
-                  </tspan>
-                  <tspan className={styles.cls25} x="9.71" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls31} x="11.26" y="0">
-                    oom
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(697.97 60.77)">
-                  <tspan x="0" y="0">
-                    Bath
-                  </tspan>
-                  <tspan className={styles.cls25} x="9.71" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls31} x="11.26" y="0">
-                    oom
+                    Bathroom
                   </tspan>
                 </text>
               </g>
-              <g className={styles.cls33}>
-                <text className={styles.cls17} transform="translate(725.18 60.77)">
+              <g>
+                <text className={styles.svgTextSmall} transform="translate(725.18 60.77)">
                   <tspan x="0" y="0">
-                    Bath
-                  </tspan>
-                  <tspan className={styles.cls25} x="9.71" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls31} x="11.26" y="0">
-                    oom
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(725.18 60.77)">
-                  <tspan x="0" y="0">
-                    Bath
-                  </tspan>
-                  <tspan className={styles.cls25} x="9.71" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls31} x="11.26" y="0">
-                    oom
+                    Bathroom
                   </tspan>
                 </text>
               </g>

--- a/love/src/components/Facility/Map/Levels/Level2.module.css
+++ b/love/src/components/Facility/Map/Levels/Level2.module.css
@@ -17,16 +17,138 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-.cls1 {
-  letter-spacing: 0.01em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
 }
-
-.cls2 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
 }
-
-.cls3 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
 }
 
 .cls4 {
@@ -55,7 +177,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls10,
 .cls12,
 .cls13 {
-  stroke: #bbd4e2;
+  stroke: var(--base-font-color);
 }
 
 .cls4,
@@ -66,17 +188,9 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 }
 
 .cls15,
-.cls16,
-.cls17 {
-  fill: #788f9b;
-}
-
-.cls18 {
-  letter-spacing: 0em;
-}
-
-.cls19 {
-  letter-spacing: 0.03em;
+.svgText,
+.svgTextSmall {
+  fill: var(--secondary-font-color);
 }
 
 .cls5,
@@ -101,7 +215,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls8,
 .cls20,
 .cls11 {
-  stroke: #788f9b;
+  stroke: var(--secondary-font-color);
 }
 
 .cls6,
@@ -109,29 +223,13 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   stroke-width: 0.71px;
 }
 
-.cls21 {
-  letter-spacing: 0.05em;
-}
-
-.cls8 {
-  stroke-width: 0.9px;
-}
-
-.cls16 {
+.svgText {
   font-size: 6px;
 }
 
-.cls16,
-.cls17 {
-  font-family: MontserratRegular, Montserrat;
-}
-
-.cls22 {
-  letter-spacing: 0em;
-}
-
-.cls23 {
-  letter-spacing: 0em;
+.svgText,
+.svgTextSmall {
+  font-family: 'Montserrat', sans-serif;
 }
 
 .cls20 {
@@ -147,75 +245,17 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   fill: rgba(187, 212, 226, 0.2);
 }
 
-.cls24 {
-  letter-spacing: 0em;
-}
-
-.cls25 {
-  letter-spacing: 0.01em;
-}
-
-.cls26 {
-  letter-spacing: 0em;
-}
-
 .cls9 {
   stroke-dasharray: 0 0 0 0 0 0 5 2.5;
 }
 
-.cls27 {
-  letter-spacing: 0.01em;
-}
-
-.cls28 {
-  letter-spacing: 0em;
-}
-
-.cls29 {
+.opacity50 {
   opacity: 0.5;
 }
-
-.cls30 {
-  letter-spacing: 0.02em;
-}
-
-.cls31 {
-  letter-spacing: 0em;
-}
-
-.cls32 {
-  letter-spacing: 0em;
-}
-
-.cls33 {
-  isolation: isolate;
-}
-
-.cls17 {
+.svgTextSmall {
   font-size: 4px;
 }
-
-.cls34 {
-  letter-spacing: 0em;
-}
-
-.cls35 {
-  letter-spacing: 0.02em;
-}
-
-.cls36 {
-  letter-spacing: 0em;
-}
-
 .cls12,
 .cls13 {
-  fill: #bbd4e2;
-}
-
-.cls37 {
-  letter-spacing: 0.01em;
-}
-
-.cls38 {
-  letter-spacing: 0.01em;
+  fill: var(--base-font-color);
 }

--- a/love/src/components/Facility/Map/Levels/Level2.module.css
+++ b/love/src/components/Facility/Map/Levels/Level2.module.css
@@ -259,3 +259,15 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls13 {
   fill: var(--base-font-color);
 }
+.zoomOut {
+  cursor: pointer;
+}
+
+.zoomOutButton {
+  fill: var(--default-background-color);
+}
+
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
+}

--- a/love/src/components/Facility/Map/Levels/Level3.jsx
+++ b/love/src/components/Facility/Map/Levels/Level3.jsx
@@ -69,10 +69,19 @@ export default class Level3 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   getDevices() {
     return <React.Fragment></React.Fragment>;
   }
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -880,6 +889,16 @@ export default class Level3 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level3.jsx
+++ b/love/src/components/Facility/Map/Levels/Level3.jsx
@@ -667,624 +667,111 @@ export default class Level3 extends Component {
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(681.5 79.96)">
                   <tspan className={styles.cls33} x="0" y="0">
-                    T
-                  </tspan>
-                  <tspan x="3.11" y="0">
-                    eles
-                  </tspan>
-                  <tspan className={styles.cls26} x="14.91" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls34} x="18.23" y="0">
-                    ope
+                    Telescope
                   </tspan>
                   <tspan x="-1.62" y="7.2">
-                    Utili
-                  </tspan>
-                  <tspan className={styles.cls1} x="10.41" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="12.78" y="7.2">
-                    y A
-                  </tspan>
-                  <tspan className={styles.cls55} x="21.91" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls43} x="24.24" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="27.77" y="7.2">
-                    a
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(681.5 79.96)">
-                  <tspan className={styles.cls33} x="0" y="0">
-                    T
-                  </tspan>
-                  <tspan x="3.11" y="0">
-                    eles
-                  </tspan>
-                  <tspan className={styles.cls26} x="14.91" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls34} x="18.23" y="0">
-                    ope
-                  </tspan>
-                  <tspan x="-1.62" y="7.2">
-                    Utili
-                  </tspan>
-                  <tspan className={styles.cls1} x="10.41" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="12.78" y="7.2">
-                    y A
-                  </tspan>
-                  <tspan className={styles.cls55} x="21.91" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls43} x="24.24" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="27.77" y="7.2">
-                    a
+                    Utility Area
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(554.35 79.96)">
                   <tspan x="0" y="0">
-                    St
-                  </tspan>
-                  <tspan className={styles.cls52} x="6.13" y="0">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls32} x="9.68" y="0">
-                    gi
-                  </tspan>
-                  <tspan className={styles.cls52} x="15.41" y="0">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls32} x="19.48" y="0">
-                    g &amp;{' '}
-                  </tspan>
-                  <tspan className={styles.cls29} x="30.76" y="0">
-                    T
-                  </tspan>
-                  <tspan className={styles.cls34} x="33.87" y="0">
-                    est
+                    Staging Test
                   </tspan>
                   <tspan x="14.58" y="7.2">
-                    A
-                  </tspan>
-                  <tspan className={styles.cls55} x="18.88" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls28} x="21.21" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="24.74" y="7.2">
-                    a
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(554.35 79.96)">
-                  <tspan x="0" y="0">
-                    St
-                  </tspan>
-                  <tspan className={styles.cls52} x="6.13" y="0">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls32} x="9.68" y="0">
-                    gi
-                  </tspan>
-                  <tspan className={styles.cls52} x="15.41" y="0">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls32} x="19.48" y="0">
-                    g &amp;{' '}
-                  </tspan>
-                  <tspan className={styles.cls29} x="30.76" y="0">
-                    T
-                  </tspan>
-                  <tspan className={styles.cls34} x="33.87" y="0">
-                    est
-                  </tspan>
-                  <tspan x="14.58" y="7.2">
-                    A
-                  </tspan>
-                  <tspan className={styles.cls55} x="18.88" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls28} x="21.21" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="24.74" y="7.2">
-                    a
+                    Area
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(466.54 75.87)">
                   <tspan x="0" y="0">
-                    Whi
-                  </tspan>
-                  <tspan className={styles.cls49} x="12.34" y="0">
-                    t
-                  </tspan>
-                  <tspan x="14.66" y="0">
-                    e
+                    White
                   </tspan>
                   <tspan x="2.29" y="7.2">
-                    A
-                  </tspan>
-                  <tspan className={styles.cls55} x="6.59" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls28} x="8.92" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="12.46" y="7.2">
-                    a
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(466.54 75.87)">
-                  <tspan x="0" y="0">
-                    Whi
-                  </tspan>
-                  <tspan className={styles.cls49} x="12.34" y="0">
-                    t
-                  </tspan>
-                  <tspan x="14.66" y="0">
-                    e
-                  </tspan>
-                  <tspan x="2.29" y="7.2">
-                    A
-                  </tspan>
-                  <tspan className={styles.cls55} x="6.59" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls28} x="8.92" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="12.46" y="7.2">
-                    a
+                    Area
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(317.75 105.91)">
                   <tspan x="0" y="0">
-                    An
-                  </tspan>
-                  <tspan className={styles.cls2} x="8.36" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls34} x="10.69" y="0">
-                    e Room
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(317.75 105.91)">
-                  <tspan x="0" y="0">
-                    An
-                  </tspan>
-                  <tspan className={styles.cls2} x="8.36" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls34} x="10.69" y="0">
-                    e Room
+                    Ante Room
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(334.31 69.01)">
                   <tspan x="0" y="0">
-                    Cl
-                  </tspan>
-                  <tspan className={styles.cls28} x="5.93" y="0">
-                    e
-                  </tspan>
-                  <tspan x="9.46" y="0">
-                    anRoom
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(334.31 69.01)">
-                  <tspan x="0" y="0">
-                    Cl
-                  </tspan>
-                  <tspan className={styles.cls28} x="5.93" y="0">
-                    e
-                  </tspan>
-                  <tspan x="9.46" y="0">
-                    anRoom
+                    Clean Room
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(366.07 197.01)">
                   <tspan x="0" y="0">
-                    8
-                  </tspan>
-                  <tspan className={styles.cls46} x="3.83" y="0">
-                    0
-                  </tspan>
-                  <tspan className={styles.cls53} x="7.85" y="0">
-                    -
-                  </tspan>
-                  <tspan className={styles.cls33} x="9.95" y="0">
-                    T
-                  </tspan>
-                  <tspan x="13.06" y="0">
-                    on
+                    80-Ton
                   </tspan>
                   <tspan x="-8.33" y="7.2">
-                    Plat
-                  </tspan>
-                  <tspan className={styles.cls31} x="3.56" y="7.2">
-                    f
-                  </tspan>
-                  <tspan className={styles.cls34} x="5.54" y="7.2">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls39} x="9.31" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls32} x="11.66" y="7.2">
-                    m Lift
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(366.07 197.01)">
-                  <tspan x="0" y="0">
-                    8
-                  </tspan>
-                  <tspan className={styles.cls46} x="3.83" y="0">
-                    0
-                  </tspan>
-                  <tspan className={styles.cls53} x="7.85" y="0">
-                    -
-                  </tspan>
-                  <tspan className={styles.cls33} x="9.95" y="0">
-                    T
-                  </tspan>
-                  <tspan x="13.06" y="0">
-                    on
-                  </tspan>
-                  <tspan x="-8.33" y="7.2">
-                    Plat
-                  </tspan>
-                  <tspan className={styles.cls31} x="3.56" y="7.2">
-                    f
-                  </tspan>
-                  <tspan className={styles.cls34} x="5.54" y="7.2">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls39} x="9.31" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls32} x="11.66" y="7.2">
-                    m Lift
+                    Platform Lift
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(800.95 202.05)">
                   <tspan x="0" y="0">
-                    M2{' '}
-                  </tspan>
-                  <tspan className={styles.cls33} x="10.71" y="0">
-                    V
-                  </tspan>
-                  <tspan x="14.57" y="0">
-                    essel
+                    M2 Vessel
                   </tspan>
                   <tspan x="2.94" y="7.2">
-                    S
-                  </tspan>
-                  <tspan className={styles.cls49} x="6.63" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="8.95" y="7.2">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls26} x="12.71" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls52} x="15.07" y="7.2">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls32} x="18.62" y="7.2">
-                    ge
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(800.95 202.05)">
-                  <tspan x="0" y="0">
-                    M2{' '}
-                  </tspan>
-                  <tspan className={styles.cls33} x="10.71" y="0">
-                    V
-                  </tspan>
-                  <tspan x="14.57" y="0">
-                    essel
-                  </tspan>
-                  <tspan x="2.94" y="7.2">
-                    S
-                  </tspan>
-                  <tspan className={styles.cls49} x="6.63" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="8.95" y="7.2">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls26} x="12.71" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls52} x="15.07" y="7.2">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls32} x="18.62" y="7.2">
-                    ge
+                    Storage
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(711.2 202.05)">
                   <tspan x="0" y="0">
-                    Mi
-                  </tspan>
-                  <tspan className={styles.cls39} x="7.34" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls55} x="9.7" y="0">
-                    r
-                  </tspan>
-                  <tspan x="12.03" y="0">
-                    or
+                    Mirror
                   </tspan>
                   <tspan className={styles.cls3} x="-2.75" y="7.2">
-                    C
-                  </tspan>
-                  <tspan className={styles.cls30} x="1.42" y="7.2">
-                    o
-                  </tspan>
-                  <tspan x="5.17" y="7.2">
-                    ati
-                  </tspan>
-                  <tspan className={styles.cls36} x="12.76" y="7.2">
-                    n
-                  </tspan>
-                  <tspan x="16.83" y="7.2">
-                    g
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(711.2 202.05)">
-                  <tspan x="0" y="0">
-                    Mi
-                  </tspan>
-                  <tspan className={styles.cls39} x="7.34" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls55} x="9.7" y="0">
-                    r
-                  </tspan>
-                  <tspan x="12.03" y="0">
-                    or
-                  </tspan>
-                  <tspan className={styles.cls3} x="-2.75" y="7.2">
-                    C
-                  </tspan>
-                  <tspan className={styles.cls30} x="1.42" y="7.2">
-                    o
-                  </tspan>
-                  <tspan x="5.17" y="7.2">
-                    ati
-                  </tspan>
-                  <tspan className={styles.cls36} x="12.76" y="7.2">
-                    n
-                  </tspan>
-                  <tspan x="16.83" y="7.2">
-                    g
+                    Coating
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(832.4 65.87)">
                   <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls26} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls34} x="14.52" y="0">
-                    e
+                    Office
                   </tspan>
                   <tspan className={styles.cls3} x="-2.78" y="7.2">
-                    C
-                  </tspan>
-                  <tspan className={styles.cls30} x="1.4" y="7.2">
-                    o
-                  </tspan>
-                  <tspan x="5.14" y="7.2">
-                    ati
-                  </tspan>
-                  <tspan className={styles.cls36} x="12.73" y="7.2">
-                    n
-                  </tspan>
-                  <tspan x="16.81" y="7.2">
-                    g
+                    Coating
                   </tspan>
                   <tspan className={styles.cls3} x="-2" y="14.4">
-                    C
-                  </tspan>
-                  <tspan x="2.18" y="14.4">
-                    ont
-                  </tspan>
-                  <tspan className={styles.cls54} x="12.44" y="14.4">
-                    r
-                  </tspan>
-                  <tspan x="14.77" y="14.4">
-                    ol
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(832.4 65.87)">
-                  <tspan x="0" y="0">
-                    Offi
-                  </tspan>
-                  <tspan className={styles.cls26} x="11.2" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls34} x="14.52" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls3} x="-2.78" y="7.2">
-                    C
-                  </tspan>
-                  <tspan className={styles.cls30} x="1.4" y="7.2">
-                    o
-                  </tspan>
-                  <tspan x="5.14" y="7.2">
-                    ati
-                  </tspan>
-                  <tspan className={styles.cls36} x="12.73" y="7.2">
-                    n
-                  </tspan>
-                  <tspan x="16.81" y="7.2">
-                    g
-                  </tspan>
-                  <tspan className={styles.cls3} x="-2" y="14.4">
-                    C
-                  </tspan>
-                  <tspan x="2.18" y="14.4">
-                    ont
-                  </tspan>
-                  <tspan className={styles.cls54} x="12.44" y="14.4">
-                    r
-                  </tspan>
-                  <tspan x="14.77" y="14.4">
-                    ol
+                    Control
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(596.67 202.05)">
                   <tspan className={styles.cls33} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="6.34" y="0">
-                    ash
-                  </tspan>
-                  <tspan className={styles.cls4} x="16.87" y="0">
-                    /
-                  </tspan>
-                  <tspan x="18.76" y="0">
-                    St
-                  </tspan>
-                  <tspan className={styles.cls39} x="24.89" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls32} x="27.25" y="0">
-                    ip
+                    Wash/Strip
                   </tspan>
                   <tspan x="9.61" y="7.2">
-                    A
-                  </tspan>
-                  <tspan className={styles.cls55} x="13.91" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls28} x="16.24" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="19.78" y="7.2">
-                    a
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(596.67 202.05)">
-                  <tspan className={styles.cls33} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="6.34" y="0">
-                    ash
-                  </tspan>
-                  <tspan className={styles.cls4} x="16.87" y="0">
-                    /
-                  </tspan>
-                  <tspan x="18.76" y="0">
-                    St
-                  </tspan>
-                  <tspan className={styles.cls39} x="24.89" y="0">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls32} x="27.25" y="0">
-                    ip
-                  </tspan>
-                  <tspan x="9.61" y="7.2">
-                    A
-                  </tspan>
-                  <tspan className={styles.cls55} x="13.91" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls28} x="16.24" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="19.78" y="7.2">
-                    a
+                    Area
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(478.34 205.65)">
                   <tspan x="0" y="0">
-                    Re
-                  </tspan>
-                  <tspan className={styles.cls26} x="7.96" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls34} x="11.29" y="0">
-                    eivi
-                  </tspan>
-                  <tspan className={styles.cls36} x="21.39" y="0">
-                    n
-                  </tspan>
-                  <tspan x="25.46" y="0">
-                    g
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(478.34 205.65)">
-                  <tspan x="0" y="0">
-                    Re
-                  </tspan>
-                  <tspan className={styles.cls26} x="7.96" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls34} x="11.29" y="0">
-                    eivi
-                  </tspan>
-                  <tspan className={styles.cls36} x="21.39" y="0">
-                    n
-                  </tspan>
-                  <tspan x="25.46" y="0">
-                    g
+                    Receiving
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls23} transform="translate(657.85 296.73)">
                   <tspan x="0" y="0">
-                    De
-                  </tspan>
-                  <tspan className={styles.cls45} x="8.58" y="0">
-                    c
-                  </tspan>
-                  <tspan x="11.91" y="0">
-                    k
-                  </tspan>
-                </text>
-                <text className={styles.cls23} transform="translate(657.85 296.73)">
-                  <tspan x="0" y="0">
-                    De
-                  </tspan>
-                  <tspan className={styles.cls45} x="8.58" y="0">
-                    c
-                  </tspan>
-                  <tspan x="11.91" y="0">
-                    k
+                    Deck
                   </tspan>
                 </text>
               </g>
@@ -1293,45 +780,14 @@ export default class Level3 extends Component {
               <g className={styles.cls48}>
                 <text className={styles.cls25} transform="translate(774.92 59.94)">
                   <tspan className={styles.cls29} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    et Shaft
-                  </tspan>
-                </text>
-                <text className={styles.cls25} transform="translate(774.92 59.94)">
-                  <tspan className={styles.cls29} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    et Shaft
+                    Wet Shaft
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls25} transform="translate(802.06 92.28)">
                   <tspan x="0" y="0">
-                    D
-                  </tspan>
-                  <tspan className={styles.cls38} x="3.3" y="0">
-                    r
-                  </tspan>
-                  <tspan x="4.97" y="0">
-                    y
-                  </tspan>
-                  <tspan x="-1.69" y="4.8">
-                    Shaft
-                  </tspan>
-                </text>
-                <text className={styles.cls25} transform="translate(802.06 92.28)">
-                  <tspan x="0" y="0">
-                    D
-                  </tspan>
-                  <tspan className={styles.cls38} x="3.3" y="0">
-                    r
-                  </tspan>
-                  <tspan x="4.97" y="0">
-                    y
+                    Dry
                   </tspan>
                   <tspan x="-1.69" y="4.8">
                     Shaft
@@ -1341,156 +797,28 @@ export default class Level3 extends Component {
               <g className={styles.cls48}>
                 <text className={styles.cls25} transform="translate(774.48 87.54)">
                   <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls27} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls40} x="8.16" y="0">
-                    . 1
-                  </tspan>
-                </text>
-                <text className={styles.cls25} transform="translate(774.48 87.54)">
-                  <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls27} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls40} x="8.16" y="0">
-                    . 1
+                    Elev. 1
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls25} transform="translate(630.36 125.28)">
                   <tspan className={styles.cls29} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    al
-                  </tspan>
-                  <tspan className={styles.cls35} x="7.66" y="0">
-                    k
-                  </tspan>
-                  <tspan className={styles.cls37} x="9.96" y="0">
-                    w
-                  </tspan>
-                  <tspan className={styles.cls1} x="13.41" y="0">
-                    a
-                  </tspan>
-                  <tspan x="15.73" y="0">
-                    y{' '}
-                  </tspan>
-                  <tspan className={styles.cls47} x="18.94" y="0">
-                    Z
-                  </tspan>
-                  <tspan className={styles.cls44} x="21.49" y="0">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls52} x="24" y="0">
-                    n
-                  </tspan>
-                  <tspan x="26.71" y="0">
-                    e
-                  </tspan>
-                </text>
-                <text className={styles.cls25} transform="translate(630.36 125.28)">
-                  <tspan className={styles.cls29} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    al
-                  </tspan>
-                  <tspan className={styles.cls35} x="7.66" y="0">
-                    k
-                  </tspan>
-                  <tspan className={styles.cls37} x="9.96" y="0">
-                    w
-                  </tspan>
-                  <tspan className={styles.cls1} x="13.41" y="0">
-                    a
-                  </tspan>
-                  <tspan x="15.73" y="0">
-                    y{' '}
-                  </tspan>
-                  <tspan className={styles.cls47} x="18.94" y="0">
-                    Z
-                  </tspan>
-                  <tspan className={styles.cls44} x="21.49" y="0">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls52} x="24" y="0">
-                    n
-                  </tspan>
-                  <tspan x="26.71" y="0">
-                    e
+                    Walkway Zone
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls25} transform="translate(279.43 50.65)">
                   <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls27} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls40} x="8.16" y="0">
-                    . 2
-                  </tspan>
-                </text>
-                <text className={styles.cls25} transform="translate(279.43 50.65)">
-                  <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls27} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls40} x="8.16" y="0">
-                    . 2
+                    Elev. 2
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls48}>
                 <text className={styles.cls25} transform="translate(326.56 124.01)">
                   <tspan x="0" y="0">
-                    Hall
-                  </tspan>
-                  <tspan className={styles.cls51} x="7.76" y="0">
-                    w
-                  </tspan>
-                  <tspan className={styles.cls50} x="11.22" y="0">
-                    a
-                  </tspan>
-                  <tspan x="13.54" y="0">
-                    y
-                  </tspan>
-                </text>
-                <text className={styles.cls25} transform="translate(326.56 124.01)">
-                  <tspan x="0" y="0">
-                    Hall
-                  </tspan>
-                  <tspan className={styles.cls51} x="7.76" y="0">
-                    w
-                  </tspan>
-                  <tspan className={styles.cls50} x="11.22" y="0">
-                    a
-                  </tspan>
-                  <tspan x="13.54" y="0">
-                    y
+                    Hallway
                   </tspan>
                 </text>
               </g>

--- a/love/src/components/Facility/Map/Levels/Level3.module.css
+++ b/love/src/components/Facility/Map/Levels/Level3.module.css
@@ -17,26 +17,139 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-.cls1 {
-  letter-spacing: -0.01em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
 }
-
-.cls2 {
-  letter-spacing: -0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
 }
-
-.cls3 {
-  letter-spacing: -0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
 }
-
-.cls4 {
-  letter-spacing: -0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
 }
-
-.cls5 {
-  stroke-width: 3px;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
 }
-
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
 .cls5,
 .cls6,
 .cls7,
@@ -103,18 +216,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   fill: #788f9b;
 }
 
-.cls26 {
-  letter-spacing: 0em;
-}
-
-.cls27 {
-  letter-spacing: -0.03em;
-}
-
-.cls28 {
-  letter-spacing: -0.01em;
-}
-
 .cls7 {
   stroke-dasharray: 0 0 0.5 1;
   stroke-width: 0.5px;
@@ -141,11 +242,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls16 {
   stroke-width: 0.71px;
 }
-
-.cls29 {
-  letter-spacing: -0.05em;
-}
-
 .cls11 {
   stroke-width: 0.9px;
 }
@@ -156,21 +252,12 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .cls23,
 .cls25 {
-  font-family: Montserrat-Regular, Montserrat;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .cls12 {
   stroke-dasharray: 0 0 0 0 0 0 0 0 0 0 2.5 1.25;
 }
-
-.cls30 {
-  letter-spacing: 0em;
-}
-
-.cls31 {
-  letter-spacing: 0em;
-}
-
 .cls18 {
   fill: #15242d;
 }
@@ -186,49 +273,12 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls20 {
   stroke-width: 0.75px;
 }
-
-.cls32 {
-  letter-spacing: 0em;
-}
-
 .cls19 {
   fill: rgba(187, 212, 226, 0.2);
 }
 
-.cls33 {
-  letter-spacing: -0.06em;
-}
-
-.cls34 {
-  letter-spacing: 0em;
-}
-
-.cls35 {
-  letter-spacing: -0.03em;
-}
-
-.cls36 {
-  letter-spacing: 0em;
-}
-
-.cls37 {
-  letter-spacing: -0.02em;
-}
-
 .cls13 {
   stroke-dasharray: 0 0 0 0 0 0 5 2.5;
-}
-
-.cls38 {
-  letter-spacing: 0.01em;
-}
-
-.cls39 {
-  letter-spacing: 0em;
-}
-
-.cls40 {
-  letter-spacing: 0em;
 }
 
 .cls41 {
@@ -239,63 +289,23 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   opacity: 0.5;
 }
 
-.cls43 {
-  letter-spacing: -0.02em;
-}
-
-.cls44 {
-  letter-spacing: 0em;
-}
-
-.cls45 {
-  letter-spacing: 0em;
-}
-
-.cls46 {
-  letter-spacing: 0em;
-}
-
-.cls47 {
-  letter-spacing: -0.02em;
-}
-
-.cls48 {
-  isolation: isolate;
-}
-
-.cls49 {
-  letter-spacing: -0.02em;
-}
-
 .cls25 {
   font-size: 4px;
-}
-
-.cls50 {
-  letter-spacing: 0em;
-}
-
-.cls51 {
-  letter-spacing: -0.02em;
-}
-
-.cls52 {
-  letter-spacing: 0em;
-}
-
-.cls53 {
-  letter-spacing: -0.03em;
 }
 
 .cls16,
 .cls17 {
   fill: #bbd4e2;
 }
-
-.cls54 {
-  letter-spacing: -0.01em;
+.zoomOut {
+  cursor: pointer;
 }
 
-.cls55 {
-  letter-spacing: -0.01em;
+.zoomOutButton {
+  fill: var(--default-background-color);
+}
+
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
 }

--- a/love/src/components/Facility/Map/Levels/Level4.jsx
+++ b/love/src/components/Facility/Map/Levels/Level4.jsx
@@ -69,6 +69,14 @@ export default class Level4 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   getDevices() {
     const { manejadoraSblancaP04, manejadoraSlimpiaP04, vex03LowerP04, vex04CargaP04 } = this.props.HVACData;
 
@@ -446,6 +454,7 @@ export default class Level4 extends Component {
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -921,6 +930,16 @@ export default class Level4 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level4.jsx
+++ b/love/src/components/Facility/Map/Levels/Level4.jsx
@@ -787,99 +787,10 @@ export default class Level4 extends Component {
               <g className={styles.cls40}>
                 <text className={styles.cls17} transform="translate(330.36 92.23)">
                   <tspan className={styles.cls32} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.27" y="0">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls29} x="7.81" y="0">
-                    m
-                  </tspan>
-                  <tspan className={styles.cls28} x="14.18" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls20} x="17.81" y="0">
-                    r
-                  </tspan>
-                  <tspan x="20.16" y="0">
-                    a Main
-                  </tspan>
-                  <tspan className={styles.cls41} x="40.22" y="0">
-                    t
-                  </tspan>
-                  <tspan x="42.54" y="0">
-                    ena
-                  </tspan>
-                  <tspan className={styles.cls29} x="53.77" y="0">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls24} x="57.84" y="0">
-                    c
-                  </tspan>
-                  <tspan x="61.16" y="0">
-                    e
+                    Camera Maintenance
                   </tspan>
                   <tspan className={styles.cls32} x="23.71" y="7.2">
-                    H
-                  </tspan>
-                  <tspan className={styles.cls26} x="28.54" y="7.2">
-                    V
-                  </tspan>
-                  <tspan className={styles.cls42} x="32.52" y="7.2">
-                    A
-                  </tspan>
-                  <tspan x="36.76" y="7.2">
-                    C
-                  </tspan>
-                  <tspan x="23.28" y="14.4">
-                    Room
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(330.36 92.23)">
-                  <tspan className={styles.cls32} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan x="4.27" y="0">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls29} x="7.81" y="0">
-                    m
-                  </tspan>
-                  <tspan className={styles.cls28} x="14.18" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls20} x="17.81" y="0">
-                    r
-                  </tspan>
-                  <tspan x="20.16" y="0">
-                    a Main
-                  </tspan>
-                  <tspan className={styles.cls41} x="40.22" y="0">
-                    t
-                  </tspan>
-                  <tspan x="42.54" y="0">
-                    ena
-                  </tspan>
-                  <tspan className={styles.cls29} x="53.77" y="0">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls24} x="57.84" y="0">
-                    c
-                  </tspan>
-                  <tspan x="61.16" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls32} x="23.71" y="7.2">
-                    H
-                  </tspan>
-                  <tspan className={styles.cls26} x="28.54" y="7.2">
-                    V
-                  </tspan>
-                  <tspan className={styles.cls42} x="32.52" y="7.2">
-                    A
-                  </tspan>
-                  <tspan x="36.76" y="7.2">
-                    C
+                    HVAC
                   </tspan>
                   <tspan x="23.28" y="14.4">
                     Room
@@ -889,258 +800,47 @@ export default class Level4 extends Component {
               <g className={styles.cls40}>
                 <text className={styles.cls17} transform="translate(636.81 167.58)">
                   <tspan x="0" y="0">
-                    Open{' '}
-                  </tspan>
-                  <tspan className={styles.cls41} x="18.36" y="0">
-                    t
-                  </tspan>
-                  <tspan x="20.68" y="0">
-                    o
+                    Open to
                   </tspan>
                   <tspan x="-15.99" y="7.2">
-                    Main
-                  </tspan>
-                  <tspan className={styles.cls41} x="-1.05" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="1.27" y="7.2">
-                    ena
-                  </tspan>
-                  <tspan className={styles.cls43} x="12.5" y="7.2">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls20} x="16.57" y="7.2">
-                    c
-                  </tspan>
-                  <tspan x="19.9" y="7.2">
-                    e Floor
+                    Maintenance Floor
                   </tspan>
                   <tspan x="3.1" y="14.4">
-                    bel
-                  </tspan>
-                  <tspan className={styles.cls22} x="12.4" y="14.4">
-                    o
-                  </tspan>
-                  <tspan x="16.07" y="14.4">
-                    w
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(636.81 167.58)">
-                  <tspan x="0" y="0">
-                    Open{' '}
-                  </tspan>
-                  <tspan className={styles.cls41} x="18.36" y="0">
-                    t
-                  </tspan>
-                  <tspan x="20.68" y="0">
-                    o
-                  </tspan>
-                  <tspan x="-15.99" y="7.2">
-                    Main
-                  </tspan>
-                  <tspan className={styles.cls41} x="-1.05" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="1.27" y="7.2">
-                    ena
-                  </tspan>
-                  <tspan className={styles.cls43} x="12.5" y="7.2">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls20} x="16.57" y="7.2">
-                    c
-                  </tspan>
-                  <tspan x="19.9" y="7.2">
-                    e Floor
-                  </tspan>
-                  <tspan x="3.1" y="14.4">
-                    bel
-                  </tspan>
-                  <tspan className={styles.cls22} x="12.4" y="14.4">
-                    o
-                  </tspan>
-                  <tspan x="16.07" y="14.4">
-                    w
+                    below
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls17} transform="translate(461.56 98.46)">
                   <tspan x="0" y="0">
-                    No
-                  </tspan>
-                  <tspan className={styles.cls35} x="8.64" y="0">
-                    r
-                  </tspan>
-                  <tspan x="11.14" y="0">
-                    th
+                    North
                   </tspan>
                   <tspan x="-8.52" y="7.2">
-                    M
-                  </tspan>
-                  <tspan className={styles.cls15} x="-2.79" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x=".8" y="7.2">
-                    zzanin
-                  </tspan>
-                  <tspan className={styles.cls2} x="20.21" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="22.53" y="7.2">
-                    e
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(461.56 98.46)">
-                  <tspan x="0" y="0">
-                    No
-                  </tspan>
-                  <tspan className={styles.cls35} x="8.64" y="0">
-                    r
-                  </tspan>
-                  <tspan x="11.14" y="0">
-                    th
-                  </tspan>
-                  <tspan x="-8.52" y="7.2">
-                    M
-                  </tspan>
-                  <tspan className={styles.cls15} x="-2.79" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x=".8" y="7.2">
-                    zzanin
-                  </tspan>
-                  <tspan className={styles.cls2} x="20.21" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="22.53" y="7.2">
-                    e
+                    Mezzanine
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls17} transform="translate(756.12 128.11)">
                   <tspan x="0" y="0">
-                    South M
-                  </tspan>
-                  <tspan className={styles.cls45} x="25.29" y="0">
-                    e
-                  </tspan>
-                  <tspan x="28.88" y="0">
-                    zanni
-                  </tspan>
-                  <tspan className={styles.cls43} x="45.23" y="0">
-                    n
-                  </tspan>
-                  <tspan x="49.3" y="0">
-                    e
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(756.12 128.11)">
-                  <tspan x="0" y="0">
-                    South M
-                  </tspan>
-                  <tspan className={styles.cls45} x="25.29" y="0">
-                    e
-                  </tspan>
-                  <tspan x="28.88" y="0">
-                    zanni
-                  </tspan>
-                  <tspan className={styles.cls43} x="45.23" y="0">
-                    n
-                  </tspan>
-                  <tspan x="49.3" y="0">
-                    e
+                    South Mezannine
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls17} transform="translate(366.07 197.01)">
                   <tspan x="0" y="0">
-                    8
-                  </tspan>
-                  <tspan className={styles.cls39} x="3.83" y="0">
-                    0
-                  </tspan>
-                  <tspan className={styles.cls44} x="7.85" y="0">
-                    -
-                  </tspan>
-                  <tspan className={styles.cls27} x="9.95" y="0">
-                    T
-                  </tspan>
-                  <tspan x="13.06" y="0">
-                    on
+                    80-Ton
                   </tspan>
                   <tspan x="-8.33" y="7.2">
-                    Plat
-                  </tspan>
-                  <tspan className={styles.cls24} x="3.56" y="7.2">
-                    f
-                  </tspan>
-                  <tspan className={styles.cls28} x="5.54" y="7.2">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls32} x="9.31" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls25} x="11.66" y="7.2">
-                    m Lift
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(366.07 197.01)">
-                  <tspan x="0" y="0">
-                    8
-                  </tspan>
-                  <tspan className={styles.cls39} x="3.83" y="0">
-                    0
-                  </tspan>
-                  <tspan className={styles.cls44} x="7.85" y="0">
-                    -
-                  </tspan>
-                  <tspan className={styles.cls27} x="9.95" y="0">
-                    T
-                  </tspan>
-                  <tspan x="13.06" y="0">
-                    on
-                  </tspan>
-                  <tspan x="-8.33" y="7.2">
-                    Plat
-                  </tspan>
-                  <tspan className={styles.cls24} x="3.56" y="7.2">
-                    f
-                  </tspan>
-                  <tspan className={styles.cls28} x="5.54" y="7.2">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls32} x="9.31" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls25} x="11.66" y="7.2">
-                    m Lift
+                    Platform Lift
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls17} transform="translate(657.85 296.73)">
                   <tspan x="0" y="0">
-                    De
-                  </tspan>
-                  <tspan className={styles.cls38} x="8.58" y="0">
-                    c
-                  </tspan>
-                  <tspan x="11.91" y="0">
-                    k
-                  </tspan>
-                </text>
-                <text className={styles.cls17} transform="translate(657.85 296.73)">
-                  <tspan x="0" y="0">
-                    De
-                  </tspan>
-                  <tspan className={styles.cls38} x="8.58" y="0">
-                    c
-                  </tspan>
-                  <tspan x="11.91" y="0">
-                    k
+                    Deck
                   </tspan>
                 </text>
               </g>
@@ -1149,45 +849,14 @@ export default class Level4 extends Component {
               <g className={styles.cls40}>
                 <text className={styles.cls19} transform="translate(774.92 59.94)">
                   <tspan className={styles.cls23} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    et Shaft
-                  </tspan>
-                </text>
-                <text className={styles.cls19} transform="translate(774.92 59.94)">
-                  <tspan className={styles.cls23} x="0" y="0">
-                    W
-                  </tspan>
-                  <tspan x="4.22" y="0">
-                    et Shaft
+                    Wet Shaft
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls19} transform="translate(802.06 92.28)">
                   <tspan x="0" y="0">
-                    D
-                  </tspan>
-                  <tspan className={styles.cls31} x="3.3" y="0">
-                    r
-                  </tspan>
-                  <tspan x="4.97" y="0">
-                    y
-                  </tspan>
-                  <tspan x="-1.69" y="4.8">
-                    Shaft
-                  </tspan>
-                </text>
-                <text className={styles.cls19} transform="translate(802.06 92.28)">
-                  <tspan x="0" y="0">
-                    D
-                  </tspan>
-                  <tspan className={styles.cls31} x="3.3" y="0">
-                    r
-                  </tspan>
-                  <tspan x="4.97" y="0">
-                    y
+                    Dry
                   </tspan>
                   <tspan x="-1.69" y="4.8">
                     Shaft
@@ -1197,96 +866,21 @@ export default class Level4 extends Component {
               <g className={styles.cls40}>
                 <text className={styles.cls19} transform="translate(774.48 87.54)">
                   <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls21} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls33} x="8.16" y="0">
-                    . 1
-                  </tspan>
-                </text>
-                <text className={styles.cls19} transform="translate(774.48 87.54)">
-                  <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls21} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls33} x="8.16" y="0">
-                    . 1
+                    Elev. 1
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls19} transform="translate(614.37 53.07)">
                   <tspan className={styles.cls38} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan className={styles.cls37} x="2.84" y="0">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls1} x="5.2" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls30} x="6.79" y="0">
-                    w
-                  </tspan>
-                  <tspan x="10.24" y="0">
-                    alk
-                  </tspan>
-                </text>
-                <text className={styles.cls19} transform="translate(614.37 53.07)">
-                  <tspan className={styles.cls38} x="0" y="0">
-                    C
-                  </tspan>
-                  <tspan className={styles.cls37} x="2.84" y="0">
-                    a
-                  </tspan>
-                  <tspan className={styles.cls1} x="5.2" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls30} x="6.79" y="0">
-                    w
-                  </tspan>
-                  <tspan x="10.24" y="0">
-                    alk
+                    Catwalk
                   </tspan>
                 </text>
               </g>
               <g className={styles.cls40}>
                 <text className={styles.cls19} transform="translate(279.43 50.65)">
                   <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls21} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls33} x="8.16" y="0">
-                    . 2
-                  </tspan>
-                </text>
-                <text className={styles.cls19} transform="translate(279.43 50.65)">
-                  <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls21} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan className={styles.cls33} x="8.16" y="0">
-                    . 2
+                    Elev. 2
                   </tspan>
                 </text>
               </g>

--- a/love/src/components/Facility/Map/Levels/Level4.module.css
+++ b/love/src/components/Facility/Map/Levels/Level4.module.css
@@ -17,12 +17,138 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-.cls1 {
-  letter-spacing: 0.01em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
 }
-
-.cls2 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
 }
 
 .cls3 {
@@ -89,18 +215,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   fill: #788f9b;
 }
 
-.cls20 {
-  letter-spacing: 0em;
-}
-
-.cls21 {
-  letter-spacing: 0.03em;
-}
-
-.cls22 {
-  letter-spacing: 0.01em;
-}
-
 .cls5,
 .cls7,
 .cls8,
@@ -119,28 +233,18 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls12 {
   stroke-width: 0.71px;
 }
-
-.cls23 {
-  letter-spacing: 0.05em;
-}
-
 .cls17 {
   font-size: 6px;
 }
 
 .cls17,
 .cls19 {
-  font-family: MontserratRegular, Montserrat;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .cls8 {
   stroke-dasharray: 0 0 0 0 0 0 0 0 0 0 2.5 1.25;
 }
-
-.cls24 {
-  letter-spacing: 0em;
-}
-
 .cls14 {
   stroke-width: 0.75px;
 }
@@ -149,49 +253,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls18 {
   stroke-miterlimit: 10;
 }
-
-.cls25 {
-  letter-spacing: 0em;
-}
-
-.cls26 {
-  letter-spacing: 0.04em;
-}
-
-.cls27 {
-  letter-spacing: 0.06em;
-}
-
-.cls28 {
-  letter-spacing: 0em;
-}
-
-.cls29 {
-  letter-spacing: 0em;
-}
-
-.cls30 {
-  letter-spacing: 0.02em;
-}
-
-.cls31 {
-  letter-spacing: 0.01em;
-}
-
-.cls32 {
-  letterspacing: 0em;
-}
-
-.cls33 {
-  letterspacing: 0em;
-}
-
 .cls34 {
   opacity: 0.2;
-}
-
-.cls35 {
-  letter-spacing: 0.01em;
 }
 
 .cls11 {
@@ -202,47 +265,23 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   opacity: 0.5;
 }
 
-.cls37 {
-  letter-spacing: 0em;
-}
-
-.cls38 {
-  letter-spacing: 0em;
-}
-
-.cls39 {
-  letter-spacing: 0em;
-}
-
-.cls40 {
-  isolation: isolate;
-}
-
-.cls41 {
-  letter-spacing: 0.02em;
-}
-
 .cls19 {
   font-size: 4px;
-}
-
-.cls42 {
-  letter-spacing: 0em;
-}
-
-.cls43 {
-  letter-spacing: 0em;
-}
-
-.cls44 {
-  letter-spacing: 0.03em;
 }
 
 .cls12,
 .cls13 {
   fill: #bbd4e2;
 }
+.zoomOut {
+  cursor: pointer;
+}
 
-.cls45 {
-  letter-spacing: 0em;
+.zoomOutButton {
+  fill: var(--default-background-color);
+}
+
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
 }

--- a/love/src/components/Facility/Map/Levels/Level5.jsx
+++ b/love/src/components/Facility/Map/Levels/Level5.jsx
@@ -69,6 +69,14 @@ export default class Level5 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   dynaleneStatetoText(ctx) {
     switch (ctx) {
       case 0:
@@ -1269,6 +1277,7 @@ export default class Level5 extends Component {
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -1781,6 +1790,16 @@ export default class Level5 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level5.module.css
+++ b/love/src/components/Facility/Map/Levels/Level5.module.css
@@ -17,24 +17,138 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-.cls1 {
-  letter-spacing: 0.01em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
 }
-
-.cls2 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
 }
-
-.cls3 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
 }
-
-.cls4 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
 }
-
-.cls5 {
-  letter-spacing: 0.03em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
 }
 
 .cls6 {
@@ -106,7 +220,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .cls7,
 .cls11 {
-  strokewidth: 0.71px;
+  stroke-width: 0.71px;
 }
 
 .cls8,
@@ -120,7 +234,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .cls16,
 .cls17 {
-  font-family: MontserratRegular, Montserrat;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .cls9,
@@ -133,11 +247,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls20 {
   stroke: #788f9b;
 }
-
-.cls21 {
-  letter-spacing: 0em;
-}
-
 .cls13 {
   fill: #29363e;
 }
@@ -146,66 +255,10 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   stroke-width: 0.75px;
 }
 
-.cls22 {
-  letter-spacing: 0em;
-}
-
-.cls23 {
-  letter-spacing: 0.06em;
-}
-
-.cls24 {
-  letter-spacing: 0em;
-}
-
-.cls25 {
-  letter-spacing: 0em;
-}
-
-.cls26 {
-  letter-spacing: 0em;
-}
-
-.cls27 {
-  letter-spacing: 0em;
-}
-
 .cls28 {
   opacity: 0.5;
 }
 
-.cls29 {
-  letter-spacing: 0.02em;
-}
-
-.cls30 {
-  letter-spacing: 0em;
-}
-
-.cls31 {
-  letter-spacing: 0em;
-}
-
-.cls32 {
-  isolation: isolate;
-}
-
 .cls17 {
   font-size: 4px;
-}
-
-.cls33 {
-  letter-spacing: 0em;
-}
-
-.cls34 {
-  letter-spacing: 0.03em;
-}
-
-.cls35 {
-  letter-spacing: 0.01em;
-}
-
-.cls36 {
-  letter-spacing: 0.01em;
 }

--- a/love/src/components/Facility/Map/Levels/Level6.jsx
+++ b/love/src/components/Facility/Map/Levels/Level6.jsx
@@ -69,11 +69,20 @@ export default class Level6 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   getDevices() {
     return <React.Fragment></React.Fragment>;
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -413,6 +422,16 @@ export default class Level6 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level6.jsx
+++ b/love/src/components/Facility/Map/Levels/Level6.jsx
@@ -361,66 +361,18 @@ export default class Level6 extends Component {
               <g class="cls-27">
                 <text className={styles.cls19} transform="translate(155.37 149.4)">
                   <tspan className={styles.cls14} x="0" y="0">
-                    P
-                  </tspan>
-                  <tspan x="4.17" y="0">
-                    ier
+                    Pier
                   </tspan>
                   <tspan x="-22.22" y="7.2">
-                    In
-                  </tspan>
-                  <tspan className={styles.cls28} x="-16.35" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="-14.03" y="7.2">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls24} x="-10.4" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls23} x="-8.05" y="7.2">
-                    m
-                  </tspan>
-                  <tspan x="-1.67" y="7.2">
-                    edia
-                  </tspan>
-                  <tspan className={styles.cls3} x="11.18" y="7.2">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls22} x="13.5" y="7.2">
-                    e Floor
+                    Intermediate Floor
                   </tspan>
                 </text>
                 <text className={styles.cls19} transform="translate(155.37 149.4)">
                   <tspan className={styles.cls14} x="0" y="0">
-                    P
-                  </tspan>
-                  <tspan x="4.17" y="0">
-                    ier
+                    Pier
                   </tspan>
                   <tspan x="-22.22" y="7.2">
-                    In
-                  </tspan>
-                  <tspan className={styles.cls28} x="-16.35" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="-14.03" y="7.2">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls24} x="-10.4" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls23} x="-8.05" y="7.2">
-                    m
-                  </tspan>
-                  <tspan x="-1.67" y="7.2">
-                    edia
-                  </tspan>
-                  <tspan className={styles.cls3} x="11.18" y="7.2">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls22} x="13.5" y="7.2">
-                    e Floor
+                    Intermediate Floor
                   </tspan>
                 </text>
               </g>
@@ -432,99 +384,25 @@ export default class Level6 extends Component {
                     Roof
                   </tspan>
                 </text>
-                <text className={styles.cls20} transform="translate(340.05 76.62)">
-                  <tspan x="0" y="0">
-                    Roof
-                  </tspan>
-                </text>
               </g>
               <g class="cls-27">
                 <text className={styles.cls20} transform="translate(212.71 193.75)">
                   <tspan x="0" y="0">
-                    Ha
-                  </tspan>
-                  <tspan className={styles.cls2} x="5.61" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls26} x="7.16" y="0">
-                    c
-                  </tspan>
-                  <tspan x="9.38" y="0">
-                    h
-                  </tspan>
-                </text>
-                <text className={styles.cls20} transform="translate(212.71 193.75)">
-                  <tspan x="0" y="0">
-                    Ha
-                  </tspan>
-                  <tspan className={styles.cls2} x="5.61" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls26} x="7.16" y="0">
-                    c
-                  </tspan>
-                  <tspan x="9.38" y="0">
-                    h
+                    Hatch
                   </tspan>
                 </text>
               </g>
               <g class="cls-27">
                 <text className={styles.cls20} transform="translate(206.67 84.73)">
                   <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls15} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan x="8.16" y="0">
-                    . 3
-                  </tspan>
-                </text>
-                <text className={styles.cls20} transform="translate(206.67 84.73)">
-                  <tspan x="0" y="0">
-                    El
-                  </tspan>
-                  <tspan className={styles.cls1} x="3.75" y="0">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls15} x="6.13" y="0">
-                    v
-                  </tspan>
-                  <tspan x="8.16" y="0">
-                    . 3
+                    Elev. 3
                   </tspan>
                 </text>
               </g>
               <g class="cls-27">
                 <text className={styles.cls20} transform="translate(300.74 111.41)">
                   <tspan x="0" y="0">
-                    Ha
-                  </tspan>
-                  <tspan className={styles.cls2} x="5.61" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls26} x="7.16" y="0">
-                    c
-                  </tspan>
-                  <tspan x="9.38" y="0">
-                    h
-                  </tspan>
-                </text>
-                <text className={styles.cls20} transform="translate(300.74 111.41)">
-                  <tspan x="0" y="0">
-                    Ha
-                  </tspan>
-                  <tspan className={styles.cls2} x="5.61" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls26} x="7.16" y="0">
-                    c
-                  </tspan>
-                  <tspan x="9.38" y="0">
-                    h
+                    Hatch
                   </tspan>
                 </text>
               </g>

--- a/love/src/components/Facility/Map/Levels/Level6.module.css
+++ b/love/src/components/Facility/Map/Levels/Level6.module.css
@@ -17,18 +17,139 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-.cls1 {
-  letter-spacing: 0.01em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
 }
-
-.cls2 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
 }
-
-.cls3 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
 }
-
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
 .cls4 {
   stroke-width: 3px;
 }
@@ -60,15 +181,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls11 {
   stroke-miterlimit: 10;
 }
-
-.cls14 {
-  letter-spacing: 0.02em;
-}
-
-.cls15 {
-  letter-spacing: 0.03em;
-}
-
 .cls5 {
   fill: rgba(187, 212, 226, 0.1);
 }
@@ -138,39 +250,19 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .cls19,
 .cls20 {
-  font-family: MontserratRegular, Montserrat;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .cls13 {
   stroke-width: 0.75px;
 }
 
-.cls22 {
-  letter-spacing: 0em;
-}
-
-.cls23 {
-  letter-spacing: 0em;
-}
-
-.cls24 {
-  letter-spacing: 0em;
-}
-
 .cls25 {
   opacity: 0.5;
 }
 
-.cls26 {
-  letter-spacing: 0em;
-}
-
 .cls27 {
   isolation: isolate;
-}
-
-.cls28 {
-  letter-spacing: 0.02em;
 }
 
 .cls20 {
@@ -179,4 +271,17 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .cls11 {
   stroke-width: 5.6px;
+}
+
+.zoomOut {
+  cursor: pointer;
+}
+
+.zoomOutButton {
+  fill: var(--default-background-color);
+}
+
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
 }

--- a/love/src/components/Facility/Map/Levels/Level7.jsx
+++ b/love/src/components/Facility/Map/Levels/Level7.jsx
@@ -157,66 +157,10 @@ export default class Level7 extends Component {
               <g className={styles.cls26}>
                 <text className={styles.cls18} transform="translate(155.37 149.4)">
                   <tspan className={styles.cls13} x="0" y="0">
-                    P
-                  </tspan>
-                  <tspan x="4.17" y="0">
-                    ier
+                    Pier
                   </tspan>
                   <tspan x="-22.22" y="7.2">
-                    In
-                  </tspan>
-                  <tspan className={styles.cls27} x="-16.35" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="-14.03" y="7.2">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls23} x="-10.4" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls22} x="-8.05" y="7.2">
-                    m
-                  </tspan>
-                  <tspan x="-1.67" y="7.2">
-                    edia
-                  </tspan>
-                  <tspan className={styles.cls3} x="11.18" y="7.2">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls21} x="13.5" y="7.2">
-                    e Floor
-                  </tspan>
-                </text>
-                <text className={styles.cls18} transform="translate(155.37 149.4)">
-                  <tspan className={styles.cls13} x="0" y="0">
-                    P
-                  </tspan>
-                  <tspan x="4.17" y="0">
-                    ier
-                  </tspan>
-                  <tspan x="-22.22" y="7.2">
-                    In
-                  </tspan>
-                  <tspan className={styles.cls27} x="-16.35" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="-14.03" y="7.2">
-                    e
-                  </tspan>
-                  <tspan className={styles.cls23} x="-10.4" y="7.2">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls22} x="-8.05" y="7.2">
-                    m
-                  </tspan>
-                  <tspan x="-1.67" y="7.2">
-                    edia
-                  </tspan>
-                  <tspan className={styles.cls3} x="11.18" y="7.2">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls21} x="13.5" y="7.2">
-                    e Floor
+                    Intermediate Floor
                   </tspan>
                 </text>
               </g>
@@ -225,30 +169,7 @@ export default class Level7 extends Component {
               <g className={styles.cls26}>
                 <text className={styles.cls19} transform="translate(212.71 193.75)">
                   <tspan x="0" y="0">
-                    Ha
-                  </tspan>
-                  <tspan className={styles.cls2} x="5.61" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls25} x="7.16" y="0">
-                    c
-                  </tspan>
-                  <tspan x="9.38" y="0">
-                    h
-                  </tspan>
-                </text>
-                <text className={styles.cls19} transform="translate(212.71 193.75)">
-                  <tspan x="0" y="0">
-                    Ha
-                  </tspan>
-                  <tspan className={styles.cls2} x="5.61" y="0">
-                    t
-                  </tspan>
-                  <tspan className={styles.cls25} x="7.16" y="0">
-                    c
-                  </tspan>
-                  <tspan x="9.38" y="0">
-                    h
+                    Hatch
                   </tspan>
                 </text>
               </g>
@@ -266,30 +187,7 @@ export default class Level7 extends Component {
             <g className={styles.cls26}>
               <text className={styles.cls19} transform="translate(206.67 84.73)">
                 <tspan x="0" y="0">
-                  El
-                </tspan>
-                <tspan className={styles.cls1} x="3.75" y="0">
-                  e
-                </tspan>
-                <tspan className={styles.cls14} x="6.13" y="0">
-                  v
-                </tspan>
-                <tspan x="8.16" y="0">
-                  . 3
-                </tspan>
-              </text>
-              <text className={styles.cls19} transform="translate(206.67 84.73)">
-                <tspan x="0" y="0">
-                  El
-                </tspan>
-                <tspan className={styles.cls1} x="3.75" y="0">
-                  e
-                </tspan>
-                <tspan className={styles.cls14} x="6.13" y="0">
-                  v
-                </tspan>
-                <tspan x="8.16" y="0">
-                  . 3
+                  Elev. 3
                 </tspan>
               </text>
             </g>

--- a/love/src/components/Facility/Map/Levels/Level7.jsx
+++ b/love/src/components/Facility/Map/Levels/Level7.jsx
@@ -69,11 +69,20 @@ export default class Level7 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   getDevices() {
     return <React.Fragment></React.Fragment>;
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -279,6 +288,16 @@ export default class Level7 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level7.module.css
+++ b/love/src/components/Facility/Map/Levels/Level7.module.css
@@ -17,16 +17,138 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-.cls1 {
-  letter-spacing: 0.01em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
 }
-
-.cls2 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
 }
-
-.cls3 {
-  letter-spacing: 0.02em;
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
 }
 
 .cls4 {
@@ -58,14 +180,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .cls12,
 .cls10 {
   stroke-miterlimit: 10;
-}
-
-.cls13 {
-  letter-spacing: 0.02em;
-}
-
-.cls14 {
-  letter-spacing: 0.03em;
 }
 
 .cls5 {
@@ -128,7 +242,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .cls18,
 .cls19 {
-  font-family: MontserratRegular, Montserrat;
+  font-family: 'Montserrat', sans-serif;
 }
 
 .cls11,
@@ -136,39 +250,23 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   stroke: #788f9b;
   stroke-width: 0.75px;
 }
-
-.cls21 {
-  letter-spacing: 0em;
-}
-
-.cls22 {
-  letter-spacing: 0em;
-}
-
-.cls23 {
-  letter-spacing: 0em;
-}
-
-.cls24 {
-  opacity: 0.5;
-}
-
-.cls25 {
-  letter-spacing: 0em;
-}
-
-.cls26 {
-  isolation: isolate;
-}
-
-.cls27 {
-  letter-spacing: 0.02em;
-}
-
 .cls19 {
   font-size: 4px;
 }
 
 .cls10 {
   stroke-width: 5.6px;
+}
+
+.zoomOut {
+  cursor: pointer;
+}
+
+.zoomOutButton {
+  fill: var(--default-background-color);
+}
+
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
 }

--- a/love/src/components/Facility/Map/Levels/Level8.jsx
+++ b/love/src/components/Facility/Map/Levels/Level8.jsx
@@ -69,11 +69,20 @@ export default class Level8 extends Component {
     this.props.savePos(transformData);
   };
 
+  zoomOut = () => {
+    const overlayId = '#' + this.overlayId;
+
+    const zoom = d3.zoom().scaleExtent([1, 8]).on('zoom', this.zoomMap);
+
+    d3.select(overlayId).call(zoom.transform, d3.zoomIdentity.translate(0, 0).scale(1)).call(zoom);
+  };
+
   getDevices() {
     return <React.Fragment></React.Fragment>;
   }
 
   render() {
+    const zoomLevel = this.props.transformData.k;
     return (
       <React.Fragment>
         <g id={this.mapId}>
@@ -1341,6 +1350,16 @@ export default class Level8 extends Component {
         <rect id={this.overlayId} pointerEvents="all" fill="none" width="882.42" height="461.23" />
 
         <g id={this.deviceId}>{!this.props.hideHVAC && this.getDevices()}</g>
+        {zoomLevel > 1 && (
+          <g className={styles.zoomOut} transform="translate(808 10)">
+            <rect onClick={this.zoomOut} className={styles.zoomOutButton} width="64" height="21" rx="4" />
+            <text onClick={this.zoomOut} className={styles.zoomOutText}>
+              <tspan x="10" y="13">
+                Zoom out
+              </tspan>
+            </text>
+          </g>
+        )}
       </React.Fragment>
     );
   }

--- a/love/src/components/Facility/Map/Levels/Level8.jsx
+++ b/love/src/components/Facility/Map/Levels/Level8.jsx
@@ -1133,30 +1133,7 @@ export default class Level8 extends Component {
               <g className={styles.cls23}>
                 <text className={styles.cls13} transform="translate(143.45 126.27)">
                   <tspan className={styles.cls19} x="0" y="0">
-                    T
-                  </tspan>
-                  <tspan x="3.11" y="0">
-                    eles
-                  </tspan>
-                  <tspan className={styles.cls15} x="14.91" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls20} x="18.23" y="0">
-                    ope
-                  </tspan>
-                </text>
-                <text className={styles.cls13} transform="translate(143.45 126.27)">
-                  <tspan className={styles.cls19} x="0" y="0">
-                    T
-                  </tspan>
-                  <tspan x="3.11" y="0">
-                    eles
-                  </tspan>
-                  <tspan className={styles.cls15} x="14.91" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls20} x="18.23" y="0">
-                    ope
+                    Telescope
                   </tspan>
                 </text>
               </g>
@@ -1167,48 +1144,13 @@ export default class Level8 extends Component {
               <g className={styles.cls23}>
                 <text className={styles.cls13} transform="translate(30.29 189.03)">
                   <tspan x="0" y="0">
-                    Do
-                  </tspan>
-                  <tspan className={styles.cls21} x="8.72" y="0">
-                    m
-                  </tspan>
-                  <tspan x="15.1" y="0">
-                    e
+                    Dome
                   </tspan>
                   <tspan x="1.69" y="7.2">
                     Floor
                   </tspan>
                   <tspan x=".23" y="14.4">
-                    bel
-                  </tspan>
-                  <tspan className={styles.cls16} x="9.54" y="14.4">
-                    o
-                  </tspan>
-                  <tspan x="13.21" y="14.4">
-                    w
-                  </tspan>
-                </text>
-                <text className={styles.cls13} transform="translate(30.29 189.03)">
-                  <tspan x="0" y="0">
-                    Do
-                  </tspan>
-                  <tspan className={styles.cls21} x="8.72" y="0">
-                    m
-                  </tspan>
-                  <tspan x="15.1" y="0">
-                    e
-                  </tspan>
-                  <tspan x="1.69" y="7.2">
-                    Floor
-                  </tspan>
-                  <tspan x=".23" y="14.4">
-                    bel
-                  </tspan>
-                  <tspan className={styles.cls16} x="9.54" y="14.4">
-                    o
-                  </tspan>
-                  <tspan x="13.21" y="14.4">
-                    w
+                    below
                   </tspan>
                 </text>
               </g>
@@ -1219,96 +1161,13 @@ export default class Level8 extends Component {
               <g className={styles.cls23}>
                 <text className={styles.cls13} transform="translate(262.36 215.63)">
                   <tspan className={styles.cls19} x="0" y="0">
-                    T
-                  </tspan>
-                  <tspan x="3.11" y="0">
-                    eles
-                  </tspan>
-                  <tspan className={styles.cls15} x="14.91" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls20} x="18.23" y="0">
-                    ope
+                    Telescope
                   </tspan>
                   <tspan x="-4.91" y="7.2">
-                    Main
-                  </tspan>
-                  <tspan className={styles.cls24} x="10.03" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="12.35" y="7.2">
-                    ena
-                  </tspan>
-                  <tspan className={styles.cls25} x="23.58" y="7.2">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls15} x="27.65" y="7.2">
-                    c
-                  </tspan>
-                  <tspan x="30.98" y="7.2">
-                    e
+                    Maintenance
                   </tspan>
                   <tspan x="1.66" y="14.4">
-                    Plat
-                  </tspan>
-                  <tspan className={styles.cls15} x="13.56" y="14.4">
-                    f
-                  </tspan>
-                  <tspan className={styles.cls20} x="15.54" y="14.4">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls22} x="19.3" y="14.4">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls18} x="21.66" y="14.4">
-                    m
-                  </tspan>
-                </text>
-                <text className={styles.cls13} transform="translate(262.36 215.63)">
-                  <tspan className={styles.cls19} x="0" y="0">
-                    T
-                  </tspan>
-                  <tspan x="3.11" y="0">
-                    eles
-                  </tspan>
-                  <tspan className={styles.cls15} x="14.91" y="0">
-                    c
-                  </tspan>
-                  <tspan className={styles.cls20} x="18.23" y="0">
-                    ope
-                  </tspan>
-                  <tspan x="-4.91" y="7.2">
-                    Main
-                  </tspan>
-                  <tspan className={styles.cls24} x="10.03" y="7.2">
-                    t
-                  </tspan>
-                  <tspan x="12.35" y="7.2">
-                    ena
-                  </tspan>
-                  <tspan className={styles.cls25} x="23.58" y="7.2">
-                    n
-                  </tspan>
-                  <tspan className={styles.cls15} x="27.65" y="7.2">
-                    c
-                  </tspan>
-                  <tspan x="30.98" y="7.2">
-                    e
-                  </tspan>
-                  <tspan x="1.66" y="14.4">
-                    Plat
-                  </tspan>
-                  <tspan className={styles.cls15} x="13.56" y="14.4">
-                    f
-                  </tspan>
-                  <tspan className={styles.cls20} x="15.54" y="14.4">
-                    o
-                  </tspan>
-                  <tspan className={styles.cls22} x="19.3" y="14.4">
-                    r
-                  </tspan>
-                  <tspan className={styles.cls18} x="21.66" y="14.4">
-                    m
+                    Platform
                   </tspan>
                 </text>
               </g>

--- a/love/src/components/Facility/Map/Levels/Level8.module.css
+++ b/love/src/components/Facility/Map/Levels/Level8.module.css
@@ -17,6 +17,140 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-Thin.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLight.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-Light.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-Black.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-Bold.ttf') format('truetype');
+}
+/* Italic fonts */
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 100;
+  src: url('../../../../fonts/Montserrat-ThinItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 200;
+  src: url('../../../../fonts/Montserrat-ExtraLightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 300;
+  src: url('../../../../fonts/Montserrat-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 400;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 500;
+  src: url('../../../../fonts/Montserrat-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 600;
+  src: url('../../../../fonts/Montserrat-SemiBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 700;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 800;
+  src: url('../../../../fonts/Montserrat-ExtraBoldItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: 900;
+  src: url('../../../../fonts/Montserrat-BlackItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: normal;
+  src: url('../../../../fonts/Montserrat-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Montserrat', sans-serif;
+  font-style: italic;
+  font-weight: bold;
+  src: url('../../../../fonts/Montserrat-BoldItalic.ttf') format('truetype');
+}
+
 .cls1 {
   fill: rgba(187, 212, 226, 0.1);
 }
@@ -74,14 +208,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   fill: #4e5d68;
 }
 
-.cls15 {
-  letter-spacing: 0em;
-}
-
-.cls16 {
-  letter-spacing: 0.01em;
-}
-
 .cls2,
 .cls3,
 .cls4,
@@ -108,7 +234,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 }
 
 .cls13 {
-  font-family: MontserratRegular, Montserrat;
+  font-family: 'Montserrat', sans-serif;
   font-size: 6px;
 }
 
@@ -137,38 +263,19 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   stroke-width: 0.75px;
 }
 
-.cls18 {
-  letter-spacing: 0em;
-}
-
-.cls19 {
-  letter-spacing: 0.06em;
-}
-
-.cls20 {
-  letter-spacing: 0em;
-}
-
-.cls21 {
-  letter-spacing: 0em;
-}
-
 .cls8 {
   stroke-dasharray: 0 0 0 0 0 0 5 2.5;
 }
 
-.cls22 {
-  letter-spacing: 0em;
+.zoomOut {
+  cursor: pointer;
 }
 
-.cls23 {
-  isolation: isolate;
+.zoomOutButton {
+  fill: var(--default-background-color);
 }
 
-.cls24 {
-  letter-spacing: 0.02em;
-}
-
-.cls25 {
-  letter-spacing: 0em;
+.zoomOutText {
+  fill: var(--default-font-color);
+  font-size: 0.6em;
 }

--- a/love/src/components/Facility/Map/Map.jsx
+++ b/love/src/components/Facility/Map/Map.jsx
@@ -19,8 +19,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component } from 'react';
 import styles from './Map.module.css';
-import { isArray } from 'lodash';
-
 import Level1 from './Levels/Level1.jsx';
 import Level2 from './Levels/Level2.jsx';
 import Level3 from './Levels/Level3.jsx';

--- a/love/src/components/Facility/Map/Map.jsx
+++ b/love/src/components/Facility/Map/Map.jsx
@@ -19,7 +19,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component } from 'react';
 import styles from './Map.module.css';
-import Badge from '../../GeneralPurpose/Badge/Badge';
+import { isArray } from 'lodash';
 
 import Level1 from './Levels/Level1.jsx';
 import Level2 from './Levels/Level2.jsx';
@@ -120,7 +120,9 @@ export default class Map extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { chiller01P01, chiller02P01, chiller03P01 } = this.props.HVACDataLevel1;
+    const { chiller01P01, chiller02P01, chiller03P01, status1, status2, warnings1, warnings2, errors1, errors2 } =
+      this.props.HVACDataLevel1;
+
     const { crack01P02, crack02P02 } = this.props.HVACDataLevel2;
     const { manejadoraSblancaP04, manejadoraSlimpiaP04, vex04CargaP04, vex03LowerP04 } = this.props.HVACDataLevel4;
     const {
@@ -162,10 +164,120 @@ export default class Map extends Component {
       chiller03P01.compresor01Alarmado ? chiller03P01.compresor01Alarmado.value : null,
       chiller03P01.compresor02Alarmado ? chiller03P01.compresor02Alarmado.value : null,
       chiller03P01.compresor03Alarmado ? chiller03P01.compresor03Alarmado.value : null,
+      status1.serviceRequired ? status1.serviceRequired.value : null,
+      errors1.powerSupplyFailureE400 ? errors1.powerSupplyFailureE400.value : null,
+      errors1.emergencyStopActivatedE401 ? errors1.emergencyStopActivatedE401.value : null,
+      errors1.highMotorTemperatureM1E402 ? errors1.highMotorTemperatureM1E402.value : null,
+      errors1.compressorDischargeTemperatureE403 ? errors1.compressorDischargeTemperatureE403.value : null,
+      errors1.startTemperatureLowE404 ? errors1.startTemperatureLowE404.value : null,
+      errors1.dischargeOverPressureE405 ? errors1.dischargeOverPressureE405.value : null,
+      errors1.linePressureSensorB1E406 ? errors1.linePressureSensorB1E406.value : null,
+      errors1.dischargePressureSensorB2E407 ? errors1.dischargePressureSensorB2E407.value : null,
+      errors1.dischargeTemperatureSensorR2E408 ? errors1.dischargeTemperatureSensorR2E408.value : null,
+      errors1.controllerHardwareE409 ? errors1.controllerHardwareE409.value : null,
+      errors1.coolingE410 ? errors1.coolingE410.value : null,
+      errors1.oilPressureLowE411 ? errors1.oilPressureLowE411.value : null,
+      errors1.externalFaultE412 ? errors1.externalFaultE412.value : null,
+      errors1.dryerE413 ? errors1.dryerE413.value : null,
+      errors1.condensateDrainE414 ? errors1.condensateDrainE414.value : null,
+      errors1.noPressureBuildUpE415 ? errors1.noPressureBuildUpE415.value : null,
+      errors1.heavyStartupE416 ? errors1.heavyStartupE416.value : null,
+      errors1.preAdjustmentVSDE500 ? errors1.preAdjustmentVSDE500.value : null,
+      errors1.preAdjustmentE501 ? errors1.preAdjustmentE501.value : null,
+      errors1.lockedVSDE502 ? errors1.lockedVSDE502.value : null,
+      errors1.writeFaultVSDE503 ? errors1.writeFaultVSDE503.value : null,
+      errors1.communicationVSDE504 ? errors1.communicationVSDE504.value : null,
+      errors1.stopPressedVSDE505 ? errors1.stopPressedVSDE505.value : null,
+      errors1.stopInputEMVSDE506 ? errors1.stopInputEMVSDE506.value : null,
+      errors1.readFaultVSDE507 ? errors1.readFaultVSDE507.value : null,
+      errors1.stopInputVSDEME508 ? errors1.stopInputVSDEME508.value : null,
+      errors1.seeVSDDisplayE509 ? errors1.seeVSDDisplayE509.value : null,
+      errors1.speedBelowMinLimitE510 ? errors1.speedBelowMinLimitE510.value : null,
+      warnings1.serviceDueA600 ? warnings1.serviceDueA600.value : null,
+      warnings1.dischargeOverPressureA601 ? warnings1.dischargeOverPressureA601.value : null,
+      warnings1.compressorDischargeTemperatureA602 ? warnings1.compressorDischargeTemperatureA602.value : null,
+      warnings1.linePressureHighA606 ? warnings1.linePressureHighA606.value : null,
+      warnings1.controllerBatteryEmptyA607 ? warnings1.controllerBatteryEmptyA607.value : null,
+      warnings1.dryerA608 ? warnings1.dryerA608?.value : null,
+      warnings1.condensateDrainA609 ? warnings1.condensateDrainA609.value : null,
+      warnings1.fineSeparatorA610 ? warnings1.fineSeparatorA610.value : null,
+      warnings1.airFilterA611 ? warnings1.airFilterA611.value : null,
+      warnings1.oilFilterA612 ? warnings1.oilFilterA612.value : null,
+      warnings1.oilLevelLowA613 ? warnings1.oilLevelLowA613.value : null,
+      warnings1.oilTemperatureHighA614 ? warnings1.oilTemperatureHighA614.value : null,
+      warnings1.externalWarningA615 ? warnings1.externalWarningA615.value : null,
+      warnings1.motorLuricationSystemA616 ? warnings1.motorLuricationSystemA616.value : null,
+      warnings1.input1A617 ? warnings1.input1A617.value : null,
+      warnings1.input2A618 ? warnings1.input2A618.value : null,
+      warnings1.input3A619 ? warnings1.input3A619.value : null,
+      warnings1.input4A620 ? warnings1.input4A620.value : null,
+      warnings1.input5A621 ? warnings1.input5A621.value : null,
+      warnings1.input6A622 ? warnings1.input6A622.value : null,
+      warnings1.fullSDCardA623 ? warnings1.fullSDCardA623.value : null,
+      warnings1.temperatureHighVSDA700 ? warnings1.temperatureHighVSDA700.value : null,
+      status2.serviceRequired ? status2.serviceRequired.value : null,
+      errors2.powerSupplyFailureE400 ? errors2.powerSupplyFailureE400.value : null,
+      errors2.emergencyStopActivatedE401 ? errors2.emergencyStopActivatedE401.value : null,
+      errors2.highMotorTemperatureM1E402 ? errors2.highMotorTemperatureM1E402.value : null,
+      errors2.compressorDischargeTemperatureE403 ? errors2.compressorDischargeTemperatureE403.value : null,
+      errors2.startTemperatureLowE404 ? errors2.startTemperatureLowE404.value : null,
+      errors2.dischargeOverPressureE405 ? errors2.dischargeOverPressureE405.value : null,
+      errors2.linePressureSensorB1E406 ? errors2.linePressureSensorB1E406.value : null,
+      errors2.dischargePressureSensorB2E407 ? errors2.dischargePressureSensorB2E407.value : null,
+      errors2.dischargeTemperatureSensorR2E408 ? errors2.dischargeTemperatureSensorR2E408.value : null,
+      errors2.controllerHardwareE409 ? errors2.controllerHardwareE409.value : null,
+      errors2.coolingE410 ? errors2.coolingE410.value : null,
+      errors2.oilPressureLowE411 ? errors2.oilPressureLowE411.value : null,
+      errors2.externalFaultE412 ? errors2.externalFaultE412.value : null,
+      errors2.dryerE413 ? errors2.dryerE413.value : null,
+      errors2.condensateDrainE414 ? errors2.condensateDrainE414.value : null,
+      errors2.noPressureBuildUpE415 ? errors2.noPressureBuildUpE415.value : null,
+      errors2.heavyStartupE416 ? errors2.heavyStartupE416.value : null,
+      errors2.preAdjustmentVSDE500 ? errors2.preAdjustmentVSDE500.value : null,
+      errors2.preAdjustmentE501 ? errors2.preAdjustmentE501.value : null,
+      errors2.lockedVSDE502 ? errors2.lockedVSDE502.value : null,
+      errors2.writeFaultVSDE503 ? errors2.writeFaultVSDE503.value : null,
+      errors2.communicationVSDE504 ? errors2.communicationVSDE504.value : null,
+      errors2.stopPressedVSDE505 ? errors2.stopPressedVSDE505.value : null,
+      errors2.stopInputEMVSDE506 ? errors2.stopInputEMVSDE506.value : null,
+      errors2.readFaultVSDE507 ? errors2.readFaultVSDE507.value : null,
+      errors2.stopInputVSDEME508 ? errors2.stopInputVSDEME508.value : null,
+      errors2.seeVSDDisplayE509 ? errors2.seeVSDDisplayE509.value : null,
+      errors2.speedBelowMinLimitE510 ? errors2.speedBelowMinLimitE510.value : null,
+      warnings2.serviceDueA600 ? warnings2.serviceDueA600.value : null,
+      warnings2.dischargeOverPressureA601 ? warnings2.dischargeOverPressureA601.value : null,
+      warnings2.compressorDischargeTemperatureA602 ? warnings2.compressorDischargeTemperatureA602.value : null,
+      warnings2.linePressureHighA606 ? warnings2.linePressureHighA606.value : null,
+      warnings2.controllerBatteryEmptyA607 ? warnings2.controllerBatteryEmptyA607.value : null,
+      warnings2.dryerA608 ? warnings2.dryerA608?.value : null,
+      warnings2.condensateDrainA609 ? warnings2.condensateDrainA609.value : null,
+      warnings2.fineSeparatorA610 ? warnings2.fineSeparatorA610.value : null,
+      warnings2.airFilterA611 ? warnings2.airFilterA611.value : null,
+      warnings2.oilFilterA612 ? warnings2.oilFilterA612.value : null,
+      warnings2.oilLevelLowA613 ? warnings2.oilLevelLowA613.value : null,
+      warnings2.oilTemperatureHighA614 ? warnings2.oilTemperatureHighA614.value : null,
+      warnings2.externalWarningA615 ? warnings2.externalWarningA615.value : null,
+      warnings2.motorLuricationSystemA616 ? warnings2.motorLuricationSystemA616.value : null,
+      warnings2.input1A617 ? warnings2.input1A617.value : null,
+      warnings2.input2A618 ? warnings2.input2A618.value : null,
+      warnings2.input3A619 ? warnings2.input3A619.value : null,
+      warnings2.input4A620 ? warnings2.input4A620.value : null,
+      warnings2.input5A621 ? warnings2.input5A621.value : null,
+      warnings2.input6A622 ? warnings2.input6A622.value : null,
+      warnings2.fullSDCardA623 ? warnings2.fullSDCardA623.value : null,
+      warnings2.temperatureHighVSDA700 ? warnings2.temperatureHighVSDA700.value : null,
     ];
 
     if (
-      (chiller01P01 || chiller02P01 || chiller03P01) &&
+      (chiller01P01 ||
+        chiller02P01 ||
+        chiller03P01 ||
+        errors1 ||
+        status1 ||
+        warnings1 ||
+        errors2 ||
+        status2 ||
+        warnings2) &&
       (prevHVACDataLevel1.chiller01P01?.alarmaGeneral?.value !== chiller01P01.alarmaGeneral?.value ||
         prevHVACDataLevel1.chiller01P01?.compresor01Alarmado?.value !== chiller01P01.compresor01Alarmado?.value ||
         prevHVACDataLevel1.chiller01P01?.compresor02Alarmado?.value !== chiller01P01.compresor02Alarmado?.value ||
@@ -177,7 +289,119 @@ export default class Map extends Component {
         prevHVACDataLevel1.chiller03P01?.alarmaGeneral?.value !== chiller03P01.alarmaGeneral?.value ||
         prevHVACDataLevel1.chiller03P01?.compresor01Alarmado?.value !== chiller03P01.compresor01Alarmado?.value ||
         prevHVACDataLevel1.chiller03P01?.compresor02Alarmado?.value !== chiller03P01.compresor02Alarmado?.value ||
-        prevHVACDataLevel1.chiller03P01?.compresor03Alarmado?.value !== chiller03P01.compresor03Alarmado?.value)
+        prevHVACDataLevel1.chiller03P01?.compresor03Alarmado?.value !== chiller03P01.compresor03Alarmado?.value ||
+        prevHVACDataLevel1.status1?.serviceRequired?.value != status1.serviceRequired?.value ||
+        prevHVACDataLevel1.errors1?.powerSupplyFailureE400?.value != errors1.powerSupplyFailureE400?.value ||
+        prevHVACDataLevel1.errors1?.emergencyStopActivatedE401?.value != errors1.emergencyStopActivatedE401?.value ||
+        prevHVACDataLevel1.errors1?.highMotorTemperatureM1E402?.value != errors1.highMotorTemperatureM1E402?.value ||
+        prevHVACDataLevel1.errors1?.compressorDischargeTemperatureE403?.value !=
+          errors1.compressorDischargeTemperatureE403?.value ||
+        prevHVACDataLevel1.errors1?.startTemperatureLowE404?.value != errors1.startTemperatureLowE404?.value ||
+        prevHVACDataLevel1.errors1?.dischargeOverPressureE405?.value != errors1.dischargeOverPressureE405?.value ||
+        prevHVACDataLevel1.errors1?.linePressureSensorB1E406?.value != errors1.linePressureSensorB1E406?.value ||
+        prevHVACDataLevel1.errors1?.dischargePressureSensorB2E407?.value !=
+          errors1.dischargePressureSensorB2E407?.value ||
+        prevHVACDataLevel1.errors1?.dischargeTemperatureSensorR2E408?.value !=
+          errors1.dischargeTemperatureSensorR2E408?.value ||
+        prevHVACDataLevel1.errors1?.controllerHardwareE409?.value != errors1.controllerHardwareE409?.value ||
+        prevHVACDataLevel1.errors1?.coolingE410?.value != errors1.coolingE410?.value ||
+        prevHVACDataLevel1.errors1?.oilPressureLowE411?.value != errors1.oilPressureLowE411?.value ||
+        prevHVACDataLevel1.errors1?.externalFaultE412?.value != errors1.externalFaultE412?.value ||
+        prevHVACDataLevel1.errors1?.dryerE413?.value != errors1.dryerE413?.value ||
+        prevHVACDataLevel1.errors1?.condensateDrainE414?.value != errors1.condensateDrainE414?.value ||
+        prevHVACDataLevel1.errors1?.noPressureBuildUpE415?.value != errors1.noPressureBuildUpE415?.value ||
+        prevHVACDataLevel1.errors1?.heavyStartupE416?.value != errors1.heavyStartupE416?.value ||
+        prevHVACDataLevel1.errors1?.preAdjustmentVSDE500?.value != errors1.preAdjustmentVSDE500?.value ||
+        prevHVACDataLevel1.errors1?.preAdjustmentE501?.value != errors1.preAdjustmentE501?.value ||
+        prevHVACDataLevel1.errors1?.lockedVSDE502?.value != errors1.lockedVSDE502?.value ||
+        prevHVACDataLevel1.errors1?.writeFaultVSDE503?.value != errors1.writeFaultVSDE503?.value ||
+        prevHVACDataLevel1.errors1?.communicationVSDE504?.value != errors1.communicationVSDE504?.value ||
+        prevHVACDataLevel1.errors1?.stopPressedVSDE505?.value != errors1.stopPressedVSDE505?.value ||
+        prevHVACDataLevel1.errors1?.stopInputEMVSDE506?.value != errors1.stopInputEMVSDE506?.value ||
+        prevHVACDataLevel1.errors1?.readFaultVSDE507?.value != errors1.readFaultVSDE507?.value ||
+        prevHVACDataLevel1.errors1?.stopInputVSDEME508?.value != errors1.stopInputVSDEME508?.value ||
+        prevHVACDataLevel1.errors1?.seeVSDDisplayE509?.value != errors1.seeVSDDisplayE509?.value ||
+        prevHVACDataLevel1.errors1?.speedBelowMinLimitE510?.value != errors1.speedBelowMinLimitE510?.value ||
+        prevHVACDataLevel1.warnings1?.serviceDueA600?.value != warnings1.serviceDueA600?.value ||
+        prevHVACDataLevel1.warnings1?.dischargeOverPressureA601?.value != warnings1.dischargeOverPressureA601?.value ||
+        prevHVACDataLevel1.warnings1?.compressorDischargeTemperatureA602?.value !=
+          warnings1.compressorDischargeTemperatureA602?.value ||
+        prevHVACDataLevel1.warnings1?.linePressureHighA606?.value != warnings1.linePressureHighA606?.value ||
+        prevHVACDataLevel1.warnings1?.controllerBatteryEmptyA607?.value !=
+          warnings1.controllerBatteryEmptyA607?.value ||
+        prevHVACDataLevel1.warnings1?.dryerA608?.value != warnings1.dryerA608?.value ||
+        prevHVACDataLevel1.warnings1?.condensateDrainA609?.value != warnings1.condensateDrainA609?.value ||
+        prevHVACDataLevel1.warnings1?.fineSeparatorA610?.value != warnings1.fineSeparatorA610?.value ||
+        prevHVACDataLevel1.warnings1?.airFilterA611?.value != warnings1.airFilterA611?.value ||
+        prevHVACDataLevel1.warnings1?.oilFilterA612?.value != warnings1.oilFilterA612?.value ||
+        prevHVACDataLevel1.warnings1?.oilLevelLowA613?.value != warnings1.oilLevelLowA613?.value ||
+        prevHVACDataLevel1.warnings1?.oilTemperatureHighA614?.value != warnings1.oilTemperatureHighA614?.value ||
+        prevHVACDataLevel1.warnings1?.externalWarningA615?.value != warnings1.externalWarningA615?.value ||
+        prevHVACDataLevel1.warnings1?.motorLuricationSystemA616?.value != warnings1.motorLuricationSystemA616?.value ||
+        prevHVACDataLevel1.warnings1?.input1A617?.value != warnings1.input1A617?.value ||
+        prevHVACDataLevel1.warnings1?.input2A618?.value != warnings1.input2A618?.value ||
+        prevHVACDataLevel1.warnings1?.input3A619?.value != warnings1.input3A619?.value ||
+        prevHVACDataLevel1.warnings1?.input4A620?.value != warnings1.input4A620?.value ||
+        prevHVACDataLevel1.warnings1?.input5A621?.value != warnings1.input5A621?.value ||
+        prevHVACDataLevel1.warnings1?.input6A622?.value != warnings1.input6A622?.value ||
+        prevHVACDataLevel1.warnings1?.fullSDCardA623?.value != warnings1.fullSDCardA623?.value ||
+        prevHVACDataLevel1.warnings1?.temperatureHighVSDA700?.value != warnings1.temperatureHighVSDA700?.value ||
+        prevHVACDataLevel1.status2?.serviceRequired?.value != status2.serviceRequired?.value ||
+        prevHVACDataLevel1.errors2?.powerSupplyFailureE400?.value != errors2.powerSupplyFailureE400?.value ||
+        prevHVACDataLevel1.errors2?.emergencyStopActivatedE401?.value != errors2.emergencyStopActivatedE401?.value ||
+        prevHVACDataLevel1.errors2?.highMotorTemperatureM1E402?.value != errors2.highMotorTemperatureM1E402?.value ||
+        prevHVACDataLevel1.errors2?.compressorDischargeTemperatureE403?.value !=
+          errors2.compressorDischargeTemperatureE403?.value ||
+        prevHVACDataLevel1.errors2?.startTemperatureLowE404?.value != errors2.startTemperatureLowE404?.value ||
+        prevHVACDataLevel1.errors2?.dischargeOverPressureE405?.value != errors2.dischargeOverPressureE405?.value ||
+        prevHVACDataLevel1.errors2?.linePressureSensorB1E406?.value != errors2.linePressureSensorB1E406?.value ||
+        prevHVACDataLevel1.errors2?.dischargePressureSensorB2E407?.value !=
+          errors2.dischargePressureSensorB2E407?.value ||
+        prevHVACDataLevel1.errors2?.dischargeTemperatureSensorR2E408?.value !=
+          errors2.dischargeTemperatureSensorR2E408?.value ||
+        prevHVACDataLevel1.errors2?.controllerHardwareE409?.value != errors2.controllerHardwareE409?.value ||
+        prevHVACDataLevel1.errors2?.coolingE410?.value != errors2.coolingE410?.value ||
+        prevHVACDataLevel1.errors2?.oilPressureLowE411?.value != errors2.oilPressureLowE411?.value ||
+        prevHVACDataLevel1.errors2?.externalFaultE412?.value != errors2.externalFaultE412?.value ||
+        prevHVACDataLevel1.errors2?.dryerE413?.value != errors2.dryerE413?.value ||
+        prevHVACDataLevel1.errors2?.condensateDrainE414?.value != errors2.condensateDrainE414?.value ||
+        prevHVACDataLevel1.errors2?.noPressureBuildUpE415?.value != errors2.noPressureBuildUpE415?.value ||
+        prevHVACDataLevel1.errors2?.heavyStartupE416?.value != errors2.heavyStartupE416?.value ||
+        prevHVACDataLevel1.errors2?.preAdjustmentVSDE500?.value != errors2.preAdjustmentVSDE500?.value ||
+        prevHVACDataLevel1.errors2?.preAdjustmentE501?.value != errors2.preAdjustmentE501?.value ||
+        prevHVACDataLevel1.errors2?.lockedVSDE502?.value != errors2.lockedVSDE502?.value ||
+        prevHVACDataLevel1.errors2?.writeFaultVSDE503?.value != errors2.writeFaultVSDE503?.value ||
+        prevHVACDataLevel1.errors2?.communicationVSDE504?.value != errors2.communicationVSDE504?.value ||
+        prevHVACDataLevel1.errors2?.stopPressedVSDE505?.value != errors2.stopPressedVSDE505?.value ||
+        prevHVACDataLevel1.errors2?.stopInputEMVSDE506?.value != errors2.stopInputEMVSDE506?.value ||
+        prevHVACDataLevel1.errors2?.readFaultVSDE507?.value != errors2.readFaultVSDE507?.value ||
+        prevHVACDataLevel1.errors2?.stopInputVSDEME508?.value != errors2.stopInputVSDEME508?.value ||
+        prevHVACDataLevel1.errors2?.seeVSDDisplayE509?.value != errors2.seeVSDDisplayE509?.value ||
+        prevHVACDataLevel1.errors2?.speedBelowMinLimitE510?.value != errors2.speedBelowMinLimitE510?.value ||
+        prevHVACDataLevel1.warnings2?.serviceDueA600?.value != warnings2.serviceDueA600?.value ||
+        prevHVACDataLevel1.warnings2?.dischargeOverPressureA601?.value != warnings2.dischargeOverPressureA601?.value ||
+        prevHVACDataLevel1.warnings2?.compressorDischargeTemperatureA602?.value !=
+          warnings2.compressorDischargeTemperatureA602?.value ||
+        prevHVACDataLevel1.warnings2?.linePressureHighA606?.value != warnings2.linePressureHighA606?.value ||
+        prevHVACDataLevel1.warnings2?.controllerBatteryEmptyA607?.value !=
+          warnings2.controllerBatteryEmptyA607?.value ||
+        prevHVACDataLevel1.warnings2?.dryerA608?.value != warnings2.dryerA608?.value ||
+        prevHVACDataLevel1.warnings2?.condensateDrainA609?.value != warnings2.condensateDrainA609?.value ||
+        prevHVACDataLevel1.warnings2?.fineSeparatorA610?.value != warnings2.fineSeparatorA610?.value ||
+        prevHVACDataLevel1.warnings2?.airFilterA611?.value != warnings2.airFilterA611?.value ||
+        prevHVACDataLevel1.warnings2?.oilFilterA612?.value != warnings2.oilFilterA612?.value ||
+        prevHVACDataLevel1.warnings2?.oilLevelLowA613?.value != warnings2.oilLevelLowA613?.value ||
+        prevHVACDataLevel1.warnings2?.oilTemperatureHighA614?.value != warnings2.oilTemperatureHighA614?.value ||
+        prevHVACDataLevel1.warnings2?.externalWarningA615?.value != warnings2.externalWarningA615?.value ||
+        prevHVACDataLevel1.warnings2?.motorLuricationSystemA616?.value != warnings2.motorLuricationSystemA616?.value ||
+        prevHVACDataLevel1.warnings2?.input1A617?.value != warnings2.input1A617?.value ||
+        prevHVACDataLevel1.warnings2?.input2A618?.value != warnings2.input2A618?.value ||
+        prevHVACDataLevel1.warnings2?.input3A619?.value != warnings2.input3A619?.value ||
+        prevHVACDataLevel1.warnings2?.input4A620?.value != warnings2.input4A620?.value ||
+        prevHVACDataLevel1.warnings2?.input5A621?.value != warnings2.input5A621?.value ||
+        prevHVACDataLevel1.warnings2?.input6A622?.value != warnings2.input6A622?.value ||
+        prevHVACDataLevel1.warnings2?.fullSDCardA623?.value != warnings2.fullSDCardA623?.value ||
+        prevHVACDataLevel1.warnings2?.temperatureHighVSDA700?.value != warnings2.temperatureHighVSDA700?.value)
     ) {
       const isAlarmed_1 = alarms_1.some((a) => {
         return a;


### PR DESCRIPTION
This PR brings a bunch of fixes to the Faility Component:

- A zoomOut button was added into the svg rendering for every level
- A bunch of stuff that wasn't used on the different levels css was removed
- Some classes were renamed
- Fonts were loaded on each level inside the svg to avoid poor rendering on some instances
- Got rid of some duplicate objects on the cartoon
- Alarm highlight for Level1 Air Compressors was reinstated

I think that's pretty much all of it