### PR TITLE
Possibly malformed YAML in script dialog causes crash loop on subsequent use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ v5.26.0
 * Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_
 * Add Environmental Degradation to top level summaries `<https://github.com/lsst-ts/LOVE-frontend/pull/538>`_
+* Possibly malformed YAML in script dialog causes crash loop on subsequent use `<https://github.com/lsst-ts/LOVE-frontend/pull/536>`
 * Add ability to add a script at the top of the queue from LOVE `<https://github.com/lsst-ts/LOVE-frontend/pull/537>`_
 * Move docs creation to CI `<https://github.com/lsst-ts/LOVE-frontend/pull/532>`_
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,6 @@ v5.26.0
 -------
 
 * Add Simonyi Interlock Signals `<https://github.com/lsst-ts/LOVE-frontend/pull/542>`_
-* Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Scripts Form Config is not showing button icons `<https://github.com/lsst-ts/LOVE-frontend/pull/541>`_
 * Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v5.26.0
 -------
 
 * Add Simonyi Interlock Signals `<https://github.com/lsst-ts/LOVE-frontend/pull/542>`_
+* Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Scripts Form Config is not showing button icons `<https://github.com/lsst-ts/LOVE-frontend/pull/541>`_
 * Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ v5.26.0
 * Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_
 * Add Environmental Degradation to top level summaries `<https://github.com/lsst-ts/LOVE-frontend/pull/538>`_
-* Possibly malformed YAML in script dialog causes crash loop on subsequent use `<https://github.com/lsst-ts/LOVE-frontend/pull/536>`
+* Possibly malformed YAML in script dialog causes crash loop on subsequent use `<https://github.com/lsst-ts/LOVE-frontend/pull/536>`_
 * Add ability to add a script at the top of the queue from LOVE `<https://github.com/lsst-ts/LOVE-frontend/pull/537>`_
 * Move docs creation to CI `<https://github.com/lsst-ts/LOVE-frontend/pull/532>`_
 

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1176,7 +1176,7 @@ export default class ManagerInterface {
     });
   }
 
