### PR TITLE
Add Enviromental Degradation to several Top Level Summaries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v5.25.4
 -------
 
 * Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_
+* Add Environmental Degradation to top level summaries `<https://github.com/lsst-ts/LOVE-frontend/pull/538>`_
 * Add ability to add a script at the top of the queue from LOVE `<https://github.com/lsst-ts/LOVE-frontend/pull/537>`_
 * Move docs creation to CI `<https://github.com/lsst-ts/LOVE-frontend/pull/532>`_
 

--- a/love/src/components/EnvironmentSummary/EnvironmentSummary.jsx
+++ b/love/src/components/EnvironmentSummary/EnvironmentSummary.jsx
@@ -25,6 +25,7 @@ import SimonyiTelescope from './Cartoons/SimonyiTelescope';
 import AuxTelescope from './Cartoons/AuxTelescope';
 import WindDirection from './Cartoons/WindDirection';
 import TemperaturesSummary from './SummaryInformation/TemperaturesSummary';
+import DegradationSummary from './SummaryInformation/DegradationSummary';
 import WeatherForecastIcon from 'components/icons/WeatherForecastIcon/WeatherForecastIcon';
 import { defaultNumberFormatter } from 'Utils';
 
@@ -132,6 +133,7 @@ export default class EnvironmentSummary extends Component {
       windSpeed,
     } = this.props;
     const { hideIconTemperature } = this.state;
