### PR TITLE
New params for narrative log: category and time_lost_type and other improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v5.27.0
 
 * Point LOVE weather station to read corresponding CSC `<https://github.com/lsst-ts/LOVE-frontend/pull/553>`_
 * Add Dynalene Component `<https://github.com/lsst-ts/LOVE-frontend/pull/552>`_
+* Add new params: category and time_lost_type to narrative log `<https://github.com/lsst-ts/LOVE-frontend/pull/551>`_
 
 v5.26.1
 -------

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -2069,3 +2069,13 @@ export function getObsDayFromDate(date) {
 export function truncateISODateToMinutes(date) {
   return date.substring(0, 16);
 }
+
+/**
+ * Function to convert first letter to uppercase
+ * @param {string} string string to be converted
+ * @returns {string} string with first letter in uppercase
+ */
+export function firstLetterToUpperCase(string) {
+  if (!string) return '';
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -2043,3 +2043,19 @@ export function simpleHtmlTokenizer(html) {
   }
   return tokens;
 }
+
+/**
+ * Function to get the OBS day from a date
+ * If the date is after 12:00 UTC, the day is the same day
+ * If the date is before 12:00 UTC, the day is the previous day
+ * @param {object} date date, as a Moment object, to be parsed
+ * @returns {string} OBS day in format YYYYMMDD
+ */
+export function getObsDayFromDate(date) {
+  const utcDate = date.utc();
+  const utcHour = utcDate.hour();
+  if (utcHour >= 12) {
+    return utcDate.format('YYYYMMDD');
+  }
+  return utcDate.subtract(1, 'day').format('YYYYMMDD');
+}

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -21,9 +21,7 @@ import html2canvas from 'html2canvas';
 import { DateTime } from 'luxon';
 import { toast } from 'react-toastify';
 import Moment from 'moment';
-import isEqual from 'lodash/isEqual';
-import { WEBSOCKET_SIMULATION, SUBPATH } from 'Config.js';
-import { parse } from 'vega';
+import { WEBSOCKET_SIMULATION, SUBPATH, ISO_INTEGER_DATE_FORMAT } from 'Config.js';
 
 /* Backwards compatibility of Array.flat */
 if (Array.prototype.flat === undefined) {
@@ -2058,7 +2056,16 @@ export function getObsDayFromDate(date) {
   const utcDate = date.utc();
   const utcHour = utcDate.hour();
   if (utcHour >= 12) {
-    return utcDate.format('YYYYMMDD');
+    return utcDate.format(ISO_INTEGER_DATE_FORMAT);
   }
-  return utcDate.subtract(1, 'day').format('YYYYMMDD');
+  return utcDate.subtract(1, 'day').format(ISO_INTEGER_DATE_FORMAT);
+}
+
+/**
+ * Function to truncate date ISO string to minutes
+ * @param {string} date date, as a ISO string, to be truncated
+ * @returns {string} truncated date in format YYYY-MM-DDTHH:mm
+ */
+export function truncateISODateToMinutes(date) {
+  return date.substring(0, 16);
 }

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -23,6 +23,7 @@ import { toast } from 'react-toastify';
 import Moment from 'moment';
 import isEqual from 'lodash/isEqual';
 import { WEBSOCKET_SIMULATION, SUBPATH } from 'Config.js';
+import { parse } from 'vega';
 
 /* Backwards compatibility of Array.flat */
 if (Array.prototype.flat === undefined) {
@@ -1956,10 +1957,10 @@ export function htmlToJiraMarkdown(html) {
  * @params {boolean} options.codeFriendly if true, text formatting is not applied
  * @returns {string} html string
  */
-export function jiraMarkdownToHtml(markdown, options = { codeFriendly: true }) {
+export function jiraMarkdownToHtml(markdown, options = { codeFriendly: true, parseLines: false }) {
   if (!markdown) return '';
 
-  const { codeFriendly } = options;
+  const { codeFriendly, parseLines } = options;
   let html = markdown;
 
   // Parse text formats
@@ -2009,9 +2010,11 @@ export function jiraMarkdownToHtml(markdown, options = { codeFriendly: true }) {
   });
 
   // Parse full lines
-  html = html.replace(/^(\s*)(.*)\r\n/gm, (match, p1, p2) => {
-    return `<p>${[...p1].map((e) => '&nbsp;').join('')}${p2}</p>`;
-  });
+  if (parseLines) {
+    html = html.replace(/^(\s*)(.*)\r\n/gm, (match, p1, p2) => {
+      return `<p>${[...p1].map((e) => '&nbsp;').join('')}${p2}</p>`;
+    });
+  }
 
   return html;
 }

--- a/love/src/Utils.test.js
+++ b/love/src/Utils.test.js
@@ -23,17 +23,18 @@ describe('htmlToJiraMarkdown', () => {
 });
 
 describe('jiraMarkdownToHtml', () => {
+  const options = { codeFriendly: true, parseLines: true };
   it('should handle links', () => {
     const input = 'This is a [link|https://example.com].\r\n';
     const expectedOutput =
       '<p>This is a <a href="https://example.com" rel="noopener noreferrer" target="_blank">link</a>.</p>';
-    expect(jiraMarkdownToHtml(input)).toEqual(expectedOutput);
+    expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 
   it('should handle headings', () => {
     const input = 'h1. This is a heading.\r\n';
     const expectedOutput = '<p><h1>This is a heading.</h1></p>';
-    expect(jiraMarkdownToHtml(input)).toEqual(expectedOutput);
+    expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 
   it('should convert Jira markdown to HTML', () => {
@@ -41,6 +42,22 @@ describe('jiraMarkdownToHtml', () => {
       'This is a string with mixed content\r\nh1. This is a heading.\r\nThis is a [link|http://google.com/].\r\n';
     const expectedOutput =
       '<p>This is a string with mixed content</p><p><h1>This is a heading.</h1></p><p>This is a <a href="http://google.com/" rel="noopener noreferrer" target="_blank">link</a>.</p>';
-    expect(jiraMarkdownToHtml(input)).toEqual(expectedOutput);
+    expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
+  });
+});
+
+describe('jiraMarkdownToHtml with options', () => {
+  it('should handle only links and headings if parseLines option is false', () => {
+    const options = { codeFriendly: true, parseLines: false };
+    const input = 'This is a [link|https://example.com].\r\nThis is another line.\r\nh1. This is a heading.\r\n';
+    const expectedOutput =
+      'This is a <a href="https://example.com" rel="noopener noreferrer" target="_blank">link</a>.\r\nThis is another line.\r\n<h1>This is a heading.</h1>\r\n';
+  });
+
+  it('should handle links, headings and lines if parseLines option is false', () => {
+    const options = { codeFriendly: true, parseLines: true };
+    const input = 'This is a [link|https://example.com].\r\nThis is another line.\r\nh1. This is a heading.\r\n';
+    const expectedOutput =
+      '<p>This is a <a href="https://example.com" rel="noopener noreferrer" target="_blank">link</a>.</p><p>This is another line.</p><p><h1>This is a heading.</h1></p>';
   });
 });

--- a/love/src/components/OLE/Exposure/Message/MessageEdit.jsx
+++ b/love/src/components/OLE/Exposure/Message/MessageEdit.jsx
@@ -111,7 +111,7 @@ export default class MessageEdit extends Component {
     const jiraUrl = getLinkJira(message.urls);
     const filesUrls = getFilesURLs(message.urls);
 
-    const htmlMessage = jiraMarkdownToHtml(message.message_text);
+    const htmlMessage = jiraMarkdownToHtml(message.message_text, { codeFriendly: true, parseLines: true });
 
     return (
       <div className={styles.message}>

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -31,7 +31,13 @@ import {
   ISO_STRING_DATE_TIME_FORMAT,
   LOG_REFRESH_INTERVAL_MS,
 } from 'Config';
-import ManagerInterface, { formatSecondsToDigital, getLinkJira, jiraMarkdownToHtml, getObsDayFromDate } from 'Utils';
+import ManagerInterface, {
+  formatSecondsToDigital,
+  getLinkJira,
+  jiraMarkdownToHtml,
+  getObsDayFromDate,
+  truncateISODateToMinutes,
+} from 'Utils';
 
 import SimpleTable from 'components/GeneralPurpose/SimpleTable/SimpleTable';
 import Button from 'components/GeneralPurpose/Button/Button';
@@ -170,7 +176,7 @@ export default class NonExposure extends Component {
         title: 'Time of Incident (UTC)',
         type: 'string',
         className: styles.tableHead,
-        render: (_, row) => `${row.date_begin?.split('.')[0]} - ${row.date_end?.split('.')[0]}`,
+        render: (_, row) => `${truncateISODateToMinutes(row.date_begin)} - ${truncateISODateToMinutes(row.date_end)}`,
       },
       {
         field: 'time_lost',

--- a/love/src/components/OLE/NonExposure/NonExposureDetail.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureDetail.jsx
@@ -33,6 +33,7 @@ import ManagerInterface, {
   formatSecondsToDigital,
   openInNewTab,
   jiraMarkdownToHtml,
+  firstLetterToUpperCase,
 } from 'Utils';
 import styles from './NonExposure.module.css';
 
@@ -185,10 +186,14 @@ export default class NonExposureDetail extends Component {
           </div>
           <div className={styles.content}>
             <div className={styles.detail}>
+              <span className={styles.label}>Category</span>
+              <span className={styles.value}>{logDetail.category}</span>
               <span className={styles.label}>Time of Incident</span>
               <span className={styles.value}>{`${logDetail.date_begin.split('.')[0]} - ${
                 logDetail.date_end.split('.')[0]
               }`}</span>
+              <span className={styles.label}>Time loss type</span>
+              <span className={styles.value}>{firstLetterToUpperCase(logDetail.time_lost_type)}</span>
               <span className={styles.label}>Obs. Time Loss</span>
               <span className={styles.value}>{formatSecondsToDigital(logDetail.time_lost * 3600)}</span>
               <span className={styles.label}>Components</span>

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -248,6 +248,26 @@ export default class NonExposureEdit extends Component {
     }
   }
 
+  renderCategoryField() {
+    return (
+      <>
+        <span className={styles.label}>Category</span>
+        <span className={styles.value}>
+          <Select
+            options={['None', 'ENG', 'SCIENCE']}
+            option={this.state.logEdit?.category}
+            onChange={({ value }) => {
+              this.setState((prevState) => ({
+                logEdit: { ...prevState.logEdit, category: value },
+              }));
+            }}
+            className={styles.select}
+          />
+        </span>
+      </>
+    );
+  }
+
   renderUrgentField() {
     return (
       <>
@@ -326,7 +346,7 @@ export default class NonExposureEdit extends Component {
   }
 
   renderTimeOfIncidentFields() {
-    const { date_begin, date_end, time_lost } = this.state.logEdit ?? {};
+    const { date_begin, date_end, time_lost, time_lost_type } = this.state.logEdit ?? {};
     const { incidentTimeIsSingular, datesAreValid } = this.state;
 
     return (
@@ -371,6 +391,18 @@ export default class NonExposureEdit extends Component {
             </Button>
           </div>
           {!datesAreValid && <div className={styles.inputError}>Error: dates must be input in valid ISO format</div>}
+        </span>
+        <span className={styles.label}>Obs. Time Loss Type</span>
+        <span className={styles.value}>
+          <Toggle
+            labels={['Fault', 'Weather']}
+            toggled={time_lost_type === 'weather'}
+            onToggle={(event) =>
+              this.setState((prevState) => ({
+                logEdit: { ...prevState.logEdit, time_lost_type: event ? 'weather' : 'fault' },
+              }))
+            }
+          />
         </span>
         <span className={styles.label}>Obs. Time Loss (hours)</span>
         <span className={styles.value}>
@@ -544,6 +576,7 @@ export default class NonExposureEdit extends Component {
           <div className={styles.detailContainerMenu}>
             <div id={this.id} className={styles.contentMenu}>
               <div className={styles.contentLeft}>
+                {this.renderCategoryField()}
                 {this.renderUrgentField()}
                 {this.renderComponentsFields()}
                 {this.renderTimeOfIncidentFields()}
@@ -615,6 +648,7 @@ export default class NonExposureEdit extends Component {
 
             <div id={this.id} className={styles.content}>
               <div className={styles.contentLeft}>
+                {this.renderCategoryField()}
                 {this.renderUrgentField()}
                 {this.renderComponentsFields()}
                 {this.renderTimeOfIncidentFields()}

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -87,6 +87,8 @@ export default class NonExposureEdit extends Component {
       tags: [],
       message_text: '',
       is_human: true,
+      category: 'None',
+      time_lost_type: 'fault',
     },
     isLogCreate: false,
     isMenu: false,

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -425,7 +425,7 @@ export default class NonExposureEdit extends Component {
 
   renderMessageField() {
     const { logEdit } = this.state;
-    const htmlMessage = jiraMarkdownToHtml(logEdit?.message_text);
+    const htmlMessage = jiraMarkdownToHtml(logEdit?.message_text, { codeFriendly: true, parseLines: true });
 
     return (
       <>


### PR DESCRIPTION
This PR adds `category` and `time_lost_type` params to the narrative log interface.
Also a few other things were done:

-  `date_added` is being swapped for a calculated `obs_day`.
- added a `parseLines` option to `jiraMarkdownToHtml` to improve formatting.
- Timestamps of time of incident were truncated to the minute, added `truncateISODateToMinutes` to Utils.
- Added function to convert first letter of a string to uppercase: `firstLetterToUpperCase`.