### PR TITLE
Update to node:lts docker image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ v5.27.2
 * Bump d3-color from 1.4.1 to 3.1.0 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/559>`_
 * Bump d3, d3-geo-veroni, get rid of cypress and vega-lib, update component d3 use of d3.event `<https://github.com/lsst-ts/LOVE-frontend/pull/558>`_
 * Clean compilation warnings on LOVE-frontend `<https://github.com/lsst-ts/LOVE-frontend/pull/557>`_
+* Update to node:lts docker image `<https://github.com/lsst-ts/LOVE-frontend/pull/556>`_
 
 v5.27.1
 -------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2-alpine as builder
+FROM node:lts as builder
 
 WORKDIR /usr/src/love
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM node:16.13.2-alpine as builder
+FROM node:lts as builder
 
 # Set working directory
 WORKDIR /usr/src/love

--- a/docker/Dockerfile-k8s
+++ b/docker/Dockerfile-k8s
@@ -1,4 +1,4 @@
-FROM node:16.13.2-alpine as builder
+FROM node:lts as builder
 
 WORKDIR /usr/src/love
 

--- a/docker/Dockerfile-test
+++ b/docker/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM node:16.13.2-alpine as builder
+FROM node:lts as builder
 
 WORKDIR /usr/src/love
 


### PR DESCRIPTION
This PR updates the `node` docker image to use the `lts` release, which will alway point to the latest stable release, currently `20.9`.