### PR TITLE
Adjust parameters names for ESS topics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.26.1
 -------
 
+* Adjust parameters names for ESS topics `<https://github.com/lsst-ts/LOVE-frontend/pull/549>`_
 * Reconnect MTDome Power Draw Plots to mocekd 'undefined' telemetries `<https://github.com/lsst-ts/LOVE-frontend/pull/548>`_
 * Add AuxTel Atmospheric Transmission `<https://github.com/lsst-ts/LOVE-frontend/pull/546>`_
 * Extend OLE Jira feature by implementing a compatible wysiwyg `<https://github.com/lsst-ts/LOVE-frontend/pull/543>`_

--- a/love/src/components/ESS/AuxTel/AuxTelESS.container.jsx
+++ b/love/src/components/ESS/AuxTel/AuxTelESS.container.jsx
@@ -102,10 +102,10 @@ const getGroupNames = (salindexList, option) => {
 
 /**
  * This function is used to parse dicts by 4 type of the telemetries
- * @param object prevParse 
- * @param array streams 
+ * @param object prevParse
+ * @param array streams
  * @param string option string for the option between temperature, relativeHumidity,
- *        airFlow and airTurbulence 
+ *        airFlow and airTurbulence
  * @returns array with the data separate parse of the telemetry
  */
 const parseStreams = (streams, option) => {
@@ -131,7 +131,7 @@ const parseStreams = (streams, option) => {
 
 /**
  * This function is used to parse dicts by temperature telemetry
- * @param {array} streams 
+ * @param {array} streams
  * @returns array with the data separate parse of the temperature telemetry
  */
 const parseTemperature = (streams) => {
@@ -168,7 +168,7 @@ const parseTemperature = (streams) => {
 
 /**
  * This function is used to parse dicts by relativeHumidity telemetry
- * @param {array} streams 
+ * @param {array} streams
  * @returns array with the data separate parse of the relativeHumidity telemetry
  */
 const parseHumidity = (streams) => {
@@ -177,7 +177,7 @@ const parseHumidity = (streams) => {
     Object.entries(stream).forEach((entry) => {
       const essData = entry[1];
       const sensorName = essData?.sensorName?.value ?? '';
-      const value = essData?.relativeHumidity?.value ?? 0;
+      const value = essData?.relativeHumidityItem?.value ?? 0;
       const location = essData?.location?.value ?? '';
       const timestamp = essData?.timestamp?.value;
       const xPosition = essData?.xPosition?.value;
@@ -200,7 +200,7 @@ const parseHumidity = (streams) => {
 
 /**
  * This function is used to parse dicts by speed telemetry
- * @param {array} streams 
+ * @param {array} streams
  * @returns array with the data separate parse of the speed telemetry
  */
 const parseAirflow = (streams) => {
@@ -274,7 +274,7 @@ const parseAirflow = (streams) => {
 
 /**
  * This function is used to parse dicts by speedMagnitud telemetry
- * @param {array} streams 
+ * @param {array} streams
  * @returns array with the data separate parse of the speedMagnitud telemetry
  */
 const parseAirTurbulence = (streams) => {

--- a/love/src/components/EnvironmentSummary/EnvironmentSummary.container.jsx
+++ b/love/src/components/EnvironmentSummary/EnvironmentSummary.container.jsx
@@ -72,7 +72,6 @@ const EnvironmentSummaryContainer = ({
   windSpeed,
   degradation,
   atmosphericTrans,
-  airTemp,
   pressure,
   humidity,
   seeing,
@@ -117,7 +116,6 @@ const EnvironmentSummaryContainer = ({
       windSpeed={windSpeed}
       degradation={degradation}
       atmosphericTrans={atmosphericTrans}
-      airTemp={airTemp}
       pressure={pressure}
       humidity={humidity}
       seeing={seeing}

--- a/love/src/components/EnvironmentSummary/EnvironmentSummary.jsx
+++ b/love/src/components/EnvironmentSummary/EnvironmentSummary.jsx
@@ -84,8 +84,6 @@ export default class EnvironmentSummary extends Component {
     degradation: PropTypes.number,
     /** Atmospheric Transmission */
     atmosphericTrans: PropTypes.number,
-    /** Air Temperature */
-    airTemp: PropTypes.number,
     /** The pressures */
     pressure: PropTypes.array,
     /** Relative humidity */
@@ -124,7 +122,6 @@ export default class EnvironmentSummary extends Component {
     windSpeed: 0,
     degradation: 'Unknown',
     atmosphericTrans: 'Unknown',
-    airTemp: 'Unknown',
     pressure: [],
     humidity: 'Unknown',
     seeing: 'Unknown',
@@ -189,7 +186,6 @@ export default class EnvironmentSummary extends Component {
       windSpeed,
       degradation,
       atmosphericTrans,
-      airTemp,
       pressure,
       humidity,
       seeing,
@@ -201,7 +197,6 @@ export default class EnvironmentSummary extends Component {
           <Summary
             degradation={degradation}
             atmosphericTrans={atmosphericTrans}
-            airTemp={airTemp}
             pressure={pressure}
             humidity={humidity}
             windSpeed={windSpeed}

--- a/love/src/components/EnvironmentSummary/Summary/Summary.jsx
+++ b/love/src/components/EnvironmentSummary/Summary/Summary.jsx
@@ -32,7 +32,6 @@ export default class Summary extends Component {
       windSpeed,
       degradation,
       atmosphericTrans,
-      airTemp,
       pressure,
       humidity,
       seeing,
@@ -48,8 +47,6 @@ export default class Summary extends Component {
           <Value>{degradation}</Value>
           <Label>Atm. Transmition</Label>
           <Value>{atmosphericTrans}</Value>
-          <Label>Air Temperature</Label>
-          <Value>{airTemp}</Value>
           <Label>Pressure</Label>
           <Value>{`${fixedFloat(pressure[0], 2)} Pa`}</Value>
         </SummaryPanel>

--- a/love/src/components/WeatherStation/WeatherStation.jsx
+++ b/love/src/components/WeatherStation/WeatherStation.jsx
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ManagerInterface, { parseCommanderData, fixedFloat } from 'Utils';
@@ -57,7 +56,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'temperature',
-          item: 'temperature',
+          item: 'temperatureItem',
           accessor: '(x) => x[0]',
         },
       ],
@@ -82,7 +81,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'dewPoint',
-          item: 'dewPoint',
+          item: 'dewPointItem',
           accessor: '(x) => x',
         },
       ],
@@ -100,7 +99,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'relativeHumidity',
-          item: 'relativeHumidity',
+          item: 'relativeHumidityItem',
           accessor: '(x) => x',
         },
       ],
@@ -118,7 +117,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'pressure',
-          item: 'pressure',
+          item: 'pressureItem',
           accessor: '(x) => x[0]',
         },
       ],
@@ -136,7 +135,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'solarRadiation',
-          item: 'solarRadiation',
+          item: 'solarRadiationItem',
           accessor: '(x) => x',
         },
       ],
@@ -154,7 +153,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'rainRate',
-          item: 'rainRate',
+          item: 'rainRateItem',
           accessor: '(x) => x',
         },
       ],
@@ -172,7 +171,7 @@ export default class WeatherStation extends Component {
           csc: 'ESS',
           salindex: this.props.salindex,
           topic: 'snowRate',
-          item: 'snowRate',
+          item: 'snowRateItem',
           accessor: '(x) => x',
         },
       ],
@@ -285,7 +284,7 @@ export default class WeatherStation extends Component {
   render() {
     const currentTemperature = fixedFloat(this.props.temperature?.temperature?.value[0], 2);
     const currentHumidity = fixedFloat(this.props.relativeHumidity?.relativeHumidity?.value, 2);
-    const currentPressure = fixedFloat(this.props.pressure?.pressure?.value[0], 2);
+    const currentPressure = fixedFloat(this.props.pressure?.pressureItem?.value[0], 2);
     const currentWindSpeed = fixedFloat(this.props.airFlow?.speed?.value, 2);
     const currentWindSpeedUnits = this.props.airFlow?.speed?.units;
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -2283,7 +2283,6 @@ export const getObservatoryState = (state) => {
     pressure: essPressure ? essPressure.pressureItem.value : 0,
     humidity: essRelativeHumidity ? essRelativeHumidity.relativeHumidityItem.value : 0,
     // TODO: Add the corresponding telemetry or event when the following variables gets integrated into SAL
-    airTemp: 'Unknown',
     atmosphericTrans: 'Unknown',
     seeing: 'Unknown',
   };

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -2274,14 +2274,14 @@ export const getObservatoryState = (state) => {
     isRaining: environmentVariables ? environmentVariables[0].raining.value : false,
     isSnowing: environmentVariables ? environmentVariables[0].snowing.value : false,
     numChannels: essTemperatures ? essTemperatures.numChannels.value : 0,
-    temperature: essTemperatures ? essTemperatures.temperature.value : [],
+    temperature: essTemperatures ? essTemperatures.temperatureItem.value : [],
     location: essTemperatures ? essTemperatures.location.value : '',
     windDirection: essAirFlow ? essAirFlow.direction.value : 0.0,
     windSpeed: essAirFlow ? essAirFlow.speed.value : 0.0,
     // TODO: Add the corresponding telemetry or event when Enviromental Degradation gets integrated into SAL
     degradation: 'Unknown',
-    pressure: essPressure ? essPressure.pressure.value : 0,
-    humidity: essRelativeHumidity ? essRelativeHumidity.relativeHumidity.value : 0,
+    pressure: essPressure ? essPressure.pressureItem.value : 0,
+    humidity: essRelativeHumidity ? essRelativeHumidity.relativeHumidityItem.value : 0,
     // TODO: Add the corresponding telemetry or event when the following variables gets integrated into SAL
     airTemp: 'Unknown',
     atmosphericTrans: 'Unknown',


### PR DESCRIPTION
This PR adjusts some ESS topics due to changes on the ESS XML that added the `Item` suffix to some topic parameters. The parameters adjusted are:

- ESS_logevent_relativeHumidity
- ESS_logevent_pressure
- ESS_logevent_temperature
- ESS_logevent_rainRate
- ESS_logevent_snowRate

Also a recently added param, `airTemp`, was removed as it was duplicating the current temperature value being displayed.