### PR TITLE
Rollback query to FinishedScript removed on a previous commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.8
 -------
 
+* Rollback query to FinishedScript removed on a previous commit `<https://github.com/lsst-ts/LOVE-frontend/pull/575>`_
 * Increase interval between audio alarms `<https://github.com/lsst-ts/LOVE-frontend/pull/574>`_
 * Improve OLE behavior when jira ticket creation fails `<https://github.com/lsst-ts/LOVE-frontend/pull/573>`_
 


### PR DESCRIPTION
This PR adds a removed query to the EFD used to retrieve logs of finished script. I've mistakenly removed it on 147f3b229651babea91661e341bd2221cd2e891d when refactoring the scripts config query to the EFD.