### PR TITLE
Make constraints to save logs more robust

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.8
 -------
 
+* Make constraints to save logs more robust `<https://github.com/lsst-ts/LOVE-frontend/pull/576>`_
 * Rollback query to FinishedScript removed on a previous commit `<https://github.com/lsst-ts/LOVE-frontend/pull/575>`_
 * Increase interval between audio alarms `<https://github.com/lsst-ts/LOVE-frontend/pull/574>`_
 * Improve OLE behavior when jira ticket creation fails `<https://github.com/lsst-ts/LOVE-frontend/pull/573>`_

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -869,6 +869,12 @@ export default class ManagerInterface {
           return resp;
         });
       }
+      if (response.status === 404) {
+        return response.json().then((resp) => {
+          toast.error('Error adding log.');
+          return resp;
+        });
+      }
       return response.json().then((resp) => {
         toast.success('Log added succesfully.');
         return resp;

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -67,7 +67,7 @@ export default class ExposureAdd extends Component {
       timespan_end: undefined,
     },
     newMessage: {
-      obs_id: undefined,
+      obs_id: [],
       instrument: undefined,
       message_text: undefined,
       level: 10,
@@ -176,7 +176,7 @@ export default class ExposureAdd extends Component {
       }
 
       // Clean form only if the response is successful
-      if (!result.error) {
+      if (!result.error && !result.detail) {
         this.cleanForm();
       }
 
@@ -220,6 +220,17 @@ export default class ExposureAdd extends Component {
   handleSubmit(event) {
     if (event) event.preventDefault();
     this.saveMessage();
+  }
+
+  isSubmitDisabled() {
+    const { jiraIssueError, savingLog, newMessage, selectedInstrument } = this.state;
+    return (
+      jiraIssueError ||
+      savingLog ||
+      newMessage.obs_id.length === 0 ||
+      !selectedInstrument ||
+      !newMessage.message_text?.trim()
+    );
   }
 
   renderInstrumentsSelect() {
@@ -370,6 +381,12 @@ export default class ExposureAdd extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    if (this.state.selectedInstrument && prevState.selectedInstrument !== this.state.selectedInstrument) {
+      this.setState((state) => ({
+        newMessage: { ...state.newMessage, instrument: state.selectedInstrument },
+      }));
+    }
+
     if (
       prevState.selectedInstrument !== this.state.selectedInstrument ||
       (this.state.selectedDayExposureStart &&
@@ -550,7 +567,9 @@ export default class ExposureAdd extends Component {
                 }}
                 onKeyCombination={(combination) => {
                   if (combination === 'ctrl+enter') {
-                    this.handleSubmit();
+                    if (!this.isSubmitDisabled()) {
+                      this.handleSubmit();
+                    }
                   }
                 }}
               />
@@ -673,7 +692,7 @@ export default class ExposureAdd extends Component {
               </div>
 
               <div className={isMenu ? styles.footerRightMenu : styles.footerRight}>
-                <Button disabled={jiraIssueError} type="submit">
+                <Button disabled={this.isSubmitDisabled()} type="submit">
                   {savingLog ? (
                     <SpinnerIcon className={styles.spinnerIcon} />
                   ) : (

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -181,6 +181,11 @@ export default class NonExposureEdit extends Component {
     this.updateOrCreateMessageNarrativeLogs();
   }
 
+  isSubmitDisabled() {
+    const { logEdit, datesAreValid, savingLog, jiraIssueError } = this.state;
+    return !datesAreValid || jiraIssueError || savingLog || !logEdit?.message_text?.trim();
+  }
+
   handleTimeOfIncident(date, type) {
     if (type === 'start') {
       this.setState((prevState) => ({
@@ -467,7 +472,7 @@ export default class NonExposureEdit extends Component {
   }
 
   renderMessageField() {
-    const { logEdit } = this.state;
+    const { logEdit, datesAreValid, savingLog, jiraIssueError } = this.state;
     const htmlMessage = jiraMarkdownToHtml(logEdit?.message_text, { codeFriendly: true, parseLines: true });
 
     return (
@@ -485,7 +490,9 @@ export default class NonExposureEdit extends Component {
           }}
           onKeyCombination={(combination) => {
             if (combination === 'ctrl+enter') {
-              this.handleSubmit();
+              if (!this.isSubmitDisabled()) {
+                this.handleSubmit();
+              }
             }
           }}
         />
@@ -610,7 +617,7 @@ export default class NonExposureEdit extends Component {
 
     return (
       <>
-        <Button disabled={!datesAreValid || jiraIssueError} type="submit">
+        <Button disabled={this.isSubmitDisabled()} type="submit">
           {savingLog ? <SpinnerIcon className={styles.spinnerIcon} /> : <span className={styles.title}>Save</span>}
         </Button>
       </>


### PR DESCRIPTION
This PR refactors the way the button for saving logs was being disabled. A function was added for both `ExposureAdd` and `NonExposureEdit` components so it evaluates the current state of availability to save logs. The `ctrl+enter` feature to save logs was also hooked up to this constraints.