### PR TITLE
Reconnecting Power Draw to mocked telemetries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.26.1
 -------
 
+* Reconnect MTDome Power Draw Plots to mocekd 'undefined' telemetries `<https://github.com/lsst-ts/LOVE-frontend/pull/548>`_
 * Add AuxTel Atmospheric Transmission `<https://github.com/lsst-ts/LOVE-frontend/pull/546>`_
 * Extend OLE Jira feature by implementing a compatible wysiwyg `<https://github.com/lsst-ts/LOVE-frontend/pull/543>`_
 

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.26.0",
+  "version": "5.26.1",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1397,7 +1397,17 @@ export const defaultNumberFormatter = (value, precision = 4) => {
  */
 export const formatTimestamp = (timestamp, location = 'TAI') => {
   const t = parseTimestamp(timestamp);
-  return `${t.toUTC().toFormat('yyyy/MM/dd HH:mm:ss')} ${location}`;
+  return `${t.toUTC().toFormat('yyyy/MM/dd HH:mm:ss') + (location ? ' ' + location : '')}`;
+};
+
+/**
+ * Converts a timestamp into  "YYYY-MM-DD HH:MM:SS" formatted string
+ * @param {date-able} timestamp if float it must be in milliseconds
+ * @returns {string} "YYYY-MM-DD HH:MM:SS" formatted string
+ */
+export const parseForPlotTimestamp = (timestamp) => {
+  const t = parseTimestamp(timestamp);
+  return `${t.toUTC().toFormat('yyyy-MM-dd HH:mm:ss')}`;
 };
 
 /**

--- a/love/src/components/MainTel/MTDomePower/MTDomePower.container.jsx
+++ b/love/src/components/MainTel/MTDomePower/MTDomePower.container.jsx
@@ -18,9 +18,10 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Power from './MTDomePower';
-import { getDomeStatus, getLouversStatus, getApertureShutter, getLightWindScreen } from '../../../redux/selectors';
+import MtDomePower from './MTDomePower';
+import { getMtDomePowerDraw } from '../../../redux/selectors';
 import { addGroup, removeGroup } from '../../../redux/actions/ws';
 import SubscriptionTableContainer from '../../GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
 
@@ -57,39 +58,57 @@ export const schema = {
 };
 
 const MTDomePowerContainer = ({
-  subscribeToStream,
-  unsubscribeToStream,
-  powerDrawShutter,
-  powerDrawLWS,
+  subscribeToStreams,
+  unsubscribeToStreams,
+  powerDrawCalibration,
+  powerDrawRAD,
+  powerDrawOBC,
+  powerDrawFans,
   powerDrawLouvers,
-  atDomePosition,
+  powerDrawLWS,
+  powerDrawShutter,
+  powerDrawElectronics,
+  timestampCalibration,
+  timestampRAD,
+  timestampOBC,
+  timestampFans,
+  timestampLouvers,
+  timestampLWS,
+  timestampShutter,
+  timestampElectronics,
   ...props
 }) => {
   if (props.isRaw) {
     return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
   }
   return (
-    <Power
-      subscribeToStream={subscribeToStream}
-      unsubscribeToStream={unsubscribeToStream}
-      powerDrawShutter={powerDrawShutter}
-      powerDrawLWS={powerDrawLWS}
+    <MtDomePower
+      subscribeToStreams={subscribeToStreams}
+      unsubscribeToStreams={unsubscribeToStreams}
+      powerDrawCalibration={powerDrawCalibration}
+      powerDrawRAD={powerDrawRAD}
+      powerDrawOBC={powerDrawOBC}
+      powerDrawFans={powerDrawFans}
       powerDrawLouvers={powerDrawLouvers}
-      atDomePosition={atDomePosition}
+      powerDrawLWS={powerDrawLWS}
+      powerDrawShutter={powerDrawShutter}
+      powerDrawElectronics={powerDrawElectronics}
+      timestampCalibration={timestampCalibration}
+      timestampRAD={timestampRAD}
+      timestampOBC={timestampOBC}
+      timestampFans={timestampFans}
+      timestampLouvers={timestampLouvers}
+      timestampLWS={timestampLWS}
+      timestampShutter={timestampShutter}
+      timestampElectronics={timestampElectronics}
     />
   );
 };
 
 const mapStateToProps = (state) => {
-  const domeState = getDomeStatus(state);
-  const louversState = getLouversStatus(state);
-  const apertureShutterState = getApertureShutter(state);
-  const lightWindScreenState = getLightWindScreen(state);
+  const mtDomePowerDraw = getMtDomePowerDraw(state);
   return {
-    ...domeState,
-    ...louversState,
-    ...apertureShutterState,
-    ...lightWindScreenState,
+    ...mtDomePowerDraw,
   };
 };
 
@@ -98,17 +117,25 @@ const mapDispatchToProps = (dispatch) => {
     'telemetry-MTDome-0-apertureShutter',
     'telemetry-MTDome-0-lightWindScreen',
     'telemetry-MTDome-0-louvers',
-    'telemetry-ATDome-0-position',
+    'telemetry-MTDome-0-rearAccessDoor',
+    'telemetry-ESS-301-temperature',
   ];
   return {
     subscriptions,
-    subscribeToStream: () => {
+    subscribeToStreams: () => {
       subscriptions.forEach((stream) => dispatch(addGroup(stream)));
     },
-    unsubscribeToStream: () => {
+    unsubscribeToStreams: () => {
       subscriptions.forEach((stream) => dispatch(removeGroup(stream)));
     },
   };
+};
+
+MtDomePower.propTypes = {
+  /** Wheter the component is in raw mode */
+  isRaw: PropTypes.bool,
+  /** List of the component's subscriptions */
+  subscriptions: PropTypes.array,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MTDomePowerContainer);