+    const degradation = 'Unknown';
 
     return (
       <div className={styles.container}>
@@ -144,6 +146,9 @@ export default class EnvironmentSummary extends Component {
         </div>
         <div className={styles.temperaturesContainer}>
           <TemperaturesSummary numChannels={numChannels} temperature={temperature} location={location} />
+        </div>
+        <div className={styles.enviroContainer}>
+          <DegradationSummary degradation={degradation} />
         </div>
         <div ref={this.containerRef} className={styles.telescopes}>
           <div className={styles.skymap}>

--- a/love/src/components/EnvironmentSummary/EnvironmentSummary.jsx
+++ b/love/src/components/EnvironmentSummary/EnvironmentSummary.jsx
@@ -131,9 +131,9 @@ export default class EnvironmentSummary extends Component {
       location,
       windDirection,
       windSpeed,
+      degradation,
     } = this.props;
     const { hideIconTemperature } = this.state;
-    const degradation = 'Unknown';
 
     return (
       <div className={styles.container}>

--- a/love/src/components/EnvironmentSummary/EnvironmentSummary.module.css
+++ b/love/src/components/EnvironmentSummary/EnvironmentSummary.module.css
@@ -30,6 +30,13 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   width: calc(35% - var(--content-padding));
 }
 
+.enviroContainer {
+  position: absolute;
+  right: 17%;
+  top: 0;
+  width: calc(20% - var(--content-padding));
+}
+
 .windDirection {
   width: 12%;
   position: absolute;

--- a/love/src/components/EnvironmentSummary/SummaryInformation/DegradationSummary.jsx
+++ b/love/src/components/EnvironmentSummary/SummaryInformation/DegradationSummary.jsx
@@ -1,0 +1,42 @@
+/** 
+This file is part of LOVE-frontend.
+
+Copyright (c) 2023 Inria Chile.
+
+Developed by Inria Chile.
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React, { Component, memo } from 'react';
+import PropTypes from 'prop-types';
+import styles from './SummaryInformation.module.css';
+
+class DegradationSummary extends Component {
+  static defaultProps = {
+    numChannels: 0,
+    temperature: [],
+    location: '',
+  };
+
+  render() {
+    const { degradation } = this.props;
+    return (
+      <div className={styles.container}>
+        <div className={styles.textTitle}>Env. Degradation</div>
+        <div>{degradation}</div>
+      </div>
+    );
+  }
+}
+
+export default memo(DegradationSummary);

--- a/love/src/components/EnvironmentSummary/SummaryInformation/DegradationSummary.jsx
+++ b/love/src/components/EnvironmentSummary/SummaryInformation/DegradationSummary.jsx
@@ -22,10 +22,13 @@ import PropTypes from 'prop-types';
 import styles from './SummaryInformation.module.css';
 
 class DegradationSummary extends Component {
+  static propTypes = {
+    /** Environmental degradation. */
+    degradation: PropTypes.any,
+  };
+
   static defaultProps = {
-    numChannels: 0,
-    temperature: [],
-    location: '',
+    degradation: 'Unknown',
   };
 
   render() {

--- a/love/src/components/EnvironmentSummary/SummaryInformation/SummaryInformation.module.css
+++ b/love/src/components/EnvironmentSummary/SummaryInformation/SummaryInformation.module.css
@@ -75,6 +75,11 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   align-items: center;
 }
 
+.textTitle {
+  font-weight: bold;
+  color: var(--base-font-color);
+}
+
 .title > :first-child {
   margin-right: var(--small-padding);
   width: 1em;

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -577,6 +577,7 @@ class Layout extends Component {
               auxtelTrackingState={this.props.observatorySummary?.auxtelTrackingState}
               auxtelTrackingMode={this.props.observatorySummary?.auxtelTrackingMode}
               auxtelObsMode={this.props.observatorySummary?.auxtelObservingMode}
+              degradation={this.props.observatorySummary?.degradation}
               auxtelPower={'UNKNOWN'}
             ></ObservatorySummaryMenu>
           </div>

--- a/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.jsx
+++ b/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.jsx
@@ -45,6 +45,7 @@ export default function ObservatorySummaryMenu({
   auxtelTrackingMode,
   auxtelObsMode,
   auxtelPower,
+  degradation,
 }) {
   const simonyiTrackingStateText = telescopeTrackingStateMap[simonyiTrackingState];
   const simonyiTrackingModeText = telescopeTrackingModeStateMap[simonyiTrackingMode];
@@ -52,7 +53,7 @@ export default function ObservatorySummaryMenu({
   const auxtelTrackingModeText = telescopeTrackingModeStateMap[auxtelTrackingMode];
   return (
     <>
-      <div className={[menuElementClassName, styles.menuElement].join(' ')}>
+      <div className={[menuElementClassName, styles.menuElement, styles.section].join(' ')}>
         <div className={styles.bigIconRow}>
           <div className={styles.iconContainer}>{locationIcon}</div>
           <div className={styles.contentContainer}>
@@ -64,6 +65,8 @@ export default function ObservatorySummaryMenu({
             </div>
           </div>
         </div>
+        <span className={styles.label}>Env. Degradation</span>
+        <span>{degradation}</span>
       </div>
 
       <div className={dividerClassName}></div>

--- a/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.module.css
+++ b/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.module.css
@@ -21,6 +21,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   display: grid;
   grid-template-columns: 2.5em max-content;
   column-gap: 0.5em;
+  grid-column: 1 /3;
 }
 
 .menuElement {

--- a/love/src/components/ObservatorySummary/ObservatorySummary.jsx
+++ b/love/src/components/ObservatorySummary/ObservatorySummary.jsx
@@ -83,6 +83,7 @@ export default class ObservatorySummary extends Component {
       auxtelTrackingMode,
       controlLocation,
       lastUpdated,
+      degradation,
     } = this.props;
 
     const controlLocationName = controlLocation
@@ -122,6 +123,8 @@ export default class ObservatorySummary extends Component {
           </Value>
           <Label>Power Source</Label>
           <Value>UNKNOWN</Value>
+          <Label>Env. Degradation</Label>
+          <Value>{degradation}</Value>
         </SummaryPanel>
 
         <SummaryPanel>

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -2197,6 +2197,8 @@ export const getObservatoryState = (state) => {
     location: essTemperatures ? essTemperatures.location.value : '',
     windDirection: essAirFlow ? essAirFlow.direction.value : 0.0,
     windSpeed: essAirFlow ? essAirFlow.speed.value : 0.0,
+    // TODO: Add the corresponding telemetry or event when Enviromental Degradation gets integrated into SAL
+    degradation: 'Unknown',
   };
 };
 


### PR DESCRIPTION
This PR adds the yet not implemented Enviromental Degradation information on a the following components:

- EnviromentSummary
- ObservatorySummary
- Layout Observatory Summary Menu

Bare in mind that this event/telemetry is not yet in SAL and uses a mock 'Unknown' information.