### PR TITLE
Update ATMCS Mount Tracking style on config file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.25.4
 -------
 
+* Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_
 * Add ability to add a script at the top of the queue from LOVE `<https://github.com/lsst-ts/LOVE-frontend/pull/537>`_
 * Move docs creation to CI `<https://github.com/lsst-ts/LOVE-frontend/pull/532>`_
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -597,7 +597,7 @@ export const stateToStyleMount = {
   UNKNOWN: 'invalid',
   'UNKNOWN POSITION': 'invalid',
   TRACKINGDISABLED: 'warning',
-  TRACKINGENABLED: 'warning',
+  TRACKINGENABLED: 'ok',
   STOPPING: 'warning',
 };
 


### PR DESCRIPTION
This PR just updates the TRACKINGENABLED state style from 'warning' to 'ok'