--- a/love/src/components/MainTel/MTDomePower/MTDomePower.jsx
+++ b/love/src/components/MainTel/MTDomePower/MTDomePower.jsx
@@ -112,9 +112,9 @@ export default class MTDomePower extends Component {
 
   componentDidUpdate = (prevProps, prevState) => {
     //Calibration Screen
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampCalibration !== this.props.timestampCalibration) {
       const newValue = {
-        system: 'calibration',
+        system: '01-calibration',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawCalibration / 1000,
       };
@@ -124,9 +124,9 @@ export default class MTDomePower extends Component {
     }
 
     //RAD
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampRAD !== this.props.timestampRAD) {
       const newValue = {
-        system: 'rad',
+        system: '04-rad',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawRAD / 1000,
       };
@@ -136,9 +136,9 @@ export default class MTDomePower extends Component {
     }
 
     //OBC
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampOBC !== this.props.timestampOBC) {
       const newValue = {
-        system: 'obc',
+        system: '05-obc',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawOBC / 1000,
       };
@@ -148,9 +148,9 @@ export default class MTDomePower extends Component {
     }
 
     //Fans
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampFans !== this.props.timestampFans) {
       const newValue = {
-        system: 'fans',
+        system: '03-fans',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawFans / 1000,
       };
@@ -160,9 +160,9 @@ export default class MTDomePower extends Component {
     }
 
     //Louvers
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampLouvers !== this.props.timestampLouvers) {
       const newValue = {
-        system: 'louvers',
+        system: '08-louvers',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawLouvers / 1000,
       };
@@ -172,9 +172,9 @@ export default class MTDomePower extends Component {
     }
 
     //LWS
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampLWS !== this.props.timestampLWS) {
       const newValue = {
-        system: 'lws',
+        system: '07-lws',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawLWS / 1000,
       };
@@ -184,9 +184,9 @@ export default class MTDomePower extends Component {
     }
 
     //Shutters
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampShutter !== this.props.timestampShutter) {
       const newValue = {
-        system: 'shutters',
+        system: '06-shutters',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawShutter / 1000,
       };
@@ -196,9 +196,9 @@ export default class MTDomePower extends Component {
     }
 
     //Electronics
-    if (prevState.timestamp !== this.state.timestamp) {
+    if (prevProps.timestampElectronics !== this.props.timestampElectronics) {
       const newValue = {
-        system: 'electronics',
+        system: '02-electronics',
         date: parseForPlotTimestamp(this.state.timestamp * 1000),
         count: this.props.powerDrawElectronics / 1000,
       };
@@ -253,16 +253,40 @@ export default class MTDomePower extends Component {
     //Plot height without its axis info. Used to measure the relative plot height for the y axis system labels.
     const height2 = height - 34;
 
-    //Calculating the position for lateral labels, from tiop to bottom.
-    //First add all values and find the corresponding position
-    const powerDrawCalibration2 = height2 - (powerTotal * height2) / limit;
-    const powerDrawRAD2 = (powerDrawCalibration * height2) / limit - fontHeight + powerDrawCalibration2;
-    const powerDrawOBC2 = (powerDrawRAD * height2) / limit - fontHeight + powerDrawRAD2;
-    const powerDrawFans2 = (powerDrawOBC * height2) / limit - fontHeight + powerDrawOBC2;
-    const powerDrawLouvers2 = (powerDrawFans * height2) / limit - fontHeight + powerDrawFans2;
-    const powerDrawLWS2 = (powerDrawLouvers * height2) / limit - fontHeight + powerDrawLouvers2;
-    const powerDrawShutter2 = (powerDrawLWS * height2) / limit - fontHeight + powerDrawLWS2;
-    const powerDrawElectronics2 = (powerDrawShutter * height2) / limit - fontHeight + powerDrawShutter2;
+    //Calculating the position for lateral labels.
+
+    const powerDrawLouvers2 =
+      -fontHeight * 6.5 +
+      height2 -
+      ((powerDrawLouvers * height) / limit < fontHeight ? fontHeight : (powerDrawLouvers * height) / limit);
+    const powerDrawLWS2 =
+      powerDrawLouvers2 +
+      fontHeight -
+      ((powerDrawLWS * height) / limit < fontHeight ? fontHeight : (powerDrawLWS * height) / limit);
+    const powerDrawShutter2 =
+      powerDrawLWS2 +
+      fontHeight -
+      ((powerDrawShutter * height) / limit < fontHeight ? fontHeight : (powerDrawShutter * height) / limit);
+    const powerDrawOBC2 =
+      powerDrawShutter2 +
+      fontHeight -
+      ((powerDrawOBC * height) / limit < fontHeight ? fontHeight : (powerDrawOBC * height) / limit);
+    const powerDrawRAD2 =
+      powerDrawOBC2 +
+      fontHeight -
+      ((powerDrawRAD * height) / limit < fontHeight ? fontHeight : (powerDrawRAD * height) / limit);
+    const powerDrawFans2 =
+      powerDrawRAD2 +
+      fontHeight -
+      ((powerDrawFans * height) / limit < fontHeight ? fontHeight : (powerDrawFans * height) / limit);
+    const powerDrawElectronics2 =
+      powerDrawFans2 +
+      fontHeight -
+      ((powerDrawElectronics * height) / limit < fontHeight ? fontHeight : (powerDrawElectronics * height) / limit);
+    const powerDrawCalibration2 =
+      powerDrawElectronics2 +
+      fontHeight -
+      ((powerDrawCalibration * height) / limit < fontHeight ? fontHeight : (powerDrawCalibration * height) / limit);
 
     //The Plot Info
     const spec = {
@@ -423,8 +447,6 @@ export default class MTDomePower extends Component {
       },
     };
 
-    console.log(this.state.data);
-
     return (
       <div className={styles.container}>
         <div className={styles.leftPanel}>
@@ -436,37 +458,61 @@ export default class MTDomePower extends Component {
             actions={false}
           />
           <div className={styles.systemList}>
-            <div style={{ top: `${powerDrawCalibration2}px` }}>
+            <div
+              style={{ top: `${powerDrawCalibration2}px` }}
+              className={this.props.powerDrawCalibration === undefined ? styles.disabled : ''}
+            >
               <span className={styles.kwBold}>{`${fixedFloat(powerDrawCalibration, 1)} kW`}</span>
               {` Calibration`}
             </div>
-            <div style={{ top: `${powerDrawRAD2}px` }}>
-              <span className={styles.kwBold}>{`${fixedFloat(powerDrawRAD, 1)} kW`}</span>
-              {` RAD`}
+            <div
+              style={{ top: `${powerDrawElectronics2}px` }}
+              className={this.props.powerDrawElectronics === undefined ? styles.disabled : ''}
+            >
+              <span className={styles.kwBold}>{`${fixedFloat(powerDrawElectronics, 1)} kW`}</span>
+              {` Electronics`}
             </div>
-            <div style={{ top: `${powerDrawOBC2}px` }}>
-              <span className={styles.kwBold}>{`${fixedFloat(powerDrawOBC, 1)} kW`}</span>
-              {` OBC`}
-            </div>
-            <div style={{ top: `${powerDrawFans2}px` }}>
+            <div
+              style={{ top: `${powerDrawFans2}px` }}
+              className={this.props.powerDrawFans === undefined ? styles.disabled : ''}
+            >
               <span className={styles.kwBold}>{`${fixedFloat(powerDrawFans, 1)} kW`}</span>
               {` Fans`}
             </div>
-            <div style={{ top: `${powerDrawLouvers2}px` }}>
-              <span className={styles.kwBold}>{`${fixedFloat(powerDrawLouvers, 1)} kW`}</span>
-              {` Louvers`}
+            <div
+              style={{ top: `${powerDrawRAD2}px` }}
+              className={this.props.powerDrawRAD === undefined ? styles.disabled : ''}
+            >
+              <span className={styles.kwBold}>{`${fixedFloat(powerDrawRAD, 1)} kW`}</span>
+              {` RAD`}
             </div>
-            <div style={{ top: `${powerDrawLWS2}px` }}>
-              <span className={styles.kwBold}>{`${fixedFloat(powerDrawLWS, 1)} kW`}</span>
-              {` LWS`}
+            <div
+              style={{ top: `${powerDrawOBC2}px` }}
+              className={this.props.powerDrawOBC === undefined ? styles.disabled : ''}
+            >
+              <span className={styles.kwBold}>{`${fixedFloat(powerDrawOBC, 1)} kW`}</span>
+              {` OBC`}
             </div>
-            <div style={{ top: `${powerDrawShutter2}px` }}>
+            <div
+              style={{ top: `${powerDrawShutter2}px` }}
+              className={this.props.powerDrawShutter === undefined ? styles.disabled : ''}
+            >
               <span className={styles.kwBold}>{`${fixedFloat(powerDrawShutter, 1)} kW`}</span>
               {` Shutters`}
             </div>
-            <div style={{ top: `${powerDrawElectronics2}px` }}>
-              <span className={styles.kwBold}>{`${fixedFloat(powerDrawElectronics, 1)} kW`}</span>
-              {` Electronics`}
+            <div
+              style={{ top: `${powerDrawLWS2}px` }}
+              className={this.props.powerDrawLWS === undefined ? styles.disabled : ''}
+            >
+              <span className={styles.kwBold}>{`${fixedFloat(powerDrawLWS, 1)} kW`}</span>
+              {` LWS`}
+            </div>
+            <div
+              style={{ top: `${powerDrawLouvers2}px` }}
+              className={this.props.powerDrawLouvers === undefined ? styles.disabled : ''}
+            >
+              <span className={styles.kwBold}>{`${fixedFloat(powerDrawLouvers, 1)} kW`}</span>
+              {` Louvers`}
             </div>
           </div>
           <div style={{ width: 0 }}>
@@ -483,7 +529,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawCalibration, 1)}
             data={this.state.dataCS}
             title={'Calibration Screen'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawCalibration === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={0.75}
@@ -492,7 +538,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawRAD, 1)}
             data={this.state.dataRAD}
             title={'Rear Access Door'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawRAD === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={3}
@@ -501,7 +547,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawOBC, 1)}
             data={this.state.dataOBC}
             title={'Overhead Bridge Crane'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawOBC === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={6}
@@ -510,7 +556,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawFans, 1)}
             data={this.state.dataFans}
             title={'Fans'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawFans === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={25}
@@ -519,7 +565,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawLouvers, 1)}
             data={this.state.dataLouvers}
             title={'Louvers'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawLouvers === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={69}
@@ -528,7 +574,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawLWS, 1)}
             data={this.state.dataLWS}
             title={'Light Wind Screen'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawLWS === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={68}
@@ -537,7 +583,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawShutter, 1)}
             data={this.state.dataShutters}
             title={'Shutters'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawShutter === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={6}
@@ -546,7 +592,7 @@ export default class MTDomePower extends Component {
             powerDraw={fixedFloat(powerDrawElectronics, 1)}
             data={this.state.dataED}
             title={'Electronic Devices'}
-            className={styles.powerPlot}
+            className={this.props.powerDrawElectronics === undefined ? styles.disabled : ''}
             height={200}
             width={150}
             limit={1}

--- a/love/src/components/MainTel/MTDomePower/MTDomePower.module.css
+++ b/love/src/components/MainTel/MTDomePower/MTDomePower.module.css
@@ -38,9 +38,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   flex-wrap: wrap;
 }
 
-.plotContainer {
-}
-
 .plotContainer svg {
   background: none !important;
 }
@@ -69,4 +66,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .powerTotal:after {
   width: 0px;
+}
+
+.disabled {
+  opacity: 0.2;
 }

--- a/love/src/components/MainTel/MTDomePower/PowerPlot/PowerPlot.jsx
+++ b/love/src/components/MainTel/MTDomePower/PowerPlot/PowerPlot.jsx
@@ -35,6 +35,8 @@ export default class PowerPlot extends Component {
     powerDrawLightWindScreen: PropTypes.number,
     /** Shutters power draw (W) */
     powerDrawShutter: PropTypes.number,
+    /** ClassName style to be asigned to the Power Plot */
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -211,13 +213,13 @@ export default class PowerPlot extends Component {
     };
 
     return (
-      <div className={styles.container}>
+      <div className={[styles.container, this.props.className].join(' ')}>
         <div className={styles.plot}>
           <VegaLite
             style={{ display: 'flex' }}
             renderer="svg"
             spec={spec}
-            className={[styles.plotContainer, this.props.className].join(' ')}
+            className={styles.plotContainer}
             actions={false}
           />
           <div style={{ width: 0 }}>

--- a/love/src/components/MainTel/MTDomePower/PowerPlot/PowerPlot.jsx
+++ b/love/src/components/MainTel/MTDomePower/PowerPlot/PowerPlot.jsx
@@ -155,30 +155,58 @@ export default class PowerPlot extends Component {
       // 4.0.0 DATA //
       ////////////////
       data: {
-        values: this.props.data,
-        // [
-        //   {
-        //     "system":"aCalibration Screen",
-        //     "count":powerDraw*0.35,
-        //     "date":"2020-01-01 10:10:00",
-        //   },{
-        //     "system":"aCalibration Screen",
-        //     "count":powerDraw*0.1,
-        //     "date":"2020-01-01 10:12:00",
-        //   },{
-        //     "system":"aCalibration Screen",
-        //     "count":powerDraw*0.05,
-        //     "date":"2020-01-01 10:14:00",
-        //   },{
-        //     "system":"aCalibration Screen",
-        //     "count":powerDraw*0.75,
-        //     "date":"2020-01-01 10:16:00",
-        //   },{
-        //     "system":"aCalibration Screen",
-        //     "count":powerDraw,
-        //     "date":"2020-01-01 10:18:00",
-        //   }
-        // ]
+        values: [
+          {
+            system: this.props.data[0]?.system ?? 0,
+            count: this.props.data[0]?.count ?? 0,
+            date: '2020-01-01 10:10:00',
+          },
+          {
+            system: this.props.data[1]?.system ?? 0,
+            count: this.props.data[1]?.count ?? 0,
+            date: '2020-01-01 10:11:00',
+          },
+          {
+            system: this.props.data[2]?.system ?? 0,
+            count: this.props.data[2]?.count ?? 0,
+            date: '2020-01-01 10:12:00',
+          },
+          {
+            system: this.props.data[3]?.system ?? 0,
+            count: this.props.data[3]?.count ?? 0,
+            date: '2020-01-01 10:13:00',
+          },
+          {
+            system: this.props.data[4]?.system ?? 0,
+            count: this.props.data[4]?.count ?? 0,
+            date: '2020-01-01 10:14:00',
+          },
+          {
+            system: this.props.data[5]?.system ?? 0,
+            count: this.props.data[5]?.count ?? 0,
+            date: '2020-01-01 10:15:00',
+          },
+          {
+            system: this.props.data[6]?.system ?? 0,
+            count: this.props.data[6]?.count ?? 0,
+            date: '2020-01-01 10:16:00',
+          },
+          {
+            system: this.props.data[7]?.system ?? 0,
+            count: this.props.data[7]?.count ?? 0,
+            date: '2020-01-01 10:17:00',
+          },
+          {
+            system: this.props.data[8]?.system ?? 0,
+            count: this.props.data[8]?.count ?? 0,
+            date: '2020-01-01 10:18:00',
+          },
+          {
+            system: this.props.data[9]?.system ?? 0,
+            count: this.props.data[9]?.count ?? 0,
+            date: '2020-01-01 10:19:00',
+          },
+        ],
       },
     };
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -1139,6 +1139,36 @@ export const getDomeStatus = (state) => {
   };
 };
 
+// MTDome Power Draw
+export const getMtDomePowerDraw = (state) => {
+  const subscriptions = [
+    'telemetry-MTDome-0-apertureShutter',
+    'telemetry-MTDome-0-lightWindScreen',
+    'telemetry-MTDome-0-louvers',
+    'telemetry-MTDome-0-rearAccessDoor',
+    'telemetry-ESS-301-temperature',
+  ];
+  const mtDomePowerDraw = getStreamsData(state, subscriptions);
+  return {
+    powerDrawCalibration: Math.floor(Math.random() * 750),
+    timestampCalibration: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawRAD: mtDomePowerDraw['telemetry-MTDome-0-rearAccessDoor']?.powerDraw?.value ?? undefined,
+    timestampRAD: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawOBC: Math.floor(Math.random() * 6000),
+    timestampOBC: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawFans: Math.floor(Math.random() * 22500) + 2500,
+    timestampFans: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawLouvers: mtDomePowerDraw['telemetry-MTDome-0-louvers']?.powerDraw?.value ?? undefined,
+    timestampLouvers: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawLWS: mtDomePowerDraw['telemetry-MTDome-0-lightWindScreen']?.powerDraw?.value ?? undefined,
+    timestampLWS: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawShutter: mtDomePowerDraw['telemetry-MTDome-0-apertureShutter']?.powerDraw?.value ?? undefined,
+    timestampShutter: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    powerDrawElectronics: Math.floor(Math.random() * 500) + 500,
+    timestampElectronics: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+  };
+};
+
 // MTMount
 /**
  * Selects the TMA status for summary view

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -1150,22 +1150,24 @@ export const getMtDomePowerDraw = (state) => {
   ];
   const mtDomePowerDraw = getStreamsData(state, subscriptions);
   return {
-    powerDrawCalibration: Math.floor(Math.random() * 750),
-    timestampCalibration: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
     powerDrawRAD: mtDomePowerDraw['telemetry-MTDome-0-rearAccessDoor']?.powerDraw?.value ?? undefined,
-    timestampRAD: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
-    powerDrawOBC: Math.floor(Math.random() * 6000),
-    timestampOBC: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
-    powerDrawFans: Math.floor(Math.random() * 22500) + 2500,
-    timestampFans: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    timestampRAD: mtDomePowerDraw['telemetry-MTDome-0-rearAccessDoor']?.timestamp?.value ?? undefined,
     powerDrawLouvers: mtDomePowerDraw['telemetry-MTDome-0-louvers']?.powerDraw?.value ?? undefined,
-    timestampLouvers: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
-    powerDrawLWS: mtDomePowerDraw['telemetry-MTDome-0-lightWindScreen']?.powerDraw?.value ?? undefined,
-    timestampLWS: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    timestampLouvers: mtDomePowerDraw['telemetry-MTDome-0-louvers']?.timestamp?.value ?? undefined,
     powerDrawShutter: mtDomePowerDraw['telemetry-MTDome-0-apertureShutter']?.powerDraw?.value ?? undefined,
-    timestampShutter: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
-    powerDrawElectronics: Math.floor(Math.random() * 500) + 500,
-    timestampElectronics: mtDomePowerDraw['telemetry-ESS-301-temperature']?.timestamp?.value ?? undefined,
+    timestampShutter: mtDomePowerDraw['telemetry-MTDome-0-apertureShutter']?.timestamp?.value ?? undefined,
+
+    //TODO: Once telemetries are created, add them here.
+    powerDrawCalibration: undefined,
+    timestampCalibration: undefined,
+    powerDrawOBC: undefined,
+    timestampOBC: undefined,
+    powerDrawFans: undefined,
+    timestampFans: undefined,
+    powerDrawLWS: undefined,
+    timestampLWS: undefined,
+    powerDrawElectronics: undefined,
+    timestampElectronics: undefined,
   };
 };
 


### PR DESCRIPTION
This PR connects the Power Draw to mocked telemetries that publish 'undefined', so that everything is ready to be implemented once these telemetries are included.

Some other minor adjustments have been done:
- Text on Total Power Plot stacks and doesn't overlap.
- Plots look disabled when no data is being received.
- Plot time axis is based on telemetry published timestamp, not timestamp of when data was recieved.