### PR TITLE
Improve OLE behavior when jira ticket creation fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,12 @@
 Version History
 ===============
 
-5.27.7
+v5.27.8
+-------
+
+* Improve OLE behavior when jira ticket creation fails `<https://github.com/lsst-ts/LOVE-frontend/pull/573>`_
+
+v5.27.7
 ------
 
 * Hotfix: make scripts timestamp evaluation more robust `<https://github.com/lsst-ts/LOVE-frontend/pull/572>`_

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -866,6 +866,7 @@ export default class ManagerInterface {
       if (response.status === 400) {
         return response.json().then((resp) => {
           toast.error(resp.ack);
+          return resp;
         });
       }
       return response.json().then((resp) => {
@@ -1036,11 +1037,13 @@ export default class ManagerInterface {
       if (response.status === 400) {
         return response.json().then((resp) => {
           toast.error(resp.ack);
+          return resp;
         });
       }
       if (response.status === 422) {
         return response.json().then((resp) => {
           toast.error(resp.detail);
+          return resp;
         });
       }
       return response.json().then((resp) => {

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -168,7 +168,12 @@ export default class ExposureAdd extends Component {
       } else {
         this.props.view();
       }
-      this.cleanForm();
+
+      // Clean form only if the response is successful
+      if (!result.error) {
+        this.cleanForm();
+      }
+
       this.setState({ savingLog: false });
     });
   }

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -109,6 +109,8 @@ export default class ExposureAdd extends Component {
       jiraIssueError: false,
     };
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.multiselectImageTagsComponentRef = React.createRef();
+    this.multiselectExposuresComponentRef = React.createRef();
     this.richTextEditorRef = React.createRef();
   }
 
@@ -117,8 +119,12 @@ export default class ExposureAdd extends Component {
   }
 
   cleanForm() {
-    this.setState({ newMessage: ExposureAdd.defaultProps.newMessage });
+    // Reset MultiSelect components value
+    this.multiselectImageTagsComponentRef.current.resetSelectedValues();
+    this.multiselectExposuresComponentRef.current.resetSelectedValues();
+    // Reset RichTextEditor component value
     this.richTextEditorRef.current.cleanContent();
+    this.setState({ newMessage: ExposureAdd.defaultProps.newMessage });
   }
 
   queryExposures() {
@@ -268,6 +274,7 @@ export default class ExposureAdd extends Component {
     const { imageTags, newMessage } = this.state;
     return (
       <MultiSelect
+        innerRef={this.multiselectImageTagsComponentRef}
         options={imageTags}
         selectedValues={newMessage.tags}
         isObject={true}
@@ -287,6 +294,7 @@ export default class ExposureAdd extends Component {
     const { observationIds, newMessage } = this.state;
     return (
       <MultiSelect
+        innerRef={this.multiselectExposuresComponentRef}
         options={observationIds}
         selectedValues={newMessage.obs_id}
         onSelect={(selectedOptions) => {

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -164,7 +164,12 @@ export default class NonExposureEdit extends Component {
           savingLog: false,
         });
         this.props.save(response);
-        this.cleanForm();
+
+        // Clean form only if the response is successful
+        if (!response.error) {
+          this.cleanForm();
+        }
+
         if (this.props.back) this.props.back();
       });
     }

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -121,8 +121,9 @@ export default class NonExposureEdit extends Component {
   }
 
   cleanForm() {
-    // Reset multiselects values
+    // Reset MultiSelect component value
     this.multiselectComponentsRef.current.resetSelectedValues();
+    // Reset RichTextEditor component value
     this.richTextEditorRef.current.cleanContent();
     this.setState({ logEdit: NonExposureEdit.defaultProps.logEdit });
   }

--- a/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
+++ b/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
@@ -160,7 +160,12 @@ export default class TeknikerAdd extends Component {
           savingLog: false,
         });
         this.props.save(response);
-        this.cleanForm();
+
+        // Clean form only if the response is successful
+        if (!response.error) {
+          this.cleanForm();
+        }
+
         if (this.props.back) this.props.back();
       });
     }


### PR DESCRIPTION
This PR removes OLE creation forms cleaning after sending a request to create a log, instead it check if there was any error and only clean the forms when the response is successful. Also add some missing `MultiSelect` component cleanings.