### PR TITLE
Make narrative log time of incident optional and improve usability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.27.12
+--------
+
+* Make narrative log time of incident optional and improve usability `<https://github.com/lsst-ts/LOVE-frontend/pull/600>`_
+
 v5.27.11
 --------
 

--- a/love/src/components/GeneralPurpose/DateTimeRange/DateTimeRange.jsx
+++ b/love/src/components/GeneralPurpose/DateTimeRange/DateTimeRange.jsx
@@ -107,13 +107,4 @@ DateTimeRange.propTypes = {
   onChange: PropTypes.func,
 };
 
-const arePropsEqual = (prevProps, nextProps) => {
-  return (
-    prevProps.label === nextProps.label &&
-    prevProps.className === nextProps.className &&
-    Moment(prevProps.startDate).isSame(nextProps.startDate) &&
-    Moment(prevProps.endDate).isSame(nextProps.endDate)
-  );
-};
-
-export default memo(DateTimeRange, arePropsEqual);
+export default memo(DateTimeRange);

--- a/love/src/components/GeneralPurpose/DateTimeRange/DateTimeRange.module.css
+++ b/love/src/components/GeneralPurpose/DateTimeRange/DateTimeRange.module.css
@@ -19,6 +19,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .horizontalFilter {
   display: flex;
+  align-items: center;
 }
 
 .label {

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -468,6 +468,10 @@ class Layout extends Component {
     );
   };
 
