### PR TITLE
Increase OLE tables contrast even more

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.11
 --------
 
+* Increase OLE tables contrast even more `<https://github.com/lsst-ts/LOVE-frontend/pull/596>`_
 * Add button to send showSchema command `<https://github.com/lsst-ts/LOVE-frontend/pull/594>`_
 * Adjust LOVE M2 force gradient coloring `<https://github.com/lsst-ts/LOVE-frontend/pull/592>`_
 * Fix GIS signals typo `<https://github.com/lsst-ts/LOVE-frontend/pull/591>`_

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -154,7 +154,7 @@ export default class NonExposure extends Component {
     return [
       {
         field: 'date_added',
-        title: 'Date Added',
+        title: 'Date Added (UTC)',
         type: 'string',
         className: styles.tableHead,
         render: (value) => moment(value).format(ISO_STRING_DATE_TIME_FORMAT),
@@ -186,7 +186,7 @@ export default class NonExposure extends Component {
         type: 'string',
         className: styles.tableHead,
         render: (value, row) => (
-          <span title={formatOLETimeOfIncident(row.date_begin, row.date_end)}>
+          <span title={formatOLETimeOfIncident(row.date_begin, row.date_end) + ' (UTC)'}>
             {formatSecondsToDigital(value * 3600)}
           </span>
         ),

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -555,7 +555,7 @@ table.table th {
 }
 
 table.table tr td {
-  border-bottom: 2px solid var(--second-tertiary-background-color) !important;
+  border-bottom: 6px solid var(--second-tertiary-background-color) !important;
 }
 
 table.table tr:hover td {

--- a/love/src/index.css
+++ b/love/src/index.css
@@ -227,7 +227,7 @@ body {
   /* --primary-background-color: #4c7487; */
   --primary-background-color: hsl(199, 28%, 41%);
   --primary-shadow-color: hsl(199, 28%, 28%);
-  --primary-font-color: #b2c4ce;
+  --primary-font-color: #d3dbe1;
   --primary-active-background-color: #3b5d6e;
   --primary-active-font-color: #8d9ea7;
   --primary-active-hover-background-color: #8d9ea7;


### PR DESCRIPTION
This PR adjusts the `primary-font-color` variable to increase the contrast ratio of the text in the OLE tables in 30%. Also the divisory line of logs is 3 times thicker and missing UTC labels were added too.