### PR TITLE
Add release instructions to CONTRIBUTING guide

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.10
 --------
 
+* Add release instructions to CONTRIBUTING guide `<https://github.com/lsst-ts/LOVE-frontend/pull/585>`_
 * Fix OLE JIRA tickets handling `<https://github.com/lsst-ts/LOVE-frontend/pull/583>`_
 
 v5.27.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,26 @@
 
 When contributing to this repository, please consider the following aspects
 
+## Making a release (creating a tag)
+
+In order to make a release of the frontend, you need to create a tag in the repository. The tag should be named `vX.Y.Z` where `X.Y.Z` is the version number. The version number should follow [semantic versioning](https://semver.org/). The tag should be created from the `master` branch.
+
+Before creating the tag, make sure to:
+- Create a PR that updates the `love/package.json` file with the new version number `X.Y.Z`.
+- Check the `CHANGELOG.md` file is updated with the changes that are going to be released.
+
+Once the PR is merged, create the tag with the following command:
+
+```
+git checkout develop
+git pull
+git checkout main
+git pull
+git merge --no-ff develop
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
 ## Adding a new Container component
 
 Container components implement the communication with Redux to obtain the available telemetry/event data. Container components:


### PR DESCRIPTION
This PR adds instructions to make releases to the `CONTRIBUTING.md` guide.