### PR TITLE
Hotfix: make scripts timestamp evaluation more robust

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+5.27.7
+------
+
+* Hotfix: make scripts timestamp evaluation more robust `<https://github.com/lsst-ts/LOVE-frontend/pull/572>`_
+
 v5.27.6
 -------
 

--- a/love/package.json
+++ b/love/package.json
@@ -1,6 +1,6 @@
 {
   "name": "love",
-  "version": "5.27.6",
+  "version": "5.27.7",
   "private": true,
   "dependencies": {
     "@emotion/core": "^10.3.1",

--- a/love/src/components/ScriptQueue/Scripts/CurrentScript/CurrentScript.jsx
+++ b/love/src/components/ScriptQueue/Scripts/CurrentScript/CurrentScript.jsx
@@ -172,7 +172,8 @@ export default class CurrentScript extends Component {
 
     const isPaused = this.props.scriptState.toLowerCase() === 'paused';
 
-    const dateScriptStarted = this.props.timestampConfigureEnd && new Date(this.props.timestampConfigureEnd * 1000);
+    const dateScriptStarted =
+      this.props.timestampConfigureEnd > 0 ? new Date(this.props.timestampConfigureEnd * 1000) : null;
 
     return (
       <div className={[scriptStyles.scriptContainer].join(' ')}>

--- a/love/src/components/ScriptQueue/Scripts/FinishedScript/FinishedScript.jsx
+++ b/love/src/components/ScriptQueue/Scripts/FinishedScript/FinishedScript.jsx
@@ -95,7 +95,8 @@ class FinishedScript extends React.Component {
         : path.substring(path.lastIndexOf('/') + 1);
     const fileExtension = path.lastIndexOf('.') > -1 ? path.substring(path.lastIndexOf('.')) : '';
 
-    const dateScriptFinished = this.props.timestampProcessEnd && new Date(this.props.timestampProcessEnd * 1000);
+    const dateScriptFinished =
+      this.props.timestampProcessEnd > 0 ? new Date(this.props.timestampProcessEnd * 1000) : null;
 
     return (
       <div className={scriptStyles.scriptContainer}>


### PR DESCRIPTION
This PR is a hotfix for the latest release `v5.27.6` in order to fix errors on the ScriptQueue when not receving timestamp for scripts.