### PR TITLE
Fix narrative log to avoid crashing when filtering by log components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ v5.27.5
 * Add script failure alert sound `<https://github.com/lsst-ts/LOVE-frontend/pull/568>`_
 * Add package override for Semver and PostCSS `<https://github.com/lsst-ts/LOVE-frontend/pull/567>`_
 * Fix OLE time of incident input `<https://github.com/lsst-ts/LOVE-frontend/pull/566>`_
+* Fix narrative log to avoid crashing when filtering by log components `<https://github.com/lsst-ts/LOVE-frontend/pull/565>`_
 
 v5.27.4
 -------

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.27.4",
+  "version": "5.27.5",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -356,7 +356,7 @@ export default class NonExposure extends Component {
 
     // Filter by component
     if (selectedComponent !== 'All components') {
-      filteredData = filteredData.filter((log) => log.components.includes(selectedComponent));
+      filteredData = filteredData.filter((log) => log.components?.includes(selectedComponent));
     }
 
     // Filter by obs time loss


### PR DESCRIPTION
This PR adds an optional chainning operator when accessing components of logs, so the component doesn't crash when looking into logs that doesn't have components.