### PR TITLE
Add Optical Alignment Alarm to M2 and M1M3 Components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v5.25.3
 -------
 
 * Add mock Dome Tracking to ATDome and MTDome `<https://github.com/lsst-ts/LOVE-frontend/pull/535>`_
+* Add Optical Alignment Alarm to M2 and M1M3 `<https://github.com/lsst-ts/LOVE-frontend/pull/534>`_
 * Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`_
 * Fix ESS component with the sorted sensors in cache `<https://github.com/lsst-ts/LOVE-frontend/pull/531>`_
 * MTCamera and CCCamera zoom out button `<https://github.com/lsst-ts/LOVE-frontend/pull/530>`_

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -638,6 +638,13 @@ export const ccCameraFilterChangerDetailedStateToStyle = {
   UNKNOWN: 'invalid',
 };
 
+// Optical Alignment Alarm
+export const alignedStateToStyle = {
+  ALIGNED: 'ok',
+  'NOT ALIGNED': 'warning',
+  UNKNOWN: 'invalid',
+};
+
 //  MTM1M3
 export const m1m3DetailedStateToStyle = {
   'DISABLED STATE': 'warning',
@@ -1046,6 +1053,13 @@ export const ccCameraFilterChangerDetailedStateMap = {
   3: 'LOADED',
   4: 'UNLOADED',
   5: 'ROTATING',
+  0: 'UNKNOWN',
+};
+
+// Optical Alignment Alarm
+export const alignedStateMap = {
+  1: 'ALIGNED',
+  2: 'NOT ALIGNED',
   0: 'UNKNOWN',
 };
 

--- a/love/src/components/MainTel/M1M3/M1M3.container.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3.container.jsx
@@ -99,7 +99,6 @@ const mapDispatchToProps = (dispatch) => {
     'event-MTM1M3-0-appliedOffsetForces',
     'event-MTM1M3-0-appliedStaticForces',
     'event-MTM1M3-0-enabledForceActuators',
-    'event-OAA-0-alignment',
     // 'event-MTM1M3-0-preclippedAccelerationForces',
     // 'event-MTM1M3-0-preclippedActiveOpticForces',
     // 'event-MTM1M3-0-preclippedBalanceForces',

--- a/love/src/components/MainTel/M1M3/M1M3.container.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3.container.jsx
@@ -26,6 +26,7 @@ import {
   getM1M3ActuatorForces,
   getM1M3HardpointMonitorData,
   getM1M3HardpointActuatorState,
+  getAlignmentState,
 } from 'redux/selectors';
 import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
 import M1M3 from './M1M3';
@@ -63,7 +64,15 @@ const mapStateToProps = (state) => {
   const actuatorsForces = getM1M3ActuatorForces(state);
   const hardpointsMonitor = getM1M3HardpointMonitorData(state);
   const hardpointsActuatorState = getM1M3HardpointActuatorState(state);
-  return { ...m1m3State, ...actuatorsState, ...actuatorsForces, ...hardpointsMonitor, ...hardpointsActuatorState };
+  const alignmentState = getAlignmentState(state);
+  return {
+    ...m1m3State,
+    ...actuatorsState,
+    ...actuatorsForces,
+    ...hardpointsMonitor,
+    ...hardpointsActuatorState,
+    ...alignmentState,
+  };
 };
 
 const mapDispatchToProps = (dispatch) => {
@@ -90,6 +99,7 @@ const mapDispatchToProps = (dispatch) => {
     'event-MTM1M3-0-appliedOffsetForces',
     'event-MTM1M3-0-appliedStaticForces',
     'event-MTM1M3-0-enabledForceActuators',
+    'event-OAA-0-alignment',
     // 'event-MTM1M3-0-preclippedAccelerationForces',
     // 'event-MTM1M3-0-preclippedActiveOpticForces',
     // 'event-MTM1M3-0-preclippedBalanceForces',

--- a/love/src/components/MainTel/M1M3/M1M3.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3.jsx
@@ -519,10 +519,6 @@ export default class M1M3 extends Component {
     const selectedHardpoint = this.getHardpoint(selectedHardpointId);
     const forceInputs = Object.keys(M1M3ActuatorForces);
 
-    console.log('alignment: ' + this.props.alignment);
-    console.log('state name: ' + alignedStateName);
-    console.log('state status: ' + alignedStateStatus);
-
     return (
       <div className={styles.mirrorContainer}>
         <SummaryPanel className={styles.summaryPanelStates}>

--- a/love/src/components/MainTel/M1M3/M1M3.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3.jsx
@@ -34,6 +34,8 @@ import {
   M1M3YActuatorsMapping,
   M1M3ZActuatorsMapping,
   M1M3SActuatorsMapping,
+  alignedStateMap,
+  alignedStateToStyle,
 } from 'Config';
 import ArrowIcon from 'components/icons/ArrowIcon/ArrowIcon';
 import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
@@ -507,6 +509,9 @@ export default class M1M3 extends Component {
     const detailedStateName = m1m3DetailedStateMap[this.props.detailedState];
     const detailedStateStatus = m1m3DetailedStateToStyle[detailedStateName];
 
+    const alignedStateName = alignedStateMap[this.props.alignment];
+    const alignedStateStatus = alignedStateToStyle[alignedStateName];
+
     const maxForce = defaultNumberFormatter(Math.max(...actuatorsForce));
     const minForce = defaultNumberFormatter(Math.min(...actuatorsForce));
 
@@ -514,16 +519,24 @@ export default class M1M3 extends Component {
     const selectedHardpoint = this.getHardpoint(selectedHardpointId);
     const forceInputs = Object.keys(M1M3ActuatorForces);
 
+    console.log('alignment: ' + this.props.alignment);
+    console.log('state name: ' + alignedStateName);
+    console.log('state status: ' + alignedStateStatus);
+
     return (
       <div className={styles.mirrorContainer}>
         <SummaryPanel className={styles.summaryPanelStates}>
           <div className={styles.state}>
-            <Title>STATE</Title>
+            <Title>State</Title>
             <StatusText status={summaryStateStatus}>{summaryStateName}</StatusText>
           </div>
           <div className={styles.state}>
-            <Title>DETAILED STATE</Title>
+            <Title>Detailed State</Title>
             <StatusText status={detailedStateStatus}>{detailedStateName}</StatusText>
+          </div>
+          <div className={styles.state}>
+            <Title>M2 Alignement</Title>
+            <StatusText status={alignedStateStatus}>{alignedStateName}</StatusText>
           </div>
         </SummaryPanel>
 

--- a/love/src/components/MainTel/M2/M2.container.jsx
+++ b/love/src/components/MainTel/M2/M2.container.jsx
@@ -20,7 +20,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 import React from 'react';
 import { connect } from 'react-redux';
 import { addGroup, removeGroup } from 'redux/actions/ws';
-import { getM2State, getM2Inclinometer, getM2Actuator, getM2ActuatorForce } from 'redux/selectors';
+import { getM2State, getM2Inclinometer, getM2Actuator, getM2ActuatorForce, getAlignmentState } from 'redux/selectors';
 import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
 import M2 from './M2';
 import { EUIs } from 'Config';
@@ -74,8 +74,9 @@ const mapStateToProps = (state) => {
   const inclinometerState = getM2Inclinometer(state);
   const actuators = getM2Actuator(state);
   const forces = getM2ActuatorForce(state);
+  const alignmentState = getAlignmentState(state);
 
-  return { ...m2State, ...inclinometerState, ...actuators, ...forces };
+  return { ...m2State, ...inclinometerState, ...actuators, ...forces, ...alignmentState };
 };
 
 const mapDispatchToProps = (dispatch) => {

--- a/love/src/components/MainTel/M2/M2.jsx
+++ b/love/src/components/MainTel/M2/M2.jsx
@@ -97,6 +97,7 @@ export default class M2 extends Component {
       tangentForceMeasured,
       minForceLimit,
       maxForceLimit,
+      alignment,
     } = this.props;
     const { summaryState, commandableByDDS, forceBalanceSystemStatus, m2AssemblyInPosition } = this.props;
     const { zenithAngleMeasured, inclinationTelemetrySource } = this.props;
@@ -108,6 +109,7 @@ export default class M2 extends Component {
           commandableByDDS={commandableByDDS}
           forceBalanceSystemStatus={forceBalanceSystemStatus}
           m2AssemblyInPosition={m2AssemblyInPosition}
+          alignment={alignment}
         />
 
         <Actuators

--- a/love/src/components/MainTel/M2/Summary/Summary.jsx
+++ b/love/src/components/MainTel/M2/Summary/Summary.jsx
@@ -19,7 +19,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { summaryStateMap, summaryStateToStyle } from 'Config';
+import { summaryStateMap, summaryStateToStyle, alignedStateMap, alignedStateToStyle } from 'Config';
 import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
 import Title from 'components/GeneralPurpose/SummaryPanel/Title';
 import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
@@ -51,6 +51,9 @@ export default class Summary extends Component {
     const summaryStateName = summaryStateMap[this.props.summaryState];
     const summaryStateStatus = summaryStateToStyle[summaryStateName];
 
+    const alignedStateName = alignedStateMap[this.props.alignment];
+    const alignedStateStatus = alignedStateToStyle[alignedStateName];
+
     const commandableByDDSValue = {
       name: this.props.commandableByDDS ? 'CSC' : 'EUI',
       class: this.props.commandableByDDS ? 'ok' : 'warning',
@@ -81,6 +84,10 @@ export default class Summary extends Component {
           <div className={styles.state}>
             <Title>Force Balance</Title>
             <StatusText status={forceBalanceSystemStatusValue?.class}>{forceBalanceSystemStatusValue?.name}</StatusText>
+          </div>
+          <div className={styles.state}>
+            <Title>M1M3 Alignment</Title>
+            <StatusText status={alignedStateStatus}>{alignedStateName}</StatusText>
           </div>
         </SummaryPanel>
       </div>

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -107,10 +107,12 @@ export const getCameraState = (state) => {
 export const getLastSALCommand = (state) => {
   return state.ws.lastSALCommand;
 };
+
 // Optical Alignment Alarm
 export const getAlignmentState = (state) => {
-  const subscriptions = ['telemetry-MTM1M3-0-forceActuatorData'];
-  const alignmentData = getStreamsData(state, subscriptions);
+  //This is a mock event that returns a parameter that does not yet exist.
+  //Whenever OAS is implemented and a CSC or Topic is published for it
+  //this selector should be updated and connected to the proper CSC
   return {
     alignment: 0,
   };

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -107,6 +107,14 @@ export const getCameraState = (state) => {
 export const getLastSALCommand = (state) => {
   return state.ws.lastSALCommand;
 };
+// Optical Alignment Alarm
+export const getAlignmentState = (state) => {
+  const subscriptions = ['telemetry-MTM1M3-0-forceActuatorData'];
+  const alignmentData = getStreamsData(state, subscriptions);
+  return {
+    alignment: 0,
+  };
+};
 
 // MTM1M3 selectors
 export const getM1M3ActuatorsState = (state) => {


### PR DESCRIPTION
This PR adds a new status badge to both the M2 and M1M3 components, indicating weather or not they are aligned.
Bare in mind that for this implementation a fake event has veen created on selectors.js since no such event exists as of yet.