### PR TITLE
Fix time of incident handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.27.12
+--------
+
+* Fix time of incident handling `<https://github.com/lsst-ts/LOVE-frontend/pull/599>`_
+
 v5.27.11
 --------
 

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -186,7 +186,7 @@ export default class NonExposure extends Component {
         type: 'string',
         className: styles.tableHead,
         render: (value, row) => (
-          <span title={formatOLETimeOfIncident(row.date_begin, row.date_end) + ' (UTC)'}>
+          <span title={formatOLETimeOfIncident(row.date_begin + 'Z', row.date_end + 'Z') + ' (UTC)'}>
             {formatSecondsToDigital(value * 3600)}
           </span>
         ),

--- a/love/src/components/OLE/NonExposure/NonExposureDetail.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureDetail.jsx
@@ -190,7 +190,7 @@ export default class NonExposureDetail extends Component {
             <div className={styles.detail}>
               <span className={styles.label}>Category</span>
               <span className={styles.value}>{logDetail.category}</span>
-              <span className={styles.label}>Time of Incident</span>
+              <span className={styles.label}>Time of Incident (UTC)</span>
               <span className={styles.value}>{`${logDetail.date_begin.split('.')[0]} - ${
                 logDetail.date_end.split('.')[0]
               }`}</span>

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -70,8 +70,8 @@ export default class NonExposureEdit extends Component {
     logEdit: {
       id: undefined,
       level: 0,
-      date_begin: Moment(),
-      date_end: Moment(),
+      date_begin: undefined,
+      date_end: undefined,
       components: [],
       primary_software_components: ['None'],
       primary_hardware_components: ['None'],
@@ -100,6 +100,9 @@ export default class NonExposureEdit extends Component {
   constructor(props) {
     super(props);
     const { logEdit } = props;
+
+    logEdit['date_begin'] = logEdit['date_begin'] ? Moment(logEdit['date_begin'] + 'Z') : Moment();
+    logEdit['date_end'] = logEdit['date_end'] ? Moment(logEdit['date_end'] + 'Z') : Moment();
 
     this.state = {
       logEdit,


### PR DESCRIPTION
This PR adjust the way `date_begin` and `date_end` narrative log params were handled on the `NonExposureEdit` component. Before this change when editing a log, the time of incident field was being incorrectly set as fields that comes from the REST API weren't being parsed to a proper time format.
Also a missing UTC label was added, along some adjustments to respect UTC time (by adding the 'Z' suffix at the end of the timestamp -which comes without the Z-)