+  goBackFromOLETab = () => {
+    this.setState({ oleTabOpen: null });
+  };
+
   renderRightSideMenu = () => {
     const { controlLocation, lastUpdated } = this.props.controlLocation;
     const filteredAlarms = this.props.alarms.filter((a) => {
@@ -517,7 +521,7 @@ class Layout extends Component {
                   </span>
                 </div>
                 <div className={styles.divider}></div>
-                <NonExposureEdit isMenu={true} back={() => this.setState({ oleTabOpen: null })} />
+                <NonExposureEdit isMenu={true} back={this.goBackFromOLETab} />
               </>
             )}
             {this.state.oleTabOpen === 'exposure' && (
@@ -536,7 +540,7 @@ class Layout extends Component {
                   </span>
                 </div>
                 <div className={styles.divider}></div>
-                <ExposureAdd isMenu={true} back={() => this.setState({ oleTabOpen: null })} />
+                <ExposureAdd isMenu={true} back={this.goBackFromOLETab} />
               </>
             )}
             {this.state.oleTabOpen === 'tma' && (
@@ -555,7 +559,7 @@ class Layout extends Component {
                   </span>
                 </div>
                 <div className={styles.divider}></div>
-                <TeknikerAdd isMenu={true} back={() => this.setState({ oleTabOpen: null })} />
+                <TeknikerAdd isMenu={true} back={this.goBackFromOLETab} />
               </>
             )}
           </div>

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import React, { Component } from 'react';
+import React, { Component, memo } from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import Moment from 'moment';
@@ -39,7 +39,7 @@ import { EXPOSURE_FLAG_OPTIONS, exposureFlagStateToStyle, ISO_INTEGER_DATE_FORMA
 import ManagerInterface, { getFilesURLs, htmlToJiraMarkdown, jiraMarkdownToHtml } from 'Utils';
 import styles from './Exposure.module.css';
 
-export default class ExposureAdd extends Component {
+class ExposureAdd extends Component {
   static propTypes = {
     /** Exposure object to which a log is going to be added */
     exposure: PropTypes.object,
@@ -717,3 +717,5 @@ export default class ExposureAdd extends Component {
     );
   }
 }
+
+export default memo(ExposureAdd);

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -44,13 +44,14 @@ import SimpleTable from 'components/GeneralPurpose/SimpleTable/SimpleTable';
 import Button from 'components/GeneralPurpose/Button/Button';
 import Input from 'components/GeneralPurpose/Input/Input';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
+import Hoverable from 'components/GeneralPurpose/Hoverable/Hoverable';
 import ClipIcon from 'components/icons/ClipIcon/ClipIcon';
 import DownloadIcon from 'components/icons/DownloadIcon/DownloadIcon';
 import EditIcon from 'components/icons/EditIcon/EditIcon';
 import AcknowledgeIcon from 'components/icons/Watcher/AcknowledgeIcon/AcknowledgeIcon';
+import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
 import SpinnerIcon from 'components/icons/SpinnerIcon/SpinnerIcon';
 import Select from 'components/GeneralPurpose/Select/Select';
-import Hoverable from 'components/GeneralPurpose/Hoverable/Hoverable';
 import NonExposureDetail from './NonExposureDetail';
 import NonExposureEdit from './NonExposureEdit';
 import styles from './NonExposure.module.css';
@@ -153,15 +154,36 @@ export default class NonExposure extends Component {
   getHeaders = () => {
     return [
       {
-        field: 'date_added',
-        title: 'Date Added (UTC)',
+        field: 'date_begin',
+        title: 'Time of incident (UTC)',
         type: 'string',
         className: styles.tableHead,
         render: (value) => moment(value).format(ISO_STRING_DATE_TIME_FORMAT),
       },
       {
-        field: 'date_added',
-        title: 'Obs Day',
+        field: 'time_lost',
+        title: 'Obs. Time Loss',
+        type: 'string',
+        className: styles.tableHead,
+        render: (value, row) => (
+          <span title={formatOLETimeOfIncident(row.date_begin + 'Z', row.date_end + 'Z') + ' (UTC)'}>
+            {formatSecondsToDigital(value * 3600)}
+          </span>
+        ),
+      },
+      {
+        field: 'date_begin',
+        title: (
+          <div className={styles.obsDayTableHeader}>
+            <span>Obs Day</span>
+            <div className={styles.infoIcon}>
+              <InfoIcon
+                title="This is a calculated field based on the time of the incident set by the user.
+              Constrained from 12 UTC of a day to 12 UTC of the next one."
+              />
+            </div>
+          </div>
+        ),
         type: 'string',
         className: styles.tableHead,
         render: (value) => getObsDayFromDate(moment(value)),
@@ -179,17 +201,6 @@ export default class NonExposure extends Component {
         type: 'string',
         className: styles.tableHead,
         render: (value) => value?.join(', '),
-      },
-      {
-        field: 'time_lost',
-        title: 'Obs. Time Loss',
-        type: 'string',
-        className: styles.tableHead,
-        render: (value, row) => (
-          <span title={formatOLETimeOfIncident(row.date_begin + 'Z', row.date_end + 'Z') + ' (UTC)'}>
-            {formatSecondsToDigital(value * 3600)}
-          </span>
-        ),
       },
       {
         field: 'message_text',

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -46,6 +46,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   box-sizing: border-box;
   margin-left: 15px;
   margin-right: 15px;
+  container: content / inline-size;
 }
 
 .header {
@@ -153,6 +154,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .infoIcon {
   width: 1em;
+  height: 1em;
   margin-left: 0.5em;
   margin-right: 0.5em;
   position: relative;
@@ -237,6 +239,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 }
 
 .label {
+  display: flex;
+  align-items: center;
   font-weight: bold;
   color: var(--secondary-font-color);
   text-align: left;
@@ -248,7 +252,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .contentLeft {
   display: grid;
-  grid-template-columns: 1fr 2fr;
+  grid-template-columns: minmax(12em, 1fr) 2fr;
   grid-auto-rows: max-content;
   grid-row-gap: 0.5em;
   align-items: center;
@@ -386,6 +390,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .dateTimeRangeStyle :global(.rdtPicker) {
   left: -176px;
+  min-width: 250px;
 }
 
 .dateTimeSingularStyle {
@@ -436,17 +441,12 @@ th.tableHead {
   margin-bottom: var(--small-padding);
 }
 
-.incidentTimeTypeContainer > :first-child {
-  margin-right: var(--small-padding);
-}
-
-.refreshDateIcon {
+.clearDateIcon {
   display: flex;
   align-items: center;
   padding: 0.25em;
-  margin-left: var(--small-padding);
 }
-.refreshDateIcon > * {
+.clearDateIcon > * {
   width: 1.5em;
   height: 1.5em;
 }
@@ -607,4 +607,50 @@ table.table tr {
 
 .inputGroup > :first-child {
   flex-grow: 1;
+}
+
+.timeOfIncidentInputContainer {
+  display: flex;
+}
+
+.timeOfIncidentInput:hover::placeholder {
+  color: #c3c3c3;
+}
+
+.hiddenButtons {
+  display: none;
+}
+
+:global(.rdtPicker) button.rdtControlsButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  --button-margin: 0.75em;
+  width: calc(100% - 2 * var(--button-margin));
+  padding: 0.25em;
+  background-color: var(--default-background-color);
+  color: var(--default-font-color);
+  margin: 0 var(--button-margin);
+}
+
+:global(.rdtPicker) button.rdtControlsButton:hover {
+  background-color: var(--default-active-background-color);
+  color: var(--default-active-font-color);
+}
+
+:global(.rdtPicker) button.rdtControlsButton svg {
+  width: 1em;
+  height: 1em;
+}
+
+.obsDayTableHeader {
+  display: flex;
+  align-items: center;
+}
+
+@container content (min-width: 1260px) {
+  .dateTimeRangeStyle :global(.rdtPicker) {
+    left: 184px;
+    top: -161px;
+  }
 }

--- a/love/src/components/OLE/NonExposure/NonExposureDetail.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureDetail.jsx
@@ -20,12 +20,13 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
+import moment from 'moment';
 import DeleteIcon from 'components/icons/DeleteIcon/DeleteIcon';
 import DownloadIcon from 'components/icons/DownloadIcon/DownloadIcon';
 import Button from 'components/GeneralPurpose/Button/Button';
 import EditIcon from 'components/icons/EditIcon/EditIcon';
 import Modal from 'components/GeneralPurpose/Modal/Modal';
-import { iconLevelOLE } from 'Config';
+import { iconLevelOLE, ISO_STRING_DATE_TIME_FORMAT } from 'Config';
 import ManagerInterface, {
   getLinkJira,
   getFilesURLs,
@@ -188,8 +189,6 @@ export default class NonExposureDetail extends Component {
           </div>
           <div className={styles.content}>
             <div className={styles.detail}>
-              <span className={styles.label}>Category</span>
-              <span className={styles.value}>{logDetail.category}</span>
               <span className={styles.label}>Time of Incident (UTC)</span>
               <span className={styles.value}>{`${logDetail.date_begin.split('.')[0]} - ${
                 logDetail.date_end.split('.')[0]
@@ -199,16 +198,22 @@ export default class NonExposureDetail extends Component {
               <span className={styles.label}>Obs. Time Loss</span>
               <span className={styles.value}>{formatSecondsToDigital(logDetail.time_lost * 3600)}</span>
               <span className={styles.label}>Components</span>
-              <span className={styles.value}>{logDetail.components?.join(', ')}</span>
+              <span className={styles.value}>
+                {logDetail.components?.length > 0 ? logDetail.components.join(', ') : 'None'}
+              </span>
               <span className={styles.label}>Primary Software Component</span>
               <span className={styles.value}>{logDetail.primary_software_components?.join(', ')}</span>
               <span className={styles.label}>Primary Hardware Component</span>
               <span className={styles.value}>{logDetail.primary_hardware_components?.join(', ')}</span>
+              <span className={styles.label}>Type of observing time</span>
+              <span className={styles.value}>{logDetail.category}</span>
             </div>
             <div className={styles.description}>
               <div className={styles.floatLeft}>
                 <span>On </span>
-                <span className={styles.bold}>{logDetail.date_added} </span>
+                <span className={styles.bold}>
+                  {moment(logDetail.date_added).format(ISO_STRING_DATE_TIME_FORMAT) + ' (UTC) '}
+                </span>
                 <span className={styles.bold}>{logDetail.user_id} </span>
                 <span>wrote:</span>
               </div>

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -23,6 +23,7 @@ import lodash from 'lodash';
 import Moment from 'moment';
 import DownloadIcon from 'components/icons/DownloadIcon/DownloadIcon';
 import CloseIcon from 'components/icons/CloseIcon/CloseIcon';
+import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
 import SpinnerIcon from 'components/icons/SpinnerIcon/SpinnerIcon';
 import RefreshIcon from 'components/icons/RefreshIcon/RefreshIcon';
 import RichTextEditor from 'components/GeneralPurpose/RichTextEditor/RichTextEditor';
@@ -70,11 +71,14 @@ export default class NonExposureEdit extends Component {
     logEdit: {
       id: undefined,
       level: 0,
-      date_begin: undefined,
-      date_end: undefined,
+      date_begin: '',
+      date_end: '',
       components: [],
+      components_ids: [],
       primary_software_components: ['None'],
+      primary_software_components_ids: OLE_JIRA_PRIMARY_SOFTWARE_COMPONENTS['None'],
       primary_hardware_components: ['None'],
+      primary_hardware_components_ids: OLE_JIRA_PRIMARY_HARDWARE_COMPONENTS['None'],
       salindex: 0,
       user: undefined,
       time_lost: 0,
@@ -101,21 +105,23 @@ export default class NonExposureEdit extends Component {
     super(props);
     const { logEdit } = props;
 
-    logEdit['date_begin'] = logEdit['date_begin'] ? Moment(logEdit['date_begin'] + 'Z') : Moment();
-    logEdit['date_end'] = logEdit['date_end'] ? Moment(logEdit['date_end'] + 'Z') : Moment();
+    logEdit['date_begin'] = logEdit['date_begin'] ? Moment(logEdit['date_begin'] + 'Z') : '';
+    logEdit['date_end'] = logEdit['date_end'] ? Moment(logEdit['date_end'] + 'Z') : '';
 
     this.state = {
       logEdit,
       savingLog: false,
       datesAreValid: true,
       jiraIssueError: false,
-      incidentTimeIsRange: false,
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.multiselectComponentsRef = React.createRef();
     this.richTextEditorRef = React.createRef();
     this.id = lodash.uniqueId('nonexposure-edit-');
+
+    this.dateBeginInputRef = React.createRef();
+    this.dateEndInputRef = React.createRef();
   }
 
   getIconLevel(level) {
@@ -126,6 +132,9 @@ export default class NonExposureEdit extends Component {
   cleanForm() {
     // Reset RichTextEditor component value
     this.richTextEditorRef.current?.cleanContent();
+
+    // Reset time of incident datetime pickers
+    this.clearDates();
 
     // Reset logEdit values
     // Keep previously saved components for persistence
@@ -150,13 +159,72 @@ export default class NonExposureEdit extends Component {
     }));
   }
 
+  closeCalendar(ref) {
+    const buttons = ref?.querySelectorAll('button');
+    const clickEvent = new Event('click', { bubbles: true });
+    if (buttons && buttons.length > 0) {
+      // buttons[2] is the button to close the calendar
+      // hidden by default so it can only be clicked programatically
+      buttons[2].dispatchEvent(clickEvent);
+    }
+  }
+
+  updateDateBeginToNow() {
+    this.setState(
+      (prevState) => ({
+        logEdit: { ...prevState.logEdit, date_begin: Moment() },
+      }),
+      () => {
+        this.closeCalendar(this.dateBeginInputRef?.current);
+      },
+    );
+  }
+
+  updateDateEndToNow() {
+    this.setState(
+      (prevState) => ({
+        logEdit: { ...prevState.logEdit, date_end: Moment() },
+      }),
+      () => {
+        this.closeCalendar(this.dateEndInputRef?.current);
+      },
+    );
+  }
+
+  clearDates() {
+    // For some reason setting logEdit.date_begin to '' does not work
+    // thus we clear the date by calling the onClick function of the clear button
+    // of each DateTime component
+    const dateBeginElement = this.dateBeginInputRef.current;
+    const dateEndElement = this.dateEndInputRef.current;
+
+    const dateBeginButtons = dateBeginElement?.querySelectorAll('button');
+    const dateEndButtons = dateEndElement?.querySelectorAll('button');
+
+    // const clickEvent = new MouseEvent('click');
+    const clickEvent = new Event('click', { bubbles: true });
+
+    if (dateBeginButtons && dateBeginButtons.length > 0) {
+      dateBeginButtons[0].dispatchEvent(clickEvent);
+      dateBeginButtons[2].dispatchEvent(clickEvent);
+    }
+
+    if (dateEndButtons && dateEndButtons.length > 0) {
+      dateEndButtons[0].dispatchEvent(clickEvent);
+      dateEndButtons[2].dispatchEvent(clickEvent);
+    }
+  }
+
   updateOrCreateMessageNarrativeLogs() {
     const payload = { ...this.state.logEdit };
-
+    const nowMoment = Moment();
     payload['request_type'] = 'narrative';
 
-    const beginDateISO = Moment(this.state.logEdit.date_begin).toISOString();
-    const endDateISO = Moment(this.state.logEdit.date_end).toISOString();
+    // Handle dates saving
+    let beginDateISO, endDateISO;
+    beginDateISO = payload.date_begin != '' ? Moment(payload.date_begin).toISOString() : nowMoment.toISOString();
+    endDateISO = payload.date_end != '' ? Moment(payload.date_end).toISOString() : nowMoment.toISOString();
+
     payload['date_begin'] = beginDateISO.substring(0, beginDateISO.length - 1); // remove Zone due to backend standard
     payload['date_end'] = endDateISO.substring(0, endDateISO.length - 1); // remove Zone due to backend standard
 
@@ -212,6 +280,9 @@ export default class NonExposureEdit extends Component {
 
   handleTimeLost() {
     const { date_begin, date_end } = this.state.logEdit;
+    if (date_begin === '' || date_end === '') {
+      return;
+    }
     const start = Moment(date_begin);
     const end = Moment(date_end);
     const duration_hr = end.diff(start, 'hours', true);
@@ -228,18 +299,7 @@ export default class NonExposureEdit extends Component {
       prevState.logEdit?.date_begin !== this.state.logEdit?.date_begin ||
       prevState.logEdit?.date_end !== this.state.logEdit?.date_end
     ) {
-      try {
-        this.state.logEdit.date_begin.toISOString();
-        this.state.logEdit.date_end.toISOString();
-        this.setState({
-          datesAreValid: true,
-        });
-        this.handleTimeLost();
-      } catch (error) {
-        this.setState({
-          datesAreValid: false,
-        });
-      }
+      this.handleTimeLost();
     }
 
     if (this.state.logEdit) {
@@ -261,17 +321,6 @@ export default class NonExposureEdit extends Component {
         } else {
           this.setState({ jiraIssueError: false });
         }
-      }
-    }
-
-    if (this.state.incidentTimeIsRange !== prevState.incidentTimeIsRange) {
-      if (!this.state.incidentTimeIsRange) {
-        this.setState((prevState) => ({
-          logEdit: {
-            ...prevState.logEdit,
-            date_end: Moment(prevState.logEdit.date_begin),
-          },
-        }));
       }
     }
   }
@@ -393,59 +442,100 @@ export default class NonExposureEdit extends Component {
 
   renderTimeOfIncidentFields() {
     const { date_begin, date_end, time_lost, time_lost_type } = this.state.logEdit ?? {};
-    const { incidentTimeIsRange, datesAreValid } = this.state;
+    const { datesAreValid } = this.state;
 
-    const renderDateTimeInput = (props) => {
-      return <input {...props} readOnly />;
+    const renderDateTimeInput = (ref) => {
+      return (props, openCalendar, closeCalendar) => {
+        function clearDate() {
+          props.onChange({ target: { value: '' } });
+        }
+        return (
+          <div ref={ref} className={styles.timeOfIncidentInputContainer}>
+            <input {...props} readOnly />
+            <Button
+              // ref={ref}
+              className={styles.clearDateIcon}
+              size="small"
+              title="Clear date"
+              onClick={clearDate}
+            >
+              <CloseIcon title="Clear date" />
+            </Button>
+            <button className={styles.hiddenButtons} type="button" onClick={openCalendar} />
+            <button className={styles.hiddenButtons} type="button" onClick={closeCalendar} />
+          </div>
+        );
+      };
+    };
+
+    const renderDatePickerView = (dateBegin = true) => {
+      return (mode, renderDefault) => {
+        const updateToNow = () => {
+          if (dateBegin) {
+            this.updateDateBeginToNow();
+          } else {
+            this.updateDateEndToNow();
+          }
+        };
+
+        // Only for years, months and days view
+        if (mode === 'time') return renderDefault();
+
+        return (
+          <div className="wrapper">
+            {renderDefault()}
+            <div className={styles.rdtControls}>
+              <Button title="Set date to now" className={styles.rdtControlsButton} onClick={updateToNow}>
+                <RefreshIcon />
+                Now
+              </Button>
+            </div>
+          </div>
+        );
+      };
     };
 
     return (
       <>
-        <span className={styles.label}>Time of Incident (UTC)</span>
+        <span className={styles.label}>
+          Time of Incident (UTC)
+          <div className={styles.infoIcon}>
+            <InfoIcon title="This fields are optionals. If not filled, the current time will be used." />
+          </div>
+        </span>
         <span className={styles.value}>
           <div className={styles.incidentTimeTypeContainer}>
-            <Toggle
-              labels={['Singular', 'Range']}
-              toggled={incidentTimeIsRange}
-              onToggle={(event) => this.setState({ incidentTimeIsRange: event })}
+            <DateTimeRange
+              label="From"
+              className={styles.dateTimeRangeStyle}
+              startDate={date_begin}
+              endDate={date_end}
+              onChange={(date, type) => this.handleTimeOfIncident(date, type)}
+              startDateProps={{
+                renderInput: renderDateTimeInput(this.dateBeginInputRef),
+                renderView: renderDatePickerView(true),
+                inputProps: {
+                  title: 'This field is optional. If it is not filled, the current time will be used.',
+                  placeholder: 'YYYY/MM/DD HH:mm',
+                  className: styles.timeOfIncidentInput,
+                },
+                dateFormat: 'YYYY/MM/DD',
+                timeFormat: 'HH:mm A',
+                closeOnSelect: false,
+              }}
+              endDateProps={{
+                renderInput: renderDateTimeInput(this.dateEndInputRef),
+                renderView: renderDatePickerView(false),
+                inputProps: {
+                  title: 'This field is optional. If it is not filled, the current time will be used.',
+                  placeholder: 'YYYY/MM/DD HH:mm',
+                  className: styles.timeOfIncidentInput,
+                },
+                dateFormat: 'YYYY/MM/DD',
+                timeFormat: 'HH:mm A',
+                closeOnSelect: false,
+              }}
             />
-            {incidentTimeIsRange ? (
-              <DateTimeRange
-                className={styles.dateTimeRangeStyle}
-                startDate={date_begin}
-                endDate={date_end}
-                onChange={(date, type) => this.handleTimeOfIncident(date, type)}
-                startDateProps={{
-                  renderInput: renderDateTimeInput,
-                }}
-                endDateProps={{
-                  renderInput: renderDateTimeInput,
-                }}
-              />
-            ) : (
-              <DateTime
-                className={styles.dateTimeSingularStyle}
-                viewMode="time"
-                dateFormat="YYYY/MM/DD"
-                timeFormat="HH:mm:ss"
-                closeOnSelect={true}
-                value={date_begin}
-                onChange={(date) => {
-                  this.setState((prevState) => ({
-                    logEdit: { ...prevState.logEdit, date_begin: date },
-                  }));
-                }}
-                renderInput={renderDateTimeInput}
-              />
-            )}
-            <Button
-              className={styles.refreshDateIcon}
-              size="small"
-              title="Refresh date"
-              onClick={() => this.updateDates()}
-            >
-              <RefreshIcon title="Refresh date" />
-            </Button>
           </div>
           {!datesAreValid && <div className={styles.inputError}>Error: dates must be input in valid ISO format</div>}
         </span>

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import React, { Component } from 'react';
+import React, { Component, memo } from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import Moment from 'moment';
@@ -31,7 +31,6 @@ import Input from 'components/GeneralPurpose/Input/Input';
 import Button from 'components/GeneralPurpose/Button/Button';
 import MultiFileUploader from 'components/GeneralPurpose/MultiFileUploader/MultiFileUploader';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
-import DateTime from 'components/GeneralPurpose/DateTime/DateTime';
 import Toggle from 'components/GeneralPurpose/Toggle/Toggle';
 import Multiselect from 'components/GeneralPurpose/MultiSelect/MultiSelect';
 import Select from 'components/GeneralPurpose/Select/Select';
@@ -51,7 +50,7 @@ import ManagerInterface, {
 } from 'Utils';
 import styles from './NonExposure.module.css';
 
-export default class NonExposureEdit extends Component {
+class NonExposureEdit extends Component {
   static propTypes = {
     /** Log to edit object */
     logEdit: PropTypes.object,
@@ -831,3 +830,5 @@ export default class NonExposureEdit extends Component {
     return isMenu ? this.renderMenu() : this.renderComponent();
   }
 }
+
+export default memo(NonExposureEdit);

--- a/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
+++ b/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React, { Component, useCallback, memo } from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import Moment from 'moment';
 import DownloadIcon from 'components/icons/DownloadIcon/DownloadIcon';
 import CloseIcon from 'components/icons/CloseIcon/CloseIcon';
+import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
 import SpinnerIcon from 'components/icons/SpinnerIcon/SpinnerIcon';
 import RefreshIcon from 'components/icons/RefreshIcon/RefreshIcon';
 import TextArea from 'components/GeneralPurpose/TextArea/TextArea';
@@ -11,7 +12,6 @@ import Input from 'components/GeneralPurpose/Input/Input';
 import Button from 'components/GeneralPurpose/Button/Button';
 import MultiFileUploader from 'components/GeneralPurpose/MultiFileUploader/MultiFileUploader';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
-import DateTime from 'components/GeneralPurpose/DateTime/DateTime';
 import Toggle from 'components/GeneralPurpose/Toggle/Toggle';
 import Multiselect from 'components/GeneralPurpose/MultiSelect/MultiSelect';
 import Select from 'components/GeneralPurpose/Select/Select';
@@ -25,7 +25,7 @@ import ManagerInterface, { getFilesURLs, getLinkJira, getFilename, openInNewTab 
 import styles from '../NonExposure/NonExposure.module.css';
 import customStyles from './Tekniker.module.css';
 
-export default class TeknikerAdd extends Component {
+class TeknikerAdd extends Component {
   static propTypes = {
     /** Log to edit object */
     logEdit: PropTypes.object,
@@ -45,8 +45,8 @@ export default class TeknikerAdd extends Component {
     logEdit: {
       id: undefined,
       level: 0,
-      date_begin: Moment(),
-      date_end: Moment(),
+      date_begin: '',
+      date_end: '',
       components: [],
       components_ids: [],
       primary_software_components: ['None'],
@@ -79,17 +79,22 @@ export default class TeknikerAdd extends Component {
     super(props);
     const { logEdit } = props;
 
+    logEdit['date_begin'] = logEdit['date_begin'] ? Moment(logEdit['date_begin'] + 'Z') : '';
+    logEdit['date_end'] = logEdit['date_end'] ? Moment(logEdit['date_end'] + 'Z') : '';
+
     this.state = {
       logEdit,
       savingLog: false,
       datesAreValid: true,
       jiraIssueError: false,
-      incidentTimeIsRange: false,
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.multiselectComponentsRef = React.createRef();
     this.id = lodash.uniqueId('nonexposure-edit-');
+
+    this.dateBeginInputRef = React.createRef();
+    this.dateEndInputRef = React.createRef();
   }
 
   getIconLevel(level) {
@@ -98,6 +103,9 @@ export default class TeknikerAdd extends Component {
   }
 
   cleanForm() {
+    // Reset time of incident datetime pickers
+    this.clearDates();
+
     // Reset logEdit values
     // Keep previously saved components for persistence
     this.setState((prevState) => ({
@@ -121,6 +129,62 @@ export default class TeknikerAdd extends Component {
     }));
   }
 
+  closeCalendar(ref) {
+    const buttons = ref?.querySelectorAll('button');
+    const clickEvent = new Event('click', { bubbles: true });
+    if (buttons && buttons.length > 0) {
+      // buttons[2] is the button to close the calendar
+      // hidden by default so it can only be clicked programatically
+      buttons[2].dispatchEvent(clickEvent);
+    }
+  }
+
+  updateDateBeginToNow() {
+    this.setState(
+      (prevState) => ({
+        logEdit: { ...prevState.logEdit, date_begin: Moment() },
+      }),
+      () => {
+        this.closeCalendar(this.dateBeginInputRef?.current);
+      },
+    );
+  }
+
+  updateDateEndToNow() {
+    this.setState(
+      (prevState) => ({
+        logEdit: { ...prevState.logEdit, date_end: Moment() },
+      }),
+      () => {
+        this.closeCalendar(this.dateEndInputRef?.current);
+      },
+    );
+  }
+
+  clearDates() {
+    // For some reason setting logEdit.date_begin to '' does not work
+    // thus we clear the date by calling the onClick function of the clear button
+    // of each DateTime component
+    const dateBeginElement = this.dateBeginInputRef.current;
+    const dateEndElement = this.dateEndInputRef.current;
+
+    const dateBeginButtons = dateBeginElement?.querySelectorAll('button');
+    const dateEndButtons = dateEndElement?.querySelectorAll('button');
+
+    // const clickEvent = new MouseEvent('click');
+    const clickEvent = new Event('click', { bubbles: true });
+
+    if (dateBeginButtons && dateBeginButtons.length > 0) {
+      dateBeginButtons[0].dispatchEvent(clickEvent);
+      dateBeginButtons[2].dispatchEvent(clickEvent);
+    }
+
+    if (dateEndButtons && dateEndButtons.length > 0) {
+      dateEndButtons[0].dispatchEvent(clickEvent);
+      dateEndButtons[2].dispatchEvent(clickEvent);
+    }
+  }
+
   makeTemplateMessage() {
     const { logEdit } = this.state;
 
@@ -139,10 +203,14 @@ export default class TeknikerAdd extends Component {
   updateOrCreateMessageNarrativeLogs() {
     const payload = { ...this.state.logEdit };
 
+    const nowMoment = Moment();
     payload['request_type'] = 'narrative';
 
-    const beginDateISO = Moment(this.state.logEdit.date_begin).toISOString();
-    const endDateISO = Moment(this.state.logEdit.date_end).toISOString();
+    // Handle dates saving
+    let beginDateISO, endDateISO;
+    beginDateISO = payload.date_begin != '' ? Moment(payload.date_begin).toISOString() : nowMoment.toISOString();
+    endDateISO = payload.date_end != '' ? Moment(payload.date_end).toISOString() : nowMoment.toISOString();
+
     payload['date_begin'] = beginDateISO.substring(0, beginDateISO.length - 1); // remove Zone due to backend standard
     payload['date_end'] = endDateISO.substring(0, endDateISO.length - 1); // remove Zone due to backend standard
 
@@ -198,6 +266,9 @@ export default class TeknikerAdd extends Component {
 
   handleTimeLost() {
     const { date_begin, date_end } = this.state.logEdit;
+    if (date_begin === '' || date_end === '') {
+      return;
+    }
     const start = Moment(date_begin);
     const end = Moment(date_end);
     const duration_hr = end.diff(start, 'hours', true);
@@ -214,18 +285,7 @@ export default class TeknikerAdd extends Component {
       prevState.logEdit?.date_begin !== this.state.logEdit?.date_begin ||
       prevState.logEdit?.date_end !== this.state.logEdit?.date_end
     ) {
-      try {
-        this.state.logEdit.date_begin.toISOString();
-        this.state.logEdit.date_end.toISOString();
-        this.setState({
-          datesAreValid: true,
-        });
-        this.handleTimeLost();
-      } catch (error) {
-        this.setState({
-          datesAreValid: false,
-        });
-      }
+      this.handleTimeLost();
     }
 
     if (this.state.logEdit) {
@@ -247,17 +307,6 @@ export default class TeknikerAdd extends Component {
         } else {
           this.setState({ jiraIssueError: false });
         }
-      }
-    }
-
-    if (this.state.incidentTimeIsRange !== prevState.incidentTimeIsRange) {
-      if (!this.state.incidentTimeIsRange) {
-        this.setState((prevState) => ({
-          logEdit: {
-            ...prevState.logEdit,
-            date_end: Moment(prevState.logEdit.date_begin),
-          },
-        }));
       }
     }
   }
@@ -380,59 +429,100 @@ export default class TeknikerAdd extends Component {
 
   renderTimeOfIncidentFields() {
     const { date_begin, date_end, time_lost, time_lost_type } = this.state.logEdit ?? {};
-    const { incidentTimeIsRange, datesAreValid } = this.state;
+    const { datesAreValid } = this.state;
 
-    const renderDateTimeInput = (props) => {
-      return <input {...props} readOnly />;
+    const renderDateTimeInput = (ref) => {
+      return (props, openCalendar, closeCalendar) => {
+        function clearDate() {
+          props.onChange({ target: { value: '' } });
+        }
+        return (
+          <div ref={ref} className={styles.timeOfIncidentInputContainer}>
+            <input {...props} readOnly />
+            <Button
+              // ref={ref}
+              className={styles.clearDateIcon}
+              size="small"
+              title="Clear date"
+              onClick={clearDate}
+            >
+              <CloseIcon title="Clear date" />
+            </Button>
+            <button className={styles.hiddenButtons} type="button" onClick={openCalendar} />
+            <button className={styles.hiddenButtons} type="button" onClick={closeCalendar} />
+          </div>
+        );
+      };
+    };
+
+    const renderDatePickerView = (dateBegin = true) => {
+      return (mode, renderDefault) => {
+        const updateToNow = () => {
+          if (dateBegin) {
+            this.updateDateBeginToNow();
+          } else {
+            this.updateDateEndToNow();
+          }
+        };
+
+        // Only for years, months and days view
+        if (mode === 'time') return renderDefault();
+
+        return (
+          <div className="wrapper">
+            {renderDefault()}
+            <div className={styles.rdtControls}>
+              <Button title="Set date to now" className={styles.rdtControlsButton} onClick={updateToNow}>
+                <RefreshIcon />
+                Now
+              </Button>
+            </div>
+          </div>
+        );
+      };
     };
 
     return (
       <>
-        <span className={styles.label}>Time of Incident (UTC)</span>
+        <span className={styles.label}>
+          Time of Incident (UTC)
+          <div className={styles.infoIcon}>
+            <InfoIcon title="This fields are optionals. If not filled, the current time will be used." />
+          </div>
+        </span>
         <span className={styles.value}>
           <div className={styles.incidentTimeTypeContainer}>
-            <Toggle
-              labels={['Singular', 'Range']}
-              toggled={incidentTimeIsRange}
-              onToggle={(event) => this.setState({ incidentTimeIsRange: event })}
+            <DateTimeRange
+              label="From"
+              className={styles.dateTimeRangeStyle}
+              startDate={date_begin}
+              endDate={date_end}
+              onChange={(date, type) => this.handleTimeOfIncident(date, type)}
+              startDateProps={{
+                renderInput: renderDateTimeInput(this.dateBeginInputRef),
+                renderView: renderDatePickerView(true),
+                inputProps: {
+                  title: 'This field is optional. If it is not filled, the current time will be used.',
+                  placeholder: 'YYYY/MM/DD HH:mm',
+                  className: styles.timeOfIncidentInput,
+                },
+                dateFormat: 'YYYY/MM/DD',
+                timeFormat: 'HH:mm A',
+                closeOnSelect: false,
+              }}
+              endDateProps={{
+                renderInput: renderDateTimeInput(this.dateEndInputRef),
+                renderView: renderDatePickerView(false),
+                inputProps: {
+                  title: 'This field is optional. If it is not filled, the current time will be used.',
+                  placeholder: 'YYYY/MM/DD HH:mm',
+                  className: styles.timeOfIncidentInput,
+                },
+                dateFormat: 'YYYY/MM/DD',
+                timeFormat: 'HH:mm A',
+                closeOnSelect: false,
+              }}
             />
-            {incidentTimeIsRange ? (
-              <DateTimeRange
-                className={styles.dateTimeRangeStyle}
-                startDate={date_begin}
-                endDate={date_end}
-                onChange={(date, type) => this.handleTimeOfIncident(date, type)}
-                startDateProps={{
-                  renderInput: renderDateTimeInput,
-                }}
-                endDateProps={{
-                  renderInput: renderDateTimeInput,
-                }}
-              />
-            ) : (
-              <DateTime
-                className={styles.dateTimeSingularStyle}
-                viewMode="time"
-                dateFormat="YYYY/MM/DD"
-                timeFormat="HH:mm:ss"
-                closeOnSelect={true}
-                value={date_begin}
-                onChange={(date) => {
-                  this.setState((prevState) => ({
-                    logEdit: { ...prevState.logEdit, date_begin: date },
-                  }));
-                }}
-                renderInput={renderDateTimeInput}
-              />
-            )}
-            <Button
-              className={styles.refreshDateIcon}
-              size="small"
-              title="Refresh date"
-              onClick={() => this.updateDates()}
-            >
-              <RefreshIcon title="Refresh date" />
-            </Button>
           </div>
           {!datesAreValid && <div className={styles.inputError}>Error: dates must be input in valid ISO format</div>}
         </span>
@@ -770,3 +860,5 @@ export default class TeknikerAdd extends Component {
     return isMenu ? this.renderMenu() : this.renderComponent();
   }
 }
+
+export default memo(TeknikerAdd);

--- a/love/src/components/icons/CloseIcon/CloseIcon.jsx
+++ b/love/src/components/icons/CloseIcon/CloseIcon.jsx
@@ -23,7 +23,7 @@ import styles from './CloseIcon.module.css';
 function CloseIcon(props) {
   return (
     <svg viewBox="0 0 24 24" {...props}>
-      <title>{'Close'}</title>
+      <title>{props.title ?? 'Close'}</title>
       <path
         className={styles.path}
         d="M3.33 22.19A1 1 0 012 20.82l8.26-8.26L2 4.31a1 1 0 010-1.38 1 1 0 011.37 0l8.25 8.25 8.26-8.26a1 1 0 011.37 1.38L13 12.56l8.25 8.26a1 1 0 010 1.37 1 1 0 01-1.38 0l-8.26-8.26z"

--- a/love/src/styles/react-datetime.css
+++ b/love/src/styles/react-datetime.css
@@ -148,7 +148,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   cursor: pointer;
 }
 .rdtPicker thead tr:first-child th:hover {
-  background: #eeeeee;
+  color: var(--highlighted-font-color);
 }
 
 .rdtPicker tfoot {


### PR DESCRIPTION
This PR makes a refactor of the "Time of Incident" field of the narrative and TMA log creation services (`NonExposureEdit` and `TeknikerAdd`) by changing the UI to be an optional param instead of forcing the user to set it each time a log is created, now instead if the field is not selected, the current time will be set.

Also a few other improvements were added in base a of Observers meeting that was held and feedback was retrieved:

- A help icon and tooltip was added to indicate the meaning of the ObsDay param and how it is calculated.
- A help icon and tooltip was added to the "Time of incident" field to give more hints to the user about how it works.
- The DatetimeRange DatePicker styles were improved for a better responsive behavior.
- Improved performance rendering of OLE navbar components.
- A few other UI improvements: a120d90a1ca389464f37c3a2de371beab78e0450