-  static updateScriptSchema(id, configSchema) {
+  static updateScriptSchema(id, configSchema, schema) {
     const token = ManagerInterface.getToken();
     if (token === null) {
       return new Promise((resolve) => resolve(false));
@@ -1187,6 +1187,7 @@ export default class ManagerInterface {
       headers: this.getHeaders(),
       body: JSON.stringify({
         config_schema: configSchema,
+        schema: schema,
       }),
     }).then((response) => {
       if (response.status >= 500) {
@@ -1198,7 +1199,7 @@ export default class ManagerInterface {
       }
       if (response.status === 400) {
         return response.json().then((resp) => {
-          toast.error(resp.ack);
+          toast.error(resp.title);
           return false;
         });
       }
@@ -1208,7 +1209,7 @@ export default class ManagerInterface {
     });
   }
 
-  static postScriptConfiguration(scriptPath, scriptType, configName, configSchema) {
+  static postScriptConfiguration(scriptPath, scriptType, configName, configSchema, schema) {
     const token = ManagerInterface.getToken();
     if (token === null) {
       return new Promise((resolve) => resolve(false));
@@ -1222,6 +1223,7 @@ export default class ManagerInterface {
         script_type: scriptType,
         config_name: configName,
         config_schema: configSchema,
+        schema: schema,
       }),
     }).then((response) => {
       if (response.status >= 500) {
@@ -1233,7 +1235,7 @@ export default class ManagerInterface {
       }
       if (response.status === 400) {
         return response.json().then((resp) => {
-          toast.error(resp.ack);
+          toast.error(resp.title);
           return false;
         });
       }

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -468,7 +468,7 @@ export default class ConfigPanel extends Component {
 
     let yamlData;
     try {
-      yamlData = configuration ? yaml.load(configuration.config_schema) : {};
+      yamlData = configuration && configuration.config_schema ? yaml.load(configuration.config_schema) ?? {} : {};
     } catch {
       yamlData = {};
     }
@@ -629,19 +629,20 @@ export default class ConfigPanel extends Component {
 
         let yamlData;
         try {
-          yamlData = configuration ? yaml.load(configuration.config_schema) : {};
+          yamlData = configuration && configuration.config_schema ? yaml.load(configuration.config_schema) ?? {} : {};
         } catch {
           yamlData = {};
         }
-
+        const value = configuration?.config_schema ?? DEFAULT_CONFIG_VALUE;
         this.setState((state) => ({
           configurationList: data,
           configurationOptions: options,
           selectedConfiguration: configuration ? { label: configuration.config_name, value: configuration.id } : null,
-          value: configuration?.config_schema ?? DEFAULT_CONFIG_VALUE,
+          value: value,
           inputConfigurationName: configuration?.config_name ?? DEFAULT_CONFIG_NAME,
           formData: yamlData,
         }));
+        this.validateConfig(value, true);
       });
     }
 
@@ -690,7 +691,7 @@ export default class ConfigPanel extends Component {
     // RJSF variables
     let rjsfSchema;
     try {
-      rjsfSchema = yamlSchema ? yaml.load(yamlSchema) : {};
+      rjsfSchema = yamlSchema ? yaml.load(yamlSchema) ?? {} : {};
     } catch {
       rjsfSchema = {};
     }

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -739,7 +739,7 @@ export default class ConfigPanel extends Component {
     // RJSF variables
     let rjsfSchema;
     try {
-      rjsfSchema = yamlSchema ? yaml.load(yamlSchema) ?? {} : {};
+      rjsfSchema = yaml.load(yamlSchema) ?? {};
     } catch {
       rjsfSchema = {};
     }

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -612,10 +612,10 @@ export default class ConfigPanel extends Component {
   };
 
   saveNewScriptSchema = (scriptPath, scriptType, configName, configSchema) => {
-    const { configurationList, value } = this.state;
+    const { configurationList } = this.state;
     this.setState({ updatingScriptSchema: true });
 
-    ManagerInterface.postScriptConfiguration(scriptPath, scriptType, configName, configSchema).then((res) => {
+    ManagerInterface.postScriptConfiguration(scriptPath, scriptType, configName, configSchema, this.props.configPanel.configSchema).then((res) => {
       const newConfigurationList = [res, ...configurationList];
       const options = newConfigurationList.map((conf) => ({ label: conf.config_name, value: conf.id }));
       const newSelectedConfiguration = { label: res.config_name, value: res.id };
@@ -629,15 +629,13 @@ export default class ConfigPanel extends Component {
         formData: yaml.load(res?.config_schema),
       });
     });
-
-    this.validateConfig(value, configSchema);
   };
 
   updateScriptSchema = (id, configSchema) => {
-    const { configurationList, value } = this.state;
+    const { configurationList } = this.state;
     this.setState({ updatingScriptSchema: true });
 
-    ManagerInterface.updateScriptSchema(id, configSchema).then((res) => {
+    ManagerInterface.updateScriptSchema(id, configSchema, this.props.configPanel.configSchema).then((res) => {
       const newSelectedConfiguration = { label: res.config_name, value: res.id };
       this.setState({
         updatingScriptSchema: false,
@@ -645,8 +643,6 @@ export default class ConfigPanel extends Component {
         configurationList: configurationList.map((conf) => (conf.id === id ? res : conf)),
       });
     });
-
-    this.validateConfig(value, configSchema);
   };
 
   componentDidUpdate = (prevProps, prevState) => {

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -275,7 +275,16 @@ export default class ConfigPanel extends Component {
      */
     const schema = this.props.configPanel.configSchema;
     if (!schema) {
-      this.setState({ validationStatus: EMPTY });
+      this.setState({
+        validationStatus: EMPTY,
+        configErrorTitle: 'Waiting for schema',
+        configErrors: [
+          {
+            name: ``,
+            message: `Schema not yet loaded`,
+          },
+        ],
+      });
       return;
     }
 
@@ -298,7 +307,16 @@ export default class ConfigPanel extends Component {
 
         /** Server error */
         if (!r.ok) {
-          this.setState({ validationStatus: SERVER_ERROR });
+          this.setState({
+            validationStatus: SERVER_ERROR,
+            configErrorTitle: 'Validation Failed',
+            configErrors: [
+              {
+                name: ``,
+                message: `There is no schema to validate or another server error was encountered`,
+              },
+            ],
+          });
           failValidate();
           return false;
         }
@@ -308,6 +326,16 @@ export default class ConfigPanel extends Component {
       .then((r) => {
         /** Handle SERVER_ERROR */
         failValidate();
+        this.setState({
+          validationStatus: SERVER_ERROR,
+          configErrorTitle: 'Validation Failed',
+          configErrors: [
+            {
+              name: ``,
+              message: `There is no schema to validate or another server error was encountered`,
+            },
+          ],
+        });
         if (!r) return;
 
         /** Valid schema should show no message */


### PR DESCRIPTION
Prevent the call function yaml.load() with parameter not defined and when the output is null.
Call method validateConfig, when receive the getScriptConfiguration.