### PR TITLE
Make OLE components field to persist set values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ v5.27.11
 
 * Bump follow-redirects from 1.15.2 to 1.15.5 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/597>`_
 * Increase OLE tables contrast even more `<https://github.com/lsst-ts/LOVE-frontend/pull/596>`_
+* Make OLE components field to persist set values `<https://github.com/lsst-ts/LOVE-frontend/pull/595>`_
 * Add button to send showSchema command `<https://github.com/lsst-ts/LOVE-frontend/pull/594>`_
 * Adjust LOVE M2 force gradient coloring `<https://github.com/lsst-ts/LOVE-frontend/pull/592>`_
 * Fix GIS signals typo `<https://github.com/lsst-ts/LOVE-frontend/pull/591>`_

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -600,3 +600,11 @@ table.table tr {
 .wikiMarkupText:has(+ .expandBtn:checked) {
   max-height: none;
 }
+
+.inputGroup {
+  display: flex;
+}
+
+.inputGroup > :first-child {
+  flex-grow: 1;
+}

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -124,11 +124,24 @@ export default class NonExposureEdit extends Component {
   }
 
   cleanForm() {
-    // Reset MultiSelect component value
-    this.multiselectComponentsRef.current?.resetSelectedValues();
     // Reset RichTextEditor component value
     this.richTextEditorRef.current?.cleanContent();
-    this.setState({ logEdit: NonExposureEdit.defaultProps.logEdit });
+
+    // Reset logEdit values
+    // Keep previously saved components for persistence
+    this.setState((prevState) => ({
+      logEdit: {
+        ...NonExposureEdit.defaultProps.logEdit,
+        components: prevState.logEdit.components,
+      },
+    }));
+  }
+
+  clearComponentsInput() {
+    this.setState((prevState) => ({
+      logEdit: { ...prevState.logEdit, components: [] },
+    }));
+    this.multiselectComponentsRef.current?.resetSelectedValues();
   }
 
   updateDates() {
@@ -326,16 +339,19 @@ export default class NonExposureEdit extends Component {
       <>
         <span className={styles.label}>Components</span>
         <span className={styles.value}>
-          <Multiselect
-            innerRef={this.multiselectComponentsRef}
-            className={styles.select}
-            options={componentOptions}
-            selectedValues={logEdit?.components}
-            onSelect={setLogEditComponents}
-            onRemove={setLogEditComponents}
-            placeholder="Select zero or several components"
-            selectedValueDecorator={(v) => (v.length > 10 ? `${v.slice(0, 10)}...` : v)}
-          />
+          <div className={styles.inputGroup}>
+            <Multiselect
+              innerRef={this.multiselectComponentsRef}
+              className={styles.select}
+              options={componentOptions}
+              selectedValues={logEdit?.components}
+              onSelect={setLogEditComponents}
+              onRemove={setLogEditComponents}
+              placeholder="Select zero or several components"
+              selectedValueDecorator={(v) => (v.length > 10 ? `${v.slice(0, 10)}...` : v)}
+            />
+            <Button onClick={() => this.clearComponentsInput()}>Clear</Button>
+          </div>
         </span>
         <span className={styles.label}>Primary Software Component</span>
         <span className={styles.value}>

--- a/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
+++ b/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
@@ -98,9 +98,21 @@ export default class TeknikerAdd extends Component {
   }
 
   cleanForm() {
-    // Reset multiselects values
+    // Reset logEdit values
+    // Keep previously saved components for persistence
+    this.setState((prevState) => ({
+      logEdit: {
+        ...TeknikerAdd.defaultProps.logEdit,
+        components: prevState.logEdit.components,
+      },
+    }));
+  }
+
+  clearComponentsInput() {
+    this.setState((prevState) => ({
+      logEdit: { ...prevState.logEdit, components: [] },
+    }));
     this.multiselectComponentsRef.current?.resetSelectedValues();
-    this.setState({ logEdit: TeknikerAdd.defaultProps.logEdit });
   }
 
   updateDates() {
@@ -314,16 +326,19 @@ export default class TeknikerAdd extends Component {
       <>
         <span className={styles.label}>Components</span>
         <span className={styles.value}>
-          <Multiselect
-            innerRef={this.multiselectComponentsRef}
-            className={styles.select}
-            options={componentOptions}
-            selectedValues={logEdit?.components}
-            onSelect={setLogEditComponents}
-            onRemove={setLogEditComponents}
-            placeholder="Select zero or several components"
-            selectedValueDecorator={(v) => (v.length > 10 ? `${v.slice(0, 10)}...` : v)}
-          />
+          <div className={styles.inputGroup}>
+            <Multiselect
+              innerRef={this.multiselectComponentsRef}
+              className={styles.select}
+              options={componentOptions}
+              selectedValues={logEdit?.components}
+              onSelect={setLogEditComponents}
+              onRemove={setLogEditComponents}
+              placeholder="Select zero or several components"
+              selectedValueDecorator={(v) => (v.length > 10 ? `${v.slice(0, 10)}...` : v)}
+            />
+            <Button onClick={() => this.clearComponentsInput()}>Clear</Button>
+          </div>
         </span>
         <span className={styles.label}>Primary Software Component</span>
         <span className={styles.value}>


### PR DESCRIPTION
This PR makes some adjustments to allow the `components` field to persist its values after saving a log. Also a button to "clear" the input was added, as now components won't be cleared automatically.