### PR TITLE
Improve Watcher alarm handling to comply with new rules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v5.27.10
 --------
 
 * Add release instructions to CONTRIBUTING guide `<https://github.com/lsst-ts/LOVE-frontend/pull/585>`_
+* Improve Watcher alarm handling to comply with new rules `<https://github.com/lsst-ts/LOVE-frontend/pull/584>`_
 * Fix OLE JIRA tickets handling `<https://github.com/lsst-ts/LOVE-frontend/pull/583>`_
 
 v5.27.9

--- a/love/src/components/Layout/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/Layout/ConfigPanel/ConfigPanel.jsx
@@ -29,15 +29,8 @@ import ManagerInterface, { formatTimestamp } from 'Utils';
 import ScriptIcon from '../../icons/ScriptIcon/ScriptIcon';
 import Button from 'components/GeneralPurpose/Button/Button';
 
-ConfigPanel.propTypes = {
-  /** Current LOVE configuration */
-  config: PropTypes.object,
-  /** Set Current LOVE configuration */
-  setConfig: PropTypes.func,
-};
-
 /** Contents of the Config File view Panel, displayed in a modal */
-function ConfigPanel({ config, setConfig }) {
+function ConfigPanel({ config, setConfig, closeModal = () => {} }) {
   const [ownConf, setOwnConf] = useState(config);
   const [configList, setConfigList] = useState([]);
 
@@ -63,6 +56,7 @@ function ConfigPanel({ config, setConfig }) {
     } else {
       setConfig(ownConf);
     }
+    closeModal();
   };
 
   const getConfigSelectOption = (conf, index) => {
@@ -119,4 +113,14 @@ function ConfigPanel({ config, setConfig }) {
     </div>
   );
 }
+
+ConfigPanel.propTypes = {
+  /** Current LOVE configuration */
+  config: PropTypes.object,
+  /** Set Current LOVE configuration */
+  setConfig: PropTypes.func,
+  /** Function to close the modal */
+  closeModal: PropTypes.func,
+};
+
 export default memo(ConfigPanel);

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -891,7 +891,11 @@ class Layout extends Component {
           onRequestClose={() => this.setState({ isConfigModalOpen: false })}
           contentLabel="LOVE Config File modal"
         >
-          <ConfigPanel config={this.props.config} setConfig={this.props.setConfig} />
+          <ConfigPanel
+            config={this.props.config}
+            setConfig={this.props.setConfig}
+            closeModal={() => this.setState({ isConfigModalOpen: false })}
+          />
         </Modal>
         <Modal
           isOpen={this.state.isEmergencyContactsModalOpen}

--- a/love/src/components/Watcher/AlarmsTable/AlarmsTable.module.css
+++ b/love/src/components/Watcher/AlarmsTable/AlarmsTable.module.css
@@ -66,10 +66,6 @@ table {
 .dataTable {
   display: grid;
   grid-template-rows: min-content minmax(0, 1fr);
-  width: calc(
-    var(--ack-width) + 2 * var(--status-width) + var(--name-width) + var(--timestamp-width) + 10 * var(--cell-padding)
-  );
-  height: inherit; /* necessary for scroll, but parent component must define height */
   table-layout: fixed;
   border-collapse: collapse;
 }

--- a/love/src/components/Watcher/Watcher.jsx
+++ b/love/src/components/Watcher/Watcher.jsx
@@ -114,6 +114,7 @@ export default class Watcher extends Component {
       if (
         alarm.severity.value <= 1 &&
         alarm.maxSeverity.value <= 1 &&
+        alarm.timestampAcknowledged.value !== 0 &&
         now - alarm.timestampAcknowledged.value >= TIMEOUT
       ) {
         return;
@@ -141,8 +142,6 @@ export default class Watcher extends Component {
         }
       }
     });
-
-    this.test = null;
 
     return (
       <div className={styles.tabsWrapper}>


### PR DESCRIPTION
This PR cleans, extends and improve the code for the Watcher alarms handling so:

- Critical alarms that goes to inactive stop sounding.
- Make `checkNotifyAlarm` more readable.
- Make LOVE config panel automatic close after saving.