### PR TITLE
Add MTM2 powerSystemState data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.11
 --------
 
+* Add MTM2 powerSystemState data `<https://github.com/lsst-ts/LOVE-frontend/pull/590>`_
 * Remove custom failed script sound alert `<https://github.com/lsst-ts/LOVE-frontend/pull/589>`_
 
 v5.27.10

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -702,7 +702,23 @@ export const m1m3ILCStateToStyle = {
   OFF: 'warning',
 };
 
-// MTM1M2
+// MTM2
+export const m2PowerTypeStateToStyle = {
+  UNKNOWN: 'invalid',
+  ACTUATOR: 'ok',
+  ILC: 'ok',
+};
+
+export const m2PowerStateToStyle = {
+  UNKNOWN: 'invalid',
+  INITIALIZATION: 'ok',
+  ON: 'ok',
+  OFF: 'warning',
+  POWERING_ON: 'running',
+  RESETTING_BREAKS: 'running',
+  POWERING_OFF: 'running',
+};
+
 export const m2ActuatorILCStateToStyle = {
   OPERATIVE: 'ok',
   FAULT: 'warning',
@@ -1095,6 +1111,23 @@ export const alignedStateMap = {
   1: 'ALIGNED',
   2: 'NOT ALIGNED',
   0: 'UNKNOWN',
+};
+
+// MTM2
+export const m2PowerTypeStateMap = {
+  0: 'UNKNOWN',
+  1: 'ACTUATOR',
+  2: 'ILC',
+};
+
+export const m2PowerStateMap = {
+  0: 'UNKNOWN',
+  1: 'INITIALIZATION',
+  2: 'OFF',
+  3: 'POWERING_ON',
+  4: 'RESETTING_BREAKS',
+  5: 'ON',
+  6: 'POWERING_OFF',
 };
 
 // M1M3

--- a/love/src/components/MainTel/M2/Actuators/Selector/Selector.jsx
+++ b/love/src/components/MainTel/M2/Actuators/Selector/Selector.jsx
@@ -236,11 +236,8 @@ export default class Selector extends Component {
     d3.select(`#${this.uniqueCircleOverlay}`).call(this.zoom);
   }
 
-  zoomOut = (event) => {
+  zoomOut = () => {
     d3.select(`#${this.uniqueCircleOverlay}`).call(this.zoom.transform, d3.zoomIdentity.scale(1)).call(this.zoom);
-    this.setState({
-      zoomLevel: event.transform.k,
-    });
   };
 
   zoomed = (event) => {

--- a/love/src/components/MainTel/M2/M2.container.jsx
+++ b/love/src/components/MainTel/M2/M2.container.jsx
@@ -20,7 +20,14 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 import React from 'react';
 import { connect } from 'react-redux';
 import { addGroup, removeGroup } from 'redux/actions/ws';
-import { getM2State, getM2Inclinometer, getM2Actuator, getM2ActuatorForce, getAlignmentState } from 'redux/selectors';
+import {
+  getM2State,
+  getM2Inclinometer,
+  getM2Actuator,
+  getM2ActuatorForce,
+  getAlignmentState,
+  getM2PowerState,
+} from 'redux/selectors';
 import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
 import M2 from './M2';
 import { EUIs } from 'Config';
@@ -75,27 +82,37 @@ const mapStateToProps = (state) => {
   const actuators = getM2Actuator(state);
   const forces = getM2ActuatorForce(state);
   const alignmentState = getAlignmentState(state);
+  const powerState = getM2PowerState(state);
 
-  return { ...m2State, ...inclinometerState, ...actuators, ...forces, ...alignmentState };
+  return {
+    ...m2State,
+    ...inclinometerState,
+    ...actuators,
+    ...forces,
+    ...alignmentState,
+    ...powerState,
+  };
 };
 
 const mapDispatchToProps = (dispatch) => {
   const subscriptions = [
-    'telemetry-MTM2-0-axialActuatorSteps',
-    'telemetry-MTM2-0-axialEncoderPositions',
-    'telemetry-MTM2-0-tangentActuatorSteps',
-    'telemetry-MTM2-0-tangentEncoderPositions',
-    'telemetry-MTM2-0-axialForce',
-    'telemetry-MTM2-0-tangentForce',
-    'telemetry-MTM2-0-ilcData',
-    'telemetry-MTM2-0-zenithAngle',
-    'event-MTM2-0-inclinationTelemetrySource',
-    'event-MTM2-0-summaryState',
+    'event-Heartbeat-0-stream',
     'event-MTM2-0-commandableByDDS',
     'event-MTM2-0-forceBalanceSystemStatus',
+    'event-MTM2-0-inclinationTelemetrySource',
     'event-MTM2-0-m2AssemblyInPosition',
-    'event-Heartbeat-0-stream',
+    'event-MTM2-0-powerSystemState',
+    'event-MTM2-0-summaryState',
+    'telemetry-MTM2-0-axialActuatorSteps',
+    'telemetry-MTM2-0-axialEncoderPositions',
+    'telemetry-MTM2-0-axialForce',
+    'telemetry-MTM2-0-ilcData',
+    'telemetry-MTM2-0-tangentActuatorSteps',
+    'telemetry-MTM2-0-tangentEncoderPositions',
+    'telemetry-MTM2-0-tangentForce',
+    'telemetry-MTM2-0-zenithAngle',
   ];
+
   return {
     subscriptions,
     subscribeToStreams: () => {
@@ -106,4 +123,5 @@ const mapDispatchToProps = (dispatch) => {
     },
   };
 };
+
 export default connect(mapStateToProps, mapDispatchToProps)(M2Container);

--- a/love/src/components/MainTel/M2/M2.jsx
+++ b/love/src/components/MainTel/M2/M2.jsx
@@ -66,14 +66,22 @@ export default class M2 extends Component {
     /** Force measurement by load cell for each actuator in sequence. */
     tangentForceMeasured: PropTypes.arrayOf(PropTypes.number),
 
+    /** M2 power system type */
+    powerType: PropTypes.number,
+    /** M2 power system state */
+    powerState: PropTypes.number,
+
     /** Number of the minimum force limit, used for the gradiant color */
     minForceLimit: PropTypes.number,
     /** Number of the maximum force limit, used for the gradiant color */
     maxForceLimit: PropTypes.number,
   };
+
   static defaultProps = {
     minForceLimit: 0,
     maxForceLimit: 1000,
+    subscribeToStreams: () => {},
+    unsubscribeToStreams: () => {},
   };
 
   componentDidMount() {
@@ -98,6 +106,8 @@ export default class M2 extends Component {
       minForceLimit,
       maxForceLimit,
       alignment,
+      powerType,
+      powerState,
     } = this.props;
     const { summaryState, commandableByDDS, forceBalanceSystemStatus, m2AssemblyInPosition } = this.props;
     const { zenithAngleMeasured, inclinationTelemetrySource } = this.props;
@@ -110,6 +120,8 @@ export default class M2 extends Component {
           forceBalanceSystemStatus={forceBalanceSystemStatus}
           m2AssemblyInPosition={m2AssemblyInPosition}
           alignment={alignment}
+          powerType={powerType}
+          powerState={powerState}
         />
 
         <Actuators

--- a/love/src/components/MainTel/M2/Summary/Summary.jsx
+++ b/love/src/components/MainTel/M2/Summary/Summary.jsx
@@ -19,7 +19,16 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { summaryStateMap, summaryStateToStyle, alignedStateMap, alignedStateToStyle } from 'Config';
+import {
+  summaryStateMap,
+  summaryStateToStyle,
+  alignedStateMap,
+  alignedStateToStyle,
+  m2PowerStateMap,
+  m2PowerStateToStyle,
+  m2PowerTypeStateMap,
+  m2PowerTypeStateToStyle,
+} from 'Config';
 import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
 import Title from 'components/GeneralPurpose/SummaryPanel/Title';
 import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
@@ -38,21 +47,32 @@ export default class Summary extends Component {
     /** Indicates when all of the M2 axes are within tolerance of the target positions.
      * True if the M2 assembly is in position. */
     m2AssemblyInPosition: PropTypes.bool,
+
+    /** M2 power system type */
+    powerType: PropTypes.number,
+    /** M2 power system state */
+    powerState: PropTypes.number,
   };
 
   static defaultProps = {
     summaryState: 0,
-    commandableByDDS: false,
-    forceBalanceSystemStatus: false,
-    m2AssemblyInPosition: false,
+    commandableByDDS: undefined,
+    forceBalanceSystemStatus: undefined,
+    m2AssemblyInPosition: undefined,
+
+    powerType: 0,
+    powerState: 0,
   };
 
   render() {
     const summaryStateName = summaryStateMap[this.props.summaryState];
     const summaryStateStatus = summaryStateToStyle[summaryStateName];
-
     const alignedStateName = alignedStateMap[this.props.alignment];
     const alignedStateStatus = alignedStateToStyle[alignedStateName];
+    const powerStateName = m2PowerStateMap[this.props.powerState];
+    const powerStateStatus = m2PowerStateToStyle[powerStateName];
+    const powerTypeStateName = m2PowerTypeStateMap[this.props.powerType];
+    const powerTypeStateStatus = m2PowerTypeStateToStyle[powerTypeStateName];
 
     const commandableByDDSValue = {
       name: this.props.commandableByDDS ? 'CSC' : 'EUI',
@@ -84,6 +104,14 @@ export default class Summary extends Component {
           <div className={styles.state}>
             <Title>Force Balance</Title>
             <StatusText status={forceBalanceSystemStatusValue?.class}>{forceBalanceSystemStatusValue?.name}</StatusText>
+          </div>
+          <div className={styles.state}>
+            <Title>Power Status</Title>
+            <StatusText status={powerStateStatus}>{powerStateName}</StatusText>
+          </div>
+          <div className={styles.state}>
+            <Title>Power Type</Title>
+            <StatusText status={powerTypeStateStatus}>{powerTypeStateName}</StatusText>
           </div>
           <div className={styles.state}>
             <Title>M1M3 Alignment</Title>

--- a/love/src/components/MainTel/M2/Summary/Summary.module.css
+++ b/love/src/components/MainTel/M2/Summary/Summary.module.css
@@ -30,6 +30,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .summaryPanelStates {
   max-width: 100%;
   display: flex;
+  flex-wrap: wrap;
+  gap: var(--small-padding);
   justify-content: flex-start;
   padding: 1em;
   margin-bottom: 1em;

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -525,6 +525,15 @@ export const getM2ActuatorTable = (state) => {
   };
 };
 
+export const getM2PowerState = (state) => {
+  const subscriptions = ['event-MTM2-0-powerSystemState'];
+  const data = getStreamsData(state, subscriptions);
+  return {
+    powerType: data['event-MTM2-0-powerSystemState']?.[0].powerType?.value ?? 0,
+    powerState: data['event-MTM2-0-powerSystemState']?.[0].state?.value ?? 0,
+  };
+};
+
 export const getDomeState = (state) => {
   const domeSubscriptions = [
     'telemetry-ATDome-0-position',


### PR DESCRIPTION
This PR adds data from `MTM2_logevent_powerSystemState` event. It also improves responsiveness of the MTM2 summary section and fixes an issue with the `zoomOut` function.