### PR TITLE
Fix documentation pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,10 @@
 Version History
 ===============
 
+v5.27.3
+-------
 
+* Fix documentation pipeline `<https://github.com/lsst-ts/LOVE-frontend/pull/561>`_
 
 v5.27.2
 -------

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,6 +116,8 @@ pipeline {
         script {
           sh """
             source ${env.SAL_SETUP_FILE}
+            # Remove old docs folder
+            rm -rf ./docs
             # Install dependencies
             cd ./love
             npm install


### PR DESCRIPTION
This PR makes a small adjustment on the `Jenkinsfile` docs build script so it removes previously created docs folder.