### PR TITLE
Fix GIS signals typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v5.27.11
 --------
 
 * Adjust LOVE M2 force gradient coloring `<https://github.com/lsst-ts/LOVE-frontend/pull/592>`_
+* Fix GIS signals typo `<https://github.com/lsst-ts/LOVE-frontend/pull/591>`_
 * Add MTM2 powerSystemState data `<https://github.com/lsst-ts/LOVE-frontend/pull/590>`_
 * Remove custom failed script sound alert `<https://github.com/lsst-ts/LOVE-frontend/pull/589>`_
 * OLE visual improvements `<https://github.com/lsst-ts/LOVE-frontend/pull/588>`_

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -2538,7 +2538,7 @@ export const signals = {
     ],
   },
   tmaInterlockSystem: {
-    breaksNotEngaged: [
+    brakesNotEngaged: [
       /** DOME IS */
       'stoCraneDrives',
       /** MAN-LIFT IS */
@@ -2674,7 +2674,7 @@ export const alertSignalIndexes = {
   emergencyStop: [23, 3],
   unauthorizedPierAccess: [23, 4],
   unauthorizedDomeAccess: [23, 5],
-  breaksNotEngaged: [23, 6],
+  brakesNotEngaged: [23, 6],
   ccwSafetyDevice: [23, 7],
   tmaEtpbs: [23, 8],
   failedWatchdogOrLossCommunication: [24, 0],
@@ -2696,7 +2696,7 @@ export const signalBypassIndexes = {
   emergencyStop: [25, 3],
   unauthorizedPierAccess: [25, 4],
   unauthorizedDomeAccess: [25, 5],
-  breaksNotEngaged: [25, 6],
+  brakesNotEngaged: [25, 6],
   ccwSafetyDevice: [25, 7],
   tmaEtpbs: [25, 8],
   failedWatchdogOrLossCommunication: [26, 0],


### PR DESCRIPTION
This PR fixes a typo on the TMA Interlock signals, specifically the `brakesNotEngaged` one.