### PR TITLE
Add AuxTel Atmospheric Transmission

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,15 @@
 Version History
 ===============
 
+v5.26.1
+-------
+
+* Add AuxTel Atmospheric Transmission `<https://github.com/lsst-ts/LOVE-frontend/pull/546>`_
+* Extend OLE Jira feature by implementing a compatible wysiwyg `<https://github.com/lsst-ts/LOVE-frontend/pull/543>`_
+
 v5.26.0
 -------
 
-* Extend OLE Jira feature by implementing a compatible wysiwyg `<https://github.com/lsst-ts/LOVE-frontend/pull/543>`_
 * Final adjustments for EnvironmentSummary `<https://github.com/lsst-ts/LOVE-frontend/pull/545>`_
 * Bump @babel/traverse from 7.22.5 to 7.23.2 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/544>`_
 * Add Simonyi Interlock Signals `<https://github.com/lsst-ts/LOVE-frontend/pull/542>`_

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -579,6 +579,7 @@ class Layout extends Component {
               auxtelObsMode={this.props.observatorySummary?.auxtelObservingMode}
               degradation={this.props.observatorySummary?.degradation}
               auxtelPower={'UNKNOWN'}
+              atmosphericTrans={this.props.observatorySummary?.atmosphericTrans}
             ></ObservatorySummaryMenu>
           </div>
         </DropdownMenu>

--- a/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.jsx
+++ b/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.jsx
@@ -46,6 +46,7 @@ export default function ObservatorySummaryMenu({
   auxtelObsMode,
   auxtelPower,
   degradation,
+  atmosphericTrans,
 }) {
   const simonyiTrackingStateText = telescopeTrackingStateMap[simonyiTrackingState];
   const simonyiTrackingModeText = telescopeTrackingModeStateMap[simonyiTrackingMode];
@@ -138,6 +139,9 @@ export default function ObservatorySummaryMenu({
 
         <span className={styles.label}>Power Source</span>
         <span>{auxtelPower}</span>
+
+        <span className={styles.label}>Atmos. Trans.</span>
+        <span>{atmosphericTrans}</span>
       </div>
     </>
   );
@@ -178,4 +182,6 @@ ObservatorySummaryMenu.propTypes = {
   auxtelObsMode: PropTypes.string,
   /** Auxiliary Telescope Power Source */
   auxtelPower: PropTypes.string,
+  /** Atmospheric Transmission */
+  atmosphericTrans: PropTypes.string,
 };

--- a/love/src/components/ObservatorySummary/ObservatorySummary.jsx
+++ b/love/src/components/ObservatorySummary/ObservatorySummary.jsx
@@ -52,6 +52,8 @@ export default class ObservatorySummary extends Component {
     controlLocation: PropTypes.object,
     /** Last Updated Control Location info */
     lastUpdated: PropTypes.instanceOf(Date),
+    /** Atmospheric Transmission */
+    atmosphericTrans: PropTypes.string,
   };
 
   static defaultProps = {
@@ -63,6 +65,7 @@ export default class ObservatorySummary extends Component {
     auxtelTrackingMode: 'UNKNOWN',
     controlLocation: null,
     lastUpdated: null,
+    atmosphericTrans: 'UNKNOWN',
   };
 
   componentDidMount() {
@@ -84,6 +87,7 @@ export default class ObservatorySummary extends Component {
       controlLocation,
       lastUpdated,
       degradation,
+      atmosphericTrans,
     } = this.props;
 
     const controlLocationName = controlLocation
@@ -143,6 +147,8 @@ export default class ObservatorySummary extends Component {
           <Value>{auxtelTrackingModeText}</Value>
           <Label>Power Source</Label>
           <Value>UNKNOWN</Value>
+          <Label>Atmos. Trans.</Label>
+          <Value>{atmosphericTrans}</Value>
         </SummaryPanel>
       </div>
     );


### PR DESCRIPTION
This PR adds the Auxtel Atmospheric Transmission value to the Observatory Summary and Observatory Summary Menu, in accordance with Jira ticket [LOVE-247](https://jira.lsstcorp.org/browse/LOVE-247).