### PR TITLE
Add button to send `showSchema` command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.11
 --------
 
+* Add button to send showSchema command `<https://github.com/lsst-ts/LOVE-frontend/pull/594>`_
 * Adjust LOVE M2 force gradient coloring `<https://github.com/lsst-ts/LOVE-frontend/pull/592>`_
 * Fix GIS signals typo `<https://github.com/lsst-ts/LOVE-frontend/pull/591>`_
 * Add MTM2 powerSystemState data `<https://github.com/lsst-ts/LOVE-frontend/pull/590>`_

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.jsx
@@ -34,6 +34,7 @@ import DeleteIcon from 'components/icons/DeleteIcon/DeleteIcon';
 import ErrorIcon from 'components/icons/ErrorIcon/ErrorIcon';
 import RotateIcon from 'components/icons/RotateIcon/RotateIcon';
 import CloseIcon from 'components/icons/CloseIcon/CloseIcon';
+import RefreshIcon from 'components/icons/RefreshIcon/RefreshIcon';
 import SaveNewIcon from 'components/icons/SaveNewIcon/SaveNewIcon';
 import SaveIcon from 'components/icons/SaveIcon/SaveIcon';
 import SpinnerIcon from 'components/icons/SpinnerIcon/SpinnerIcon';
@@ -99,8 +100,13 @@ const getDocumentationLink = (scriptPath) => {
 
 export default class ConfigPanel extends Component {
   static propTypes = {
+    /** Function to launch a script */
     launchScript: PropTypes.func,
+    /** Function to close the config panel */
     closeConfigPanel: PropTypes.func,
+    /** Function to reload the schema */
+    reloadSchema: PropTypes.func,
+    /** Object containing the configuration panel information */
     configPanel: PropTypes.object,
   };
 
@@ -458,6 +464,13 @@ export default class ConfigPanel extends Component {
     );
   };
 
+  onReloadSchema = () => {
+    const { script } = this.props.configPanel ?? {};
+    const path = script.path;
+    const isStandard = script.type === 'standard';
+    this.props.reloadSchema(path, isStandard);
+  };
+
   startResizingWithMouse = (ev) => {
     this.setState({ resizingStart: { x: ev.clientX, y: ev.clientY, sizeWeight: this.state.sizeWeight } });
     document.onmousemove = this.onMouseMove;
@@ -615,7 +628,13 @@ export default class ConfigPanel extends Component {
     const { configurationList } = this.state;
     this.setState({ updatingScriptSchema: true });
 
-    ManagerInterface.postScriptConfiguration(scriptPath, scriptType, configName, configSchema, this.props.configPanel.configSchema).then((res) => {
+    ManagerInterface.postScriptConfiguration(
+      scriptPath,
+      scriptType,
+      configName,
+      configSchema,
+      this.props.configPanel.configSchema,
+    ).then((res) => {
       const newConfigurationList = [res, ...configurationList];
       const options = newConfigurationList.map((conf) => ({ label: conf.config_name, value: conf.id }));
       const newSelectedConfiguration = { label: res.config_name, value: res.id };
@@ -792,6 +811,19 @@ export default class ConfigPanel extends Component {
                 >
                   Go to documentation
                 </a>
+              )}
+
+              {showSchema && (
+                <Button
+                  title="Send command to reload schema"
+                  className={styles.refreshSchemaSection}
+                  onClick={this.onReloadSchema}
+                  size="extra-small"
+                  command
+                >
+                  <RefreshIcon />
+                  Reload schema
+                </Button>
               )}
 
               {showSchema && (

--- a/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.module.css
+++ b/love/src/components/ScriptQueue/ConfigPanel/ConfigPanel.module.css
@@ -477,16 +477,16 @@ fieldset p {
   flex-wrap: wrap;
 }
 .sidePanel :global(.col-xs-9) {
-  width: calc(100% / 12 * 9 );
+  width: calc(100% / 12 * 9);
 }
 .sidePanel :global(.col-xs-5) {
-  width: calc(100% / 12 * 5 );
+  width: calc(100% / 12 * 5);
 }
 .sidePanel :global(.col-xs-3) {
-  width: calc(100% / 12 * 3 );
+  width: calc(100% / 12 * 3);
 }
 .sidePanel :global(.col-xs-2) {
-  width: calc(100% / 12 * 2 );
+  width: calc(100% / 12 * 2);
 }
 .sidePanel :global(.array-item-list) {
   display: -webkit-box;
@@ -504,5 +504,19 @@ fieldset p {
   display: block;
   padding: 0.5rem 1rem;
   text-decoration: none;
-  border: 1px solid rgba(0,0,0,.125);
+  border: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.refreshSchemaSection {
+  display: flex;
+  align-items: center;
+  margin-left: var(--content-padding);
+  margin-bottom: var(--small-padding);
+}
+
+.refreshSchemaSection svg {
+  width: 1.5em;
+  height: 1.5em;
+  margin-right: 0.5em;
+  fill: var(--second-primary-background-color);
 }

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -449,6 +449,19 @@ export default class ScriptQueue extends Component {
     this.closeConfigPanel();
   };
 
+  reloadSchema = (path, isStandard) => {
+    const payload = {
+      component: 'ScriptQueue',
+      salindex: this.props.salindex,
+      cmd: 'cmd_showSchema',
+      params: {
+        path,
+        isStandard,
+      },
+    };
+    this.props.requestSALCommand(payload);
+  };
+
   closeConfigPanel = () => {
     this.setState({
       configPanel: {
@@ -687,6 +700,7 @@ export default class ScriptQueue extends Component {
         <ConfigPanel
           launchScript={this.launchScript}
           closeConfigPanel={this.closeConfigPanel}
+          reloadSchema={this.reloadSchema}
           configPanel={this.state.configPanel}
         />
         <ContextMenu


### PR DESCRIPTION
This PR adds a button to the `ScriptQueue/ConfigPanel` component to provide a mechanism to send the `ScriptQueue_command_showSchema` command. This way in case of missing schemas or known schemas that need to be updated, the user can interact with the queue to retrieve the respective value.