### PR TITLE
Remove auto formatting from RichTextEditor

### DIFF
--- a/love/src/components/GeneralPurpose/RichTextEditor/RichTextEditor.jsx
+++ b/love/src/components/GeneralPurpose/RichTextEditor/RichTextEditor.jsx
@@ -99,6 +99,7 @@ const RichTextEditor = forwardRef(
         <ReactQuill
           ref={reactQuillRef}
           modules={modules}
+          formats={[]}
           theme="snow"
           value={value}
           onChange={handleChange}


### PR DESCRIPTION
This PR removes the auto formatting feature of the `RichTextEditor` component by setting the `format` param of `ReactQuill` to an empty array `[]`.