### PR TITLE
Add mocked Dome Tracking to AT and MT Dome Components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.25.3
 -------
 
+* Add mock Dome Tracking to ATDome and MTDome `<https://github.com/lsst-ts/LOVE-frontend/pull/535>`_
 * Add ZoomOut button and better performance on FacilityMap component `<https://github.com/lsst-ts/LOVE-frontend/pull/533>`_
 * Fix ESS component with the sorted sensors in cache `<https://github.com/lsst-ts/LOVE-frontend/pull/531>`_
 * MTCamera and CCCamera zoom out button `<https://github.com/lsst-ts/LOVE-frontend/pull/530>`_

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -832,6 +832,14 @@ export const mtdomeElevationEnabledStatetoStyle = {
   FAULT: 'fault',
 };
 
+export const mtDomeTrackingStatetoStyle = {
+  UNKNOWN: 'invalid',
+};
+
+export const atDomeTrackingStatetoStyle = {
+  UNKNOWN: 'invalid',
+};
+
 export const ataosCorrectionsStateToStyle = {
   DISABLED: 'warning',
   ENABLED: 'ok',
@@ -1101,6 +1109,14 @@ export const mainDoorStateMap = {
   3: 'PARTIALLY OPEN',
   4: 'OPENING',
   5: 'CLOSING',
+  0: 'UNKNOWN',
+};
+
+export const mtDomeTrackingStateMap = {
+  0: 'UNKNOWN',
+};
+
+export const atDomeTrackingStateMap = {
   0: 'UNKNOWN',
 };
 

--- a/love/src/components/AuxTel/Dome/Dome.container.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.container.jsx
@@ -85,6 +85,7 @@ const DomeContainer = ({
   subscribeToStream,
   unsubscribeToStream,
   controls,
+  atDomeTracking,
   ...props
 }) => {
   if (props.isRaw) {
@@ -126,6 +127,7 @@ const DomeContainer = ({
       controls={controls}
       atDomeSummaryState={atDomeSummaryState}
       ATMCSSummaryState={ATMCSSummaryState}
+      atDomeTracking={atDomeTracking}
     />
   );
 };

--- a/love/src/components/AuxTel/Dome/Dome.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.jsx
@@ -246,6 +246,7 @@ export default class Dome extends Component {
       currentPointingNasmyth2,
       atDomeSummaryState,
       ATMCSSummaryState,
+      atDomeTracking,
     } = this.props;
 
     const isProjected = true;
@@ -379,6 +380,7 @@ export default class Dome extends Component {
             minM3={minM3}
             atDomeSummaryState={atDomeSummaryState}
             ATMCSSummaryState={ATMCSSummaryState}
+            domeTracking={atDomeTracking}
           />
         </div>
         {this.props.controls && (

--- a/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
+++ b/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
@@ -30,6 +30,8 @@ import {
   stateToStyleDomeAndMount,
   summaryStateToStyle,
   summaryStateMap,
+  atDomeTrackingStateMap,
+  atDomeTrackingStatetoStyle,
 } from '../../../../Config';
 import Limits from 'components/GeneralPurpose/Limits/Limits';
 import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
@@ -104,6 +106,7 @@ export default class DomeSummaryTable extends Component {
       minM3,
       atDomeSummaryState,
       ATMCSSummaryState,
+      domeTracking,
     } = this.props;
 
     const azimuthStateValue = domeAzimuthStateMap[this.props.azimuthState];
@@ -139,6 +142,9 @@ export default class DomeSummaryTable extends Component {
     const atDomeSummaryStateValue = summaryStateMap[atDomeSummaryState];
     const ATMCSSummaryStateValue = summaryStateMap[ATMCSSummaryState];
 
+    const domeTrackingName = atDomeTrackingStateMap[domeTracking];
+    const domeTrackingStyle = atDomeTrackingStatetoStyle[domeTrackingName];
+
     let domeInPositionLabel = 'UNKNOWN';
     if (domeInPositionValue !== 0) domeInPositionLabel = domeInPositionValue ? 'IN POSITION' : 'NOT IN POSITION';
     let mountInPositionLabel = 'UNKNOWN';
@@ -161,7 +167,10 @@ export default class DomeSummaryTable extends Component {
             {domeInPositionLabel}
           </StatusText>
         </Value>
-
+        <Label>Tracking</Label>
+        <Value>
+          <StatusText status={domeTrackingStyle}>{domeTrackingName}</StatusText>
+        </Value>
         <Label>Azimuth</Label>
         <Value>
           <StatusText title={azimuthStateValue} status={stateToStyleDomeAndMount[azimuthStateValue]} small>

--- a/love/src/components/MainTel/MTDome/MTDome.container.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.container.jsx
@@ -72,6 +72,7 @@ const MTDomeContainer = ({
   targetPointingAz,
   currentPointingEl,
   targetPointingEl,
+  mtDomeTracking,
   ...props
 }) => {
   if (props.isRaw) {
@@ -100,6 +101,7 @@ const MTDomeContainer = ({
       targetPointingAz={targetPointingAz}
       currentPointingEl={currentPointingEl}
       targetPointingEl={targetPointingEl}
+      mtDomeTracking={mtDomeTracking}
     />
   );
 };

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -554,6 +554,7 @@ export default class MTDome extends Component {
     const azimuthDomeTarget = this.props.azimuthDomeTarget;
     const azimuthDomeMotion = this.props.azimuthDomeMotion;
     const mtMountSummaryState = this.props.mtMountSummaryState;
+    const mtDomeTracking = this.props.mtDomeTracking;
 
     //domeAzimuth
     const positionActualDomeAz = this.props.positionActualDomeAz;
@@ -653,6 +654,7 @@ export default class MTDome extends Component {
                 positionCommandedShutter={positionCommandedShutter}
                 currentPointing={currentPointing}
                 targetPointing={targetPointing}
+                domeTracking={mtDomeTracking}
               />
             </div>
           </div>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -39,6 +39,8 @@ import {
   mtdomeMotionStateMap,
   mtdomeMotionStatetoStyle,
   MTMountLimits,
+  mtDomeTrackingStateMap,
+  mtDomeTrackingStatetoStyle,
 } from '../../../../Config';
 
 export default class MTDomeSummaryTable extends Component {
@@ -89,6 +91,8 @@ export default class MTDomeSummaryTable extends Component {
     const azimuthDomeState = mtDomeAzimuthEnabledStateMap[this.props.azimuthDomeState];
     const azimuthDomeMotion = mtdomeMotionStateMap[this.props.azimuthDomeMotion];
     const mtMountStatus = summaryStateMap[this.props.mtMountSummaryState];
+    const mtDomeTrackingName = mtDomeTrackingStateMap[this.props.domeTracking];
+    const mtDomeTrackingStyle = mtDomeTrackingStatetoStyle[mtDomeTrackingName];
 
     const domeActualAz = this.props.positionActualDomeAz;
     const domeCommandedAz = this.props.positionCommandedDomeAz;
@@ -108,6 +112,10 @@ export default class MTDomeSummaryTable extends Component {
           <Label>Mode</Label>
           <Value>
             <StatusText status={mtDomeModeStatetoStyle[modeDomeStatus]}>{modeDomeStatus}</StatusText>
+          </Value>
+          <Label>Tracking</Label>
+          <Value>
+            <StatusText status={mtDomeTrackingStyle}>{mtDomeTrackingName}</StatusText>
           </Value>
           <Label>Az State</Label>
           <Value>

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -536,7 +536,7 @@ export const getDomeState = (state) => {
     dropoutDoorState: domeData['event-ATDome-0-dropoutDoorState']?.[0].state?.value ?? 0,
     mainDoorState: domeData['event-ATDome-0-mainDoorState']?.[0].state?.value ?? 0,
     atDomeSummaryState: domeData['event-ATDome-0-summaryState']?.[0].summaryState?.value ?? 0,
-    //The following parameter is missing a CSC, add it when it becomes available//
+    // TODO: The following parameter is missing a CSC, add it when it becomes available//
     atDomeTracking: 0,
   };
 };
@@ -1124,7 +1124,7 @@ export const getDomeStatus = (state) => {
     azimuthDomeTarget: domeStatus['event-MTDome-0-azTarget']?.[0]?.position?.value ?? 0,
     modeDomeStatus: domeStatus['event-MTDome-0-operationalMode']?.[0]?.operationalMode?.value ?? 0,
     mtMountSummaryState: domeStatus['event-MTMount-0-summaryState']?.[0]?.summaryState?.value ?? 0,
-    //The following parameter is missing a CSC, add it when it becomes available//
+    // TODO: The following parameter is missing a CSC, add it when it becomes available//
     mtDomeTracking: 0,
   };
 };

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -536,6 +536,8 @@ export const getDomeState = (state) => {
     dropoutDoorState: domeData['event-ATDome-0-dropoutDoorState']?.[0].state?.value ?? 0,
     mainDoorState: domeData['event-ATDome-0-mainDoorState']?.[0].state?.value ?? 0,
     atDomeSummaryState: domeData['event-ATDome-0-summaryState']?.[0].summaryState?.value ?? 0,
+    //The following parameter is missing a CSC, add it when it becomes available//
+    atDomeTracking: 0,
   };
 };
 
@@ -1122,6 +1124,8 @@ export const getDomeStatus = (state) => {
     azimuthDomeTarget: domeStatus['event-MTDome-0-azTarget']?.[0]?.position?.value ?? 0,
     modeDomeStatus: domeStatus['event-MTDome-0-operationalMode']?.[0]?.operationalMode?.value ?? 0,
     mtMountSummaryState: domeStatus['event-MTMount-0-summaryState']?.[0]?.summaryState?.value ?? 0,
+    //The following parameter is missing a CSC, add it when it becomes available//
+    mtDomeTracking: 0,
   };
 };
 


### PR DESCRIPTION
This PR adds a mocked Dome Tracking to both the AuxTel and Main Dome Components.
Bare in mind that a fake '_atDomeTracking_' and '_mtDomeTracking_' event has been added to selectors.js
This needs to be replaced once the actual event is added to whatever CSC it will be add to.