### PR TITLE
Remove drag and drop ability on `RichTextEditor` component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.27.12
 --------
 
+* Remove drag and drop ability on RichTextEditor component `<https://github.com/lsst-ts/LOVE-frontend/pull/602>`_
 * Make narrative log time of incident optional and improve usability `<https://github.com/lsst-ts/LOVE-frontend/pull/600>`_
 
 v5.27.11

--- a/love/src/components/GeneralPurpose/RichTextEditor/RichTextEditor.jsx
+++ b/love/src/components/GeneralPurpose/RichTextEditor/RichTextEditor.jsx
@@ -95,7 +95,7 @@ const RichTextEditor = forwardRef(
     }, []);
 
     return (
-      <div className={[className ?? '', styles.container].join(' ')}>
+      <div onDrop={(e) => e.preventDefault()} className={[className ?? '', styles.container].join(' ')}>
         <ReactQuill
           ref={reactQuillRef}
           modules={modules}


### PR DESCRIPTION
This PR removes the ability to drag and drop HTML elements to the `RichTextEditor` component. This is being done as this use case has not yet been defined and it's existence was leading to potential XSS vulnerabilities.
A dependabot alert was generated https://github.com/lsst-ts/LOVE-frontend/security/dependabot/86, although I missed to identify the drag and drop case.
In case of wanting to add the feature, special handlers will be needed to sanitize the value that comes from the `onDrag` event.
