### PR TITLE
Extend logs edition feature to allow JIRA tickets attachment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.28.1
+-------
+
+* Extend logs edition feature to allow JIRA tickets attachment `<https://github.com/lsst-ts/LOVE-frontend/pull/604>`_
+
 v5.28.0
 -------
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -38,6 +38,9 @@ export const WEBSOCKET_SIMULATION = false;
 // set of websocket messages
 export const WEBSOCKET_SIMULATION_FILE = 'test.json';
 
+// Base URL prefix for LSST JIRA tickets
+export const JIRA_TICKETS_BASE_URL = 'https://jira.lsstcorp.org/browse';
+
 // Base URL for ScriptQueue scripts' documentation
 export const SCRIPT_DOCUMENTATION_BASE_URL = 'https://ts-standardscripts.lsst.io/py-api';
 

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -21,7 +21,13 @@ import html2canvas from 'html2canvas';
 import { DateTime } from 'luxon';
 import { toast } from 'react-toastify';
 import Moment from 'moment';
-import { WEBSOCKET_SIMULATION, SUBPATH, ISO_INTEGER_DATE_FORMAT, AUTO_HYPERLINK_JIRA_PROJECTS } from 'Config.js';
+import {
+  WEBSOCKET_SIMULATION,
+  SUBPATH,
+  ISO_INTEGER_DATE_FORMAT,
+  AUTO_HYPERLINK_JIRA_PROJECTS,
+  JIRA_TICKETS_BASE_URL,
+} from 'Config.js';
 
 /* Backwards compatibility of Array.flat */
 if (Array.prototype.flat === undefined) {
@@ -1566,12 +1572,12 @@ export function openInNewTab(url) {
 
 /**
  * Function to get OLE Narrative and Exposure logs parameters from urls field.
- * @param {string} urls array of urls that comes from OLE message
+ * @param {string[]} urls array of urls that comes from OLE message
  * @returns {string} string with first url with the condition if jira link
  */
 export function getLinkJira(urls) {
   if (!urls) return '';
-  const filtered = urls.filter((url) => url.includes('jira'));
+  const filtered = urls.filter((url) => url.includes(JIRA_TICKETS_BASE_URL));
   if (filtered.length > 0) {
     return filtered[0];
   }
@@ -1580,12 +1586,12 @@ export function getLinkJira(urls) {
 
 /**
  * Function to get OLE Narrative and Exposure logs parameters from urls field.
- * @param {string} urls array of urls that comes from OLE message
+ * @param {string[]} urls array of urls that comes from OLE message
  * @returns {string} string with first url that is not a jira link
  */
 export function getFileURL(urls) {
   if (!urls) return '';
-  const filtered = urls.filter((url) => !url.includes('jira'));
+  const filtered = urls.filter((url) => !url.includes(JIRA_TICKETS_BASE_URL));
   if (filtered.length > 0) {
     return filtered[0];
   }

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -927,9 +927,9 @@ export default class ManagerInterface {
     if (token === null) {
       return new Promise((resolve) => resolve(false));
     }
-    const url = `${this.getApiBaseUrl()}ole/narrativelog/messages/?order_by=-date_added&limit=1000${
-      from ? `&min_date_added=${from}` : ''
-    }${to ? `&max_date_added=${to}` : ''}`;
+    const url = `${this.getApiBaseUrl()}ole/narrativelog/messages/?order_by=-date_begin&limit=1000${
+      from ? `&min_date_begin=${from}` : ''
+    }${to ? `&max_date_begin=${to}` : ''}`;
     return fetch(url, {
       method: 'GET',
       headers: ManagerInterface.getHeaders(),

--- a/love/src/components/OLE/Exposure/Exposure.module.css
+++ b/love/src/components/OLE/Exposure/Exposure.module.css
@@ -323,21 +323,22 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .checkboxText {
   display: flex;
-  margin-right: 5px;
   align-items: center;
-  flex-wrap: wrap;
+  margin-bottom: var(--small-padding);
 }
 
-.checkboxText > * {
+.checkboxText > *:not(:last-child) {
   margin-right: 0.5em;
-}
-
-.checkboxText > input:first-of-type {
-  width: auto;
 }
 
 .checkboxText > button {
   text-align: right;
+}
+
+.radioText {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--small-padding);
 }
 
 .paddingTop {
@@ -504,17 +505,11 @@ th.tableHead {
 }
 
 .footer .flag,
-.footerMenu .flag,
-.footer .jira,
-.footerMenu .jira {
+.footerMenu .flag {
   display: flex;
   align-items: center;
   gap: var(--small-padding);
   white-space: nowrap;
-}
-
-.footerMenu .jira {
-  flex-wrap: wrap;
 }
 
 .footer .flag .label,
@@ -532,8 +527,7 @@ th.tableHead {
 }
 
 .inputError {
-  margin-top: var(--small-padding);
-  color: var(--status-alert-color);
+  border-color: var(--status-alert-color);
 }
 
 .obsIdSelector {

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -36,7 +36,7 @@ import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange
 import Modal from 'components/GeneralPurpose/Modal/Modal';
 import FlagIcon from 'components/icons/FlagIcon/FlagIcon';
 import { EXPOSURE_FLAG_OPTIONS, exposureFlagStateToStyle, ISO_INTEGER_DATE_FORMAT } from 'Config';
-import ManagerInterface, { getFilesURLs, htmlToJiraMarkdown, jiraMarkdownToHtml } from 'Utils';
+import ManagerInterface, { getFilesURLs, getLinkJira, htmlToJiraMarkdown, jiraMarkdownToHtml } from 'Utils';
 import styles from './Exposure.module.css';
 
 class ExposureAdd extends Component {
@@ -323,6 +323,92 @@ class ExposureAdd extends Component {
         placeholder="Select one or several observations"
         selectedValueDecorator={(v) => (v.length > 10 ? `...${v.slice(-10)}` : v)}
       />
+    );
+  }
+
+  renderJiraFields() {
+    const { newMessage, jiraIssueError } = this.state;
+    const logHasJira = getLinkJira(newMessage.urls) !== '';
+    return (
+      <>
+        <div className={styles.jira}>
+          {!logHasJira && (
+            <>
+              <div className={styles.checkboxText}>
+                <Input
+                  type="checkbox"
+                  checked={newMessage?.jira}
+                  onChange={(event) => {
+                    this.setState((prevState) => ({
+                      newMessage: { ...prevState.newMessage, jira: event.target.checked },
+                    }));
+                  }}
+                />
+                <span>link Jira ticket</span>
+              </div>
+              {newMessage?.jira && (
+                <div className={styles.radioText}>
+                  <div>
+                    <input
+                      type="radio"
+                      name="jira"
+                      value="new"
+                      checked={newMessage?.jira_new}
+                      onChange={() => {
+                        this.setState((prevState) => ({
+                          newMessage: { ...prevState.newMessage, jira_new: true },
+                        }));
+                      }}
+                    />
+                    <span>New</span>
+                  </div>
+                  <div>
+                    <input
+                      type="radio"
+                      name="jira"
+                      value="existent"
+                      checked={!newMessage?.jira_new}
+                      onChange={() => {
+                        this.setState((prevState) => ({
+                          newMessage: { ...prevState.newMessage, jira_new: false },
+                        }));
+                      }}
+                    />
+                    <span>Existent</span>
+                  </div>
+                </div>
+              )}
+              {newMessage?.jira && (
+                <div className={styles.textInput}>
+                  {newMessage?.jira_new ? (
+                    <Input
+                      value={newMessage?.jira_issue_title}
+                      className={jiraIssueError ? styles.inputError : ''}
+                      placeholder="Jira ticket title"
+                      onChange={(event) =>
+                        this.setState((prevState) => ({
+                          newMessage: { ...prevState.newMessage, jira_issue_title: event.target.value },
+                        }))
+                      }
+                    />
+                  ) : (
+                    <Input
+                      value={newMessage?.jira_issue_id}
+                      className={jiraIssueError ? styles.inputError : ''}
+                      placeholder="Jira ticket id"
+                      onChange={(event) =>
+                        this.setState((prevState) => ({
+                          newMessage: { ...prevState.newMessage, jira_issue_id: event.target.value },
+                        }))
+                      }
+                    />
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </>
     );
   }
 
@@ -634,60 +720,7 @@ class ExposureAdd extends Component {
                   />
                 </div>
 
-                <div className={styles.jira}>
-                  <span className={styles.label}>Jira ticket</span>
-                  <span>
-                    <Input
-                      type="checkbox"
-                      checked={newMessage?.jira}
-                      onChange={(event) => {
-                        this.setState((prevState) => ({
-                          newMessage: { ...prevState.newMessage, jira: event.target.checked },
-                        }));
-                      }}
-                    />
-                  </span>
-
-                  {newMessage?.jira && (
-                    <>
-                      <span>
-                        <Toggle
-                          labels={['New', 'Existent']}
-                          toggled={!newMessage?.jira_new}
-                          onToggle={(event) => {
-                            this.setState((prevState) => ({
-                              newMessage: { ...prevState.newMessage, jira_new: !event },
-                            }));
-                          }}
-                        />
-                      </span>
-
-                      {newMessage?.jira_new ? (
-                        <Input
-                          value={newMessage?.jira_issue_title}
-                          placeholder="Jira ticket title"
-                          onChange={(event) =>
-                            this.setState((prevState) => ({
-                              newMessage: { ...prevState.newMessage, jira_issue_title: event.target.value },
-                            }))
-                          }
-                        />
-                      ) : (
-                        <Input
-                          value={newMessage?.jira_issue_id}
-                          placeholder="Jira ticket id"
-                          onChange={(event) =>
-                            this.setState((prevState) => ({
-                              newMessage: { ...prevState.newMessage, jira_issue_id: event.target.value },
-                            }))
-                          }
-                        />
-                      )}
-
-                      {jiraIssueError && <div className={styles.inputError}>This field cannot be empty.</div>}
-                    </>
-                  )}
-                </div>
+                {this.renderJiraFields()}
               </div>
 
               <div className={isMenu ? styles.footerRightMenu : styles.footerRight}>

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -341,11 +341,6 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   border: 1px solid var(--secondary-font-color);
 }
 
-.footerLeft {
-  display: flex;
-  align-items: center;
-}
-
 .footerRight {
   margin-left: auto;
 }
@@ -357,15 +352,14 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   align-items: end;
 }
 
-.checkboxText {
-  display: flex;
-  margin-right: 5px;
-  align-items: center;
-  text-align: left;
-}
-
 .footerMenu .checkboxText {
   flex-wrap: wrap;
+}
+
+.checkboxText {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--small-padding);
 }
 
 .checkboxText > *:not(:last-child) {
@@ -374,6 +368,16 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .checkboxText > button {
   text-align: right;
+}
+
+.radioText {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--small-padding);
+}
+
+.textInput {
+  margin-bottom: var(--small-padding);
 }
 
 .issueIdInput {
@@ -482,11 +486,8 @@ th.tableHead {
 
 .footer .jira,
 .footerMenu .jira {
+  text-align: left;
   white-space: nowrap;
-}
-
-.footer .jira {
-  margin-right: var(--small-padding);
 }
 
 .footerMenu .jira {

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -108,7 +108,7 @@ class NonExposureEdit extends Component {
     logEdit['date_end'] = logEdit['date_end'] ? Moment(logEdit['date_end'] + 'Z') : '';
 
     this.state = {
-      logEdit,
+      logEdit: { ...NonExposureEdit.defaultProps.logEdit, ...logEdit },
       savingLog: false,
       datesAreValid: true,
       jiraIssueError: false,
@@ -623,60 +623,84 @@ class NonExposureEdit extends Component {
 
   renderJiraFields() {
     const { logEdit, jiraIssueError } = this.state;
+    const logHasJira = getLinkJira(logEdit.urls) !== '';
     return (
       <>
         <div className={styles.jira}>
-          {!logEdit?.id && (
-            <span className={styles.checkboxText}>
-              <Input
-                type="checkbox"
-                checked={logEdit?.jira}
-                onChange={(event) => {
-                  this.setState((prevState) => ({
-                    logEdit: { ...prevState.logEdit, jira: event.target.checked },
-                  }));
-                }}
-              />
-              <span>link Jira ticket</span>
+          {!logHasJira && (
+            <>
+              <div className={styles.checkboxText}>
+                <Input
+                  type="checkbox"
+                  checked={logEdit?.jira}
+                  onChange={(event) => {
+                    this.setState((prevState) => ({
+                      logEdit: { ...prevState.logEdit, jira: event.target.checked },
+                    }));
+                  }}
+                />
+                <span>link Jira ticket</span>
+              </div>
               {logEdit?.jira && (
-                <>
-                  <Toggle
-                    labels={['New', 'Existent']}
-                    toggled={!logEdit?.jira_new}
-                    onToggle={(event) =>
-                      this.setState((prevState) => ({
-                        logEdit: { ...prevState.logEdit, jira_new: !event },
-                      }))
-                    }
-                  />
+                <div className={styles.radioText}>
                   <div>
-                    {logEdit?.jira_new ? (
-                      <Input
-                        value={logEdit?.jira_issue_title}
-                        className={jiraIssueError ? styles.inputError : ''}
-                        placeholder="Jira ticket title"
-                        onChange={(event) =>
-                          this.setState((prevState) => ({
-                            logEdit: { ...prevState.logEdit, jira_issue_title: event.target.value },
-                          }))
-                        }
-                      />
-                    ) : (
-                      <Input
-                        value={logEdit?.jira_issue_id}
-                        className={jiraIssueError ? styles.inputError : ''}
-                        placeholder="Jira ticket id"
-                        onChange={(event) =>
-                          this.setState((prevState) => ({
-                            logEdit: { ...prevState.logEdit, jira_issue_id: event.target.value },
-                          }))
-                        }
-                      />
-                    )}
+                    <input
+                      type="radio"
+                      name="jira"
+                      value="new"
+                      checked={logEdit?.jira_new}
+                      onChange={() => {
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_new: true },
+                        }));
+                      }}
+                    />
+                    <span>New</span>
                   </div>
-                </>
+                  <div>
+                    <input
+                      type="radio"
+                      name="jira"
+                      value="existent"
+                      checked={!logEdit?.jira_new}
+                      onChange={() => {
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_new: false },
+                        }));
+                      }}
+                    />
+                    <span>Existent</span>
+                  </div>
+                </div>
               )}
-            </span>
+              {logEdit?.jira && (
+                <div className={styles.textInput}>
+                  {logEdit?.jira_new ? (
+                    <Input
+                      value={logEdit?.jira_issue_title}
+                      className={jiraIssueError ? styles.inputError : ''}
+                      placeholder="Jira ticket title"
+                      onChange={(event) =>
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_issue_title: event.target.value },
+                        }))
+                      }
+                    />
+                  ) : (
+                    <Input
+                      value={logEdit?.jira_issue_id}
+                      className={jiraIssueError ? styles.inputError : ''}
+                      placeholder="Jira ticket id"
+                      onChange={(event) =>
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_issue_id: event.target.value },
+                        }))
+                      }
+                    />
+                  )}
+                </div>
+              )}
+            </>
           )}
         </div>
       </>
@@ -776,11 +800,7 @@ class NonExposureEdit extends Component {
               {this.state.logEdit.id && <span className={styles.bold}>#{this.state.logEdit.id}</span>}
               {jiraUrl && (
                 <span>
-                  <Button
-                    status="link"
-                    title={this.state.logEdit.jiraurl}
-                    onClick={() => openInNewTab(this.state.logEdit.jiraurl)}
-                  >
+                  <Button status="link" title={jiraUrl} onClick={() => openInNewTab(jiraUrl)}>
                     view Jira ticket
                   </Button>
                 </span>
@@ -813,8 +833,8 @@ class NonExposureEdit extends Component {
 
             <div className={styles.footer}>
               <div className={styles.footerLeft}>
-                {!isLogCreate && this.renderAttachedFiles()}
                 {this.renderJiraFields()}
+                {!isLogCreate && this.renderAttachedFiles()}
                 {this.renderFilesField()}
               </div>
               <span className={styles.footerRight}>{this.renderSubmitButton()}</span>

--- a/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
+++ b/love/src/components/OLE/Tekniker/TeknikerAdd.jsx
@@ -645,60 +645,84 @@ class TeknikerAdd extends Component {
 
   renderJiraFields() {
     const { logEdit, jiraIssueError } = this.state;
+    const logHasJira = getLinkJira(logEdit.urls) !== '';
     return (
       <>
         <div className={styles.jira}>
-          {!logEdit?.id && (
-            <span className={styles.checkboxText}>
-              <Input
-                type="checkbox"
-                checked={logEdit?.jira}
-                onChange={(event) => {
-                  this.setState((prevState) => ({
-                    logEdit: { ...prevState.logEdit, jira: event.target.checked },
-                  }));
-                }}
-              />
-              <span>link Jira ticket</span>
+          {!logHasJira && (
+            <>
+              <div className={styles.checkboxText}>
+                <Input
+                  type="checkbox"
+                  checked={logEdit?.jira}
+                  onChange={(event) => {
+                    this.setState((prevState) => ({
+                      logEdit: { ...prevState.logEdit, jira: event.target.checked },
+                    }));
+                  }}
+                />
+                <span>link Jira ticket</span>
+              </div>
               {logEdit?.jira && (
-                <>
-                  <Toggle
-                    labels={['New', 'Existent']}
-                    toggled={!logEdit?.jira_new}
-                    onToggle={(event) =>
-                      this.setState((prevState) => ({
-                        logEdit: { ...prevState.logEdit, jira_new: !event },
-                      }))
-                    }
-                  />
+                <div className={styles.radioText}>
                   <div>
-                    {logEdit?.jira_new ? (
-                      <Input
-                        value={logEdit?.jira_issue_title}
-                        className={jiraIssueError ? styles.inputError : ''}
-                        placeholder="Jira ticket title"
-                        onChange={(event) =>
-                          this.setState((prevState) => ({
-                            logEdit: { ...prevState.logEdit, jira_issue_title: event.target.value },
-                          }))
-                        }
-                      />
-                    ) : (
-                      <Input
-                        value={logEdit?.jira_issue_id}
-                        className={jiraIssueError ? styles.inputError : ''}
-                        placeholder="Jira ticket id"
-                        onChange={(event) =>
-                          this.setState((prevState) => ({
-                            logEdit: { ...prevState.logEdit, jira_issue_id: event.target.value },
-                          }))
-                        }
-                      />
-                    )}
+                    <input
+                      type="radio"
+                      name="jira"
+                      value="new"
+                      checked={logEdit?.jira_new}
+                      onChange={() => {
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_new: true },
+                        }));
+                      }}
+                    />
+                    <span>New</span>
                   </div>
-                </>
+                  <div>
+                    <input
+                      type="radio"
+                      name="jira"
+                      value="existent"
+                      checked={!logEdit?.jira_new}
+                      onChange={() => {
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_new: false },
+                        }));
+                      }}
+                    />
+                    <span>Existent</span>
+                  </div>
+                </div>
               )}
-            </span>
+              {logEdit?.jira && (
+                <div className={styles.textInput}>
+                  {logEdit?.jira_new ? (
+                    <Input
+                      value={logEdit?.jira_issue_title}
+                      className={jiraIssueError ? styles.inputError : ''}
+                      placeholder="Jira ticket title"
+                      onChange={(event) =>
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_issue_title: event.target.value },
+                        }))
+                      }
+                    />
+                  ) : (
+                    <Input
+                      value={logEdit?.jira_issue_id}
+                      className={jiraIssueError ? styles.inputError : ''}
+                      placeholder="Jira ticket id"
+                      onChange={(event) =>
+                        this.setState((prevState) => ({
+                          logEdit: { ...prevState.logEdit, jira_issue_id: event.target.value },
+                        }))
+                      }
+                    />
+                  )}
+                </div>
+              )}
+            </>
           )}
         </div>
       </>


### PR DESCRIPTION
This PR extends the `NonExposureEdit`, `ExposureAdd` and `TeknikerAdd` components to allow JIRA tickets attachment when editing logs.
Also the narrative logs query to retrieve the list of messages was adjusted to use `date_begin` param (from time of incident field) instead of `date_added`, this is related with some changes on #600.
Furthermore this relates with https://github.com/lsst-ts/LOVE-manager/pull/235 too. 