### PR TITLE
Layout improvements for OLE components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.25.4
 -------
 
+* Layout improvements for OLE components `<https://github.com/lsst-ts/LOVE-frontend/pull/540>`_
 * Update ATMCS Mount Tracking config file `<https://github.com/lsst-ts/LOVE-frontend/pull/539>`_
 * Add Environmental Degradation to top level summaries `<https://github.com/lsst-ts/LOVE-frontend/pull/538>`_
 * Add ability to add a script at the top of the queue from LOVE `<https://github.com/lsst-ts/LOVE-frontend/pull/537>`_

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -365,7 +365,7 @@ export const MTCSCommands = {
 export const LOG_REFRESH_INTERVAL_MS = 60000;
 
 export const OLE_COMMENT_TYPE_OPTIONS = [
-  { label: 'Priority', value: 'all' },
+  { label: 'All priorities', value: 'all' },
   { label: 'Urgent', value: 100 },
   { label: 'Non urgent', value: 0 },
 ];

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1826,3 +1826,15 @@ export function copyToClipboard(text, effect) {
   navigator.clipboard.writeText(text);
   if (effect) effect();
 }
+
+/**
+ * Function to trim a string to a specified length
+ * @param {string} string text to be trimmed
+ * @param {number} length length to be trimmed, 100 by default
+ */
+export function trimString(string, length = 100) {
+  if (string.length > length) {
+    return `${string.substring(0, length)}...`;
+  }
+  return string;
+}

--- a/love/src/components/GeneralPurpose/Input/Input.jsx
+++ b/love/src/components/GeneralPurpose/Input/Input.jsx
@@ -40,7 +40,7 @@ const Input = ({
       defaultValue={defaultValue}
       value={value}
       type={type}
-      className={[styles.input, className].join(' ')}
+      className={[className, styles.input, type === 'checkbox' ? styles.checkbox : ''].join(' ')}
       placeholder={placeholder}
       checked={checked}
       min={min}

--- a/love/src/components/GeneralPurpose/Input/Input.module.css
+++ b/love/src/components/GeneralPurpose/Input/Input.module.css
@@ -40,5 +40,9 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .input:focus {
   outline: none;
   border: 1px solid var(--secondary-font-color);
-  /* outline: var(--primary-active-font-color) auto 5px; */
+}
+
+.input.checkbox {
+  height: 1.25em;
+  width: 1.25em;
 }

--- a/love/src/components/OLE/Exposure/Exposure.jsx
+++ b/love/src/components/OLE/Exposure/Exposure.jsx
@@ -32,7 +32,7 @@ import Button from 'components/GeneralPurpose/Button/Button';
 import Select from 'components/GeneralPurpose/Select/Select';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
 import Hoverable from 'components/GeneralPurpose/Hoverable/Hoverable';
-import { exposureFlagStateToStyle, DATE_TIME_FORMAT, ISO_INTEGER_DATE_FORMAT, LOG_REFRESH_INTERVAL_MS } from 'Config';
+import { exposureFlagStateToStyle, TIME_FORMAT, ISO_INTEGER_DATE_FORMAT, LOG_REFRESH_INTERVAL_MS } from 'Config';
 import ManagerInterface, { trimString } from 'Utils';
 import ExposureAdd from './ExposureAdd';
 import ExposureDetail from './ExposureDetail';
@@ -465,7 +465,6 @@ export default class Exposure extends Component {
 
     return (
       <div className={styles.margin10}>
-        <div className={styles.title}>Filter</div>
         <div className={styles.filters}>
           <Button disabled={updatingExposures} onClick={() => this.queryExposures()}>
             Refresh data
@@ -513,7 +512,7 @@ export default class Exposure extends Component {
           </div>
         </div>
         <div className={styles.lastUpdated}>
-          Last updated: {this.state.lastUpdated ? this.state.lastUpdated.format(DATE_TIME_FORMAT) : ''}
+          Last updated: {this.state.lastUpdated ? this.state.lastUpdated.format(TIME_FORMAT) : ''}
           {updatingExposures && <SpinnerIcon className={styles.spinnerIcon} />}
         </div>
         <SimpleTable headers={headers} data={filteredData} />

--- a/love/src/components/OLE/Exposure/Exposure.jsx
+++ b/love/src/components/OLE/Exposure/Exposure.jsx
@@ -309,6 +309,11 @@ export default class Exposure extends Component {
     });
   }
 
+  parseCsvData(data) {
+    // TODO: implement if needed.
+    return data;
+  }
+
   setQueryExposuresInterval() {
     this.queryExposuresInterval = setInterval(() => {
       this.queryExposures();
@@ -373,11 +378,25 @@ export default class Exposure extends Component {
     let csvHeaders = null;
     let csvData = "There aren't exposures created for the current search...";
     let csvTitle = 'exposure.csv';
-
     if (filteredData.length > 0) {
-      const logExampleKeys = Object.keys(filteredData[0] ?? {});
-      csvHeaders = logExampleKeys.map((key) => ({ label: key, key }));
-      csvData = filteredData;
+      const exportedParams = [
+        'obs_id',
+        'instrument',
+        'observation_type',
+        'observation_reason',
+        'day_obs',
+        'seq_num',
+        'group_name',
+        'target_name',
+        'science_program',
+        'tracking_ra',
+        'tracking_dec',
+        'sky_angle',
+        'timespan_begin',
+        'timespan_end',
+      ];
+      csvHeaders = exportedParams.map((key) => ({ label: key, key }));
+      csvData = this.parseCsvData(filteredData);
     }
 
     if (selectedDayExposureStart && selectedDayExposureEnd) {

--- a/love/src/components/OLE/Exposure/Exposure.jsx
+++ b/love/src/components/OLE/Exposure/Exposure.jsx
@@ -310,8 +310,14 @@ export default class Exposure extends Component {
   }
 
   parseCsvData(data) {
-    // TODO: implement if needed.
-    return data;
+    const csvData = data.map((row) => {
+      const exposureLength = Moment(row.timespan_end).diff(Moment(row.timespan_begin), 'seconds', true);
+      return {
+        ...row,
+        seconds_length: exposureLength,
+      };
+    });
+    return csvData;
   }
 
   setQueryExposuresInterval() {
@@ -393,7 +399,7 @@ export default class Exposure extends Component {
         'tracking_dec',
         'sky_angle',
         'timespan_begin',
-        'timespan_end',
+        'seconds_length',
       ];
       csvHeaders = exportedParams.map((key) => ({ label: key, key }));
       csvData = this.parseCsvData(filteredData);

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -637,7 +637,7 @@ export default class ExposureAdd extends Component {
                   {savingLog ? (
                     <SpinnerIcon className={styles.spinnerIcon} />
                   ) : (
-                    <span className={styles.title}>Upload Log</span>
+                    <span className={styles.title}>Save</span>
                   )}
                 </Button>
               </div>

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -23,7 +23,7 @@ import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import { CSVLink } from 'react-csv';
 import {
-  DATE_TIME_FORMAT,
+  TIME_FORMAT,
   OLE_COMMENT_TYPE_OPTIONS,
   OLE_JIRA_COMPONENTS,
   iconLevelOLE,
@@ -392,7 +392,6 @@ export default class NonExposure extends Component {
       />
     ) : (
       <div className={styles.margin10}>
-        <div className={styles.title}>Filter</div>
         <div className={styles.filters}>
           <Button disabled={this.state.updatingLogs} onClick={() => this.queryNarrativeLogs()}>
             Refresh data
@@ -416,28 +415,28 @@ export default class NonExposure extends Component {
             onChange={changeDayNarrative}
           />
 
+          <div className={styles.checkboxText}>
+            <Input
+              type="checkbox"
+              checked={selectedObsTimeLoss}
+              onChange={(event) => changeObsTimeLossSelect(event.target.checked)}
+            />
+            Show only with time loss
+          </div>
+
           <Select
             options={OLE_COMMENT_TYPE_OPTIONS}
             option={selectedCommentType}
             onChange={(value) => changeCommentTypeSelect(value)}
-            className={styles.select}
+            className={styles.selectComment}
           />
 
           <Select
             options={['All components', ...OLE_JIRA_COMPONENTS]}
             option={selectedComponent}
             onChange={({ value }) => changeComponentSelect(value)}
-            className={styles.select}
+            className={styles.selectComponent}
           />
-
-          <div className={styles.checkboxText}>
-            Show only with time loss
-            <Input
-              type="checkbox"
-              checked={selectedObsTimeLoss}
-              onChange={(event) => changeObsTimeLossSelect(event.target.checked)}
-            />
-          </div>
 
           <div className={styles.divExportBtn}>
             <CSVLink data={csvData} headers={csvHeaders} filename={csvTitle}>
@@ -451,7 +450,7 @@ export default class NonExposure extends Component {
           </div>
         </div>
         <div className={styles.lastUpdated}>
-          Last updated: {this.state.lastUpdated ? this.state.lastUpdated.format(DATE_TIME_FORMAT) : ''}
+          Last updated: {this.state.lastUpdated ? this.state.lastUpdated.format(TIME_FORMAT) : ''}
           {this.state.updatingLogs && <SpinnerIcon className={styles.spinnerIcon} />}
         </div>
         <SimpleTable headers={headers} data={filteredData} />

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -248,9 +248,11 @@ export default class NonExposure extends Component {
   parseCsvData(data) {
     const csvData = data.map((row) => {
       const escapedMessageText = row.message_text.replace(/"/g, '""');
+      const parsedLevel = OLE_COMMENT_TYPE_OPTIONS.find((option) => option.value === row.level).label;
       return {
         ...row,
         message_text: escapedMessageText,
+        level: parsedLevel,
       };
     });
     return csvData;
@@ -320,7 +322,6 @@ export default class NonExposure extends Component {
         'date_added',
         'message_text',
         'level',
-        'tags',
         'urls',
         'date_begin',
         'date_end',

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -149,7 +149,7 @@ export default class NonExposure extends Component {
         title: 'Date Added (UTC)',
         type: 'string',
         className: styles.tableHead,
-        render: (value) => value,
+        render: (value) => value.split('.')[0],
       },
       {
         field: 'level',

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -25,6 +25,7 @@ import { CSVLink } from 'react-csv';
 import {
   DATE_TIME_FORMAT,
   OLE_COMMENT_TYPE_OPTIONS,
+  OLE_JIRA_COMPONENTS,
   iconLevelOLE,
   ISO_INTEGER_DATE_FORMAT,
   ISO_STRING_DATE_TIME_FORMAT,
@@ -63,6 +64,10 @@ export default class NonExposure extends Component {
     }),
     /** Function to handle the comment type filter */
     changeCommentTypeSelect: PropTypes.func,
+    /** Selected component of the component filter */
+    selectedComponent: PropTypes.string,
+    /** Function to handle the component filter */
+    changeComponentSelect: PropTypes.func,
     /** Selected obs time loss of the obs time loss filter */
     selectedObsTimeLoss: PropTypes.bool,
     /** Function to handle the obs time loss filter */
@@ -75,6 +80,8 @@ export default class NonExposure extends Component {
     changeDayNarrative: () => {},
     selectedCommentType: OLE_COMMENT_TYPE_OPTIONS[0],
     changeCommentTypeSelect: () => {},
+    selectedComponent: 'All components',
+    changeComponentSelect: () => {},
     selectedObsTimeLoss: false,
     changeObsTimeLossSelect: () => {},
   };
@@ -150,6 +157,13 @@ export default class NonExposure extends Component {
         type: 'string',
         className: styles.tableHead,
         render: (value) => this.getLevel(value),
+      },
+      {
+        field: 'components',
+        title: 'Components',
+        type: 'string',
+        className: styles.tableHead,
+        render: (value) => value.join(', '),
       },
       {
         field: null,
@@ -293,9 +307,11 @@ export default class NonExposure extends Component {
       selectedDayNarrativeStart,
       selectedDayNarrativeEnd,
       selectedCommentType,
+      selectedComponent,
       selectedObsTimeLoss,
       changeDayNarrative,
       changeCommentTypeSelect,
+      changeComponentSelect,
       changeObsTimeLossSelect,
     } = this.props;
     const { logs: tableData, modeView, modeEdit } = this.state;
@@ -304,8 +320,13 @@ export default class NonExposure extends Component {
     let filteredData = [...tableData];
 
     // Filter by type
-    if (selectedCommentType.value !== 'all') {
+    if (selectedCommentType.value !== OLE_COMMENT_TYPE_OPTIONS[0].value) {
       filteredData = filteredData.filter((log) => log.level === selectedCommentType.value);
+    }
+
+    // Filter by component
+    if (selectedComponent !== 'All components') {
+      filteredData = filteredData.filter((log) => log.components.includes(selectedComponent));
     }
 
     // Filter by obs time loss
@@ -399,6 +420,13 @@ export default class NonExposure extends Component {
             options={OLE_COMMENT_TYPE_OPTIONS}
             option={selectedCommentType}
             onChange={(value) => changeCommentTypeSelect(value)}
+            className={styles.select}
+          />
+
+          <Select
+            options={['All components', ...OLE_JIRA_COMPONENTS]}
+            option={selectedComponent}
+            onChange={({ value }) => changeComponentSelect(value)}
             className={styles.select}
           />
 

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -116,9 +116,9 @@ export default class NonExposure extends Component {
     const label = value >= 100 ? 'urgent' : 'info';
     const icon = iconLevelOLE[label] ?? undefined;
     return (
-      <>
-        <span className={styles.levelIcon}>{icon}</span> {label}
-      </>
+      <span title={label} className={styles.levelIcon}>
+        {icon}
+      </span>
     );
   }
 

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -195,16 +195,27 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   height: 1.5em;
 }
 
-.filters .select {
+.filters .selectComment,
+.filters .selectComponent {
+  text-align: left;
   white-space: nowrap;
-  flex: 0 0 300px;
   border: 1px solid var(--secondary-font-dimmed-color);
 }
 
+.filters .selectComment {
+  flex: 0 0 20ch;
+}
+
+.filters .selectComponent {
+  flex: 0 0 35ch;
+}
+
 .lastUpdated {
+  display: flex;
+  align-items: center;
   text-align: left;
-  margin-bottom: 0.5em;
   color: var(--primary-font-color);
+  margin-bottom: var(--small-padding);
 }
 
 .floatRight {

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -267,7 +267,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .contentRight textarea {
   width: 100%;
   min-width: 30em;
-  height: 12em;
+  min-height: 12ch;
   resize: none;
   background: var(--secondary-background-dimmed-color);
   color: var(--base-font-color);
@@ -328,6 +328,11 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   border: 1px solid var(--secondary-font-color);
 }
 
+.footerLeft {
+  display: flex;
+  align-items: center;
+}
+
 .footerRight {
   margin-left: auto;
 }
@@ -344,7 +349,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   margin-right: 5px;
   align-items: center;
   text-align: left;
-  min-width: 24ch;
 }
 
 .footerMenu .checkboxText {
@@ -353,10 +357,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .checkboxText > *:not(:last-child) {
   margin-right: 0.5em;
-}
-
-.checkboxText > input:first-of-type {
-  width: auto;
 }
 
 .checkboxText > button {
@@ -423,14 +423,17 @@ th.tableHead {
 }
 
 .inputError {
-  margin-top: var(--small-padding);
-  color: var(--status-alert-color);
+  border-color: var(--status-alert-color);
 }
 
 .incidentTimeTypeContainer {
   display: flex;
   align-items: center;
   margin-bottom: var(--small-padding);
+}
+
+.incidentTimeTypeContainer > :first-child {
+  margin-right: var(--small-padding);
 }
 
 .refreshDateIcon {
@@ -473,12 +476,15 @@ th.tableHead {
   margin-right: var(--small-padding);
 }
 
-.footer .toAttachFiles,
-.footerMenu .toAttachFiles {
-  margin-bottom: var(--small-padding);
-}
-
 .footer .jira,
 .footerMenu .jira {
   white-space: nowrap;
+}
+
+.footer .jira {
+  margin-right: var(--small-padding);
+}
+
+.footerMenu .jira {
+  margin-bottom: var(--small-padding);
 }

--- a/love/src/components/OLE/OLE.jsx
+++ b/love/src/components/OLE/OLE.jsx
@@ -47,6 +47,7 @@ export default class OLE extends Component {
       selectedDayNarrativeStart: Moment().subtract(1, 'days'),
       selectedDayNarrativeEnd: Moment(),
       selectedCommentType: OLE_COMMENT_TYPE_OPTIONS[0],
+      selectedComponent: 'All components',
       selectedObsTimeLoss: false,
       // Exposure filters
       instruments: [],
@@ -69,6 +70,10 @@ export default class OLE extends Component {
 
   changeCommentTypeSelect(value) {
     this.setState({ selectedCommentType: value });
+  }
+
+  changeComponentSelect(value) {
+    this.setState({ selectedComponent: value });
   }
 
   changeObsTimeLossSelect(value) {
@@ -146,6 +151,8 @@ export default class OLE extends Component {
             changeDayNarrative={(day, type) => this.changeDayNarrative(day, type)}
             selectedCommentType={this.state.selectedCommentType}
             changeCommentTypeSelect={(value) => this.changeCommentTypeSelect(value)}
+            selectedComponent={this.state.selectedComponent}
+            changeComponentSelect={(value) => this.changeComponentSelect(value)}
             selectedObsTimeLoss={this.state.selectedObsTimeLoss}
             changeObsTimeLossSelect={(value) => this.changeObsTimeLossSelect(value)}
           />


### PR DESCRIPTION
This PR makes several improvements to the OLE components to better use of the layout and also a few requested things were implemented too:

- Remove the level column from the csv file in the narrative log.
- Remove "ID" from saved column in exposure log csv.
- Add exposure length column (in seconds) and remove timespan_end column in exposureLog.
- Remove group_id from exposureLog csv file.
- Implement interface suggestions for moving buttons and making stuff more clear. See attached presentation on [LOVE-249](https://jira.lsstcorp.org/browse/LOVE-249). 
- Display latest message of each image logs on exposure log table.
- Implement a way to filter narrative logs by components notated (AuxTel, MainTel, etc).
- Remove "Priority" category in the filter. Priority is the name of the filter, not a category.