### PR TITLE
Create OrderableTable to extend SimpleTable to allow rows sorting by column

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.28.1
 -------
 
+* Create OrderableTable to extend SimpleTable to allow rows sorting by column `<https://github.com/lsst-ts/LOVE-frontend/pull/605>`_
 * Extend logs edition feature to allow JIRA tickets attachment `<https://github.com/lsst-ts/LOVE-frontend/pull/604>`_
 
 v5.28.0

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -61,6 +61,11 @@ export const EUIs = {
   ATDOME: 'https://atmcs-dev.cp.lsst.org',
 };
 
+// Types of sorting
+export const SORT_ASCENDING = 'ascending';
+export const SORT_DESCENDING = 'descending';
+export const SORT_UNSORTED = 'unsorted';
+
 // Moment formats
 export const ISO_STRING_DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 export const ISO_STRING_DATE_FORMAT = 'YYYY-MM-DD';

--- a/love/src/components/GeneralPurpose/OrderableTable/OrderableTable.jsx
+++ b/love/src/components/GeneralPurpose/OrderableTable/OrderableTable.jsx
@@ -1,0 +1,142 @@
+/** 
+This file is part of LOVE-frontend.
+
+Copyright (c) 2023 Inria Chile.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import SimpleTable from '../SimpleTable/SimpleTable';
+import { SORT_ASCENDING, SORT_DESCENDING, SORT_UNSORTED } from 'Config';
+import styles from './OrderableTable.module.css';
+
+const defaultSort = (row1, row2, sortingColumn, sortDirection) => {
+  const value1 = row1?.[sortingColumn];
+  const value2 = row2?.[sortingColumn];
+
+  if (value1 === undefined || value1 === null) return 0;
+  if (value2 === undefined || value2 === null) return 0;
+
+  const sortFactor = sortDirection === SORT_ASCENDING ? 1 : -1;
+  if (value1 < value2) return -1 * sortFactor;
+  if (value1 > value2) return 1 * sortFactor;
+  return 0;
+};
+
+/**
+ * A table that can sorted by specific columns.
+ * Default sorting can be overwritten for each column.
+ */
+const OrderableTable = function ({ data, headers, ...otherProps }) {
+  const [sortDirections, setSortDirections] = React.useState({});
+  const [sortingColumn, setSortingColumn] = React.useState(null);
+
+  const initialSortDirections = headers.reduce((prevDict, header) => {
+    prevDict[header.field] = SORT_UNSORTED;
+    return prevDict;
+  }, {});
+
+  React.useEffect(() => {
+    setSortDirections(initialSortDirections);
+  }, []);
+
+  const changeSortDirection = (column) => {
+    let newDirection = SORT_UNSORTED;
+    if (sortDirections[column] === SORT_UNSORTED) {
+      newDirection = SORT_ASCENDING;
+    } else if (sortDirections[column] === SORT_ASCENDING) {
+      newDirection = SORT_DESCENDING;
+    }
+    setSortDirections((sortDirections) => ({
+      ...initialSortDirections,
+      [column]: newDirection,
+    }));
+    setSortingColumn(column);
+  };
+
+  const newHeaders = headers.map((header, index) => {
+    const sortDirection = sortDirections[header.field];
+    return {
+      ...header,
+      title: (
+        <div className={styles.columnHeader}>
+          <span className={styles.primaryText}>{header.title}</span>
+          <span className={styles.secondaryText}>{header.subtitle}</span>
+          <div className={styles.orderSymbol} onClick={() => changeSortDirection(header.field)}>
+            <span title="Ascending order" className={sortDirection === SORT_ASCENDING ? styles.selected : ''}>
+              ▲
+            </span>
+            <span title="Descending order" className={sortDirection === SORT_DESCENDING ? styles.selected : ''}>
+              ▼
+            </span>
+          </div>
+        </div>
+      ),
+    };
+  });
+
+  // only recalculate when necessary.
+  const transformedData = React.useMemo(() => {
+    const newData = data.toSorted((row1, row2) => {
+      /** No sorting column */
+      if (!sortingColumn) return 0;
+
+      /** No sorting applied */
+      const sortDirection = sortDirections[sortingColumn];
+      if (sortDirection === SORT_UNSORTED) return 0;
+
+      const header = headers.find((header) => header.field === sortingColumn);
+      const sort = header?.sort ?? defaultSort;
+      return sort(row1, row2, sortingColumn, sortDirection);
+    });
+    return newData;
+  }, [data, sortingColumn, sortDirections, headers]);
+
+  return <SimpleTable data={transformedData} headers={newHeaders} {...otherProps} />;
+};
+
+OrderableTable.propTypes = {
+  /** Array with properties of table columns and its headers.*/
+  headers: PropTypes.arrayOf(
+    PropTypes.shape({
+      /** (Inherited from SimpleTable) Property accessor of this column's value on each data row */
+      field: PropTypes.string,
+      /** (Inherited from SimpleTable)  Node to be rendered as header label */
+      title: PropTypes.node,
+      /** Text/node shown below the header title */
+      subtitle: PropTypes.node,
+      /** (Inherited from SimpleTable) Data type of this column: number, string, ... */
+      type: PropTypes.string,
+      /** (Inherited from SimpleTable) Callback that receives this column's value and should return a `node`.
+       * Use it customize how the cell's value is   */
+      render: PropTypes.func,
+      /** (Inherited from SimpleTable) className to be applied to the whole column */
+      className: PropTypes.string,
+      /** Function to sort table rows. Defaults to regular (>, <, ===) comparison.
+       * Its signature is `(row1, row2, sortingColumn, sortingDirection) => value` where:
+       * (row1, row2)  are two rows of the `data` array to compare;
+       * (sortingColumn) is the currently selected column that runs the sorting. Only one column at a time;
+       * (sortingDirection): indicates the user-selected sorting direction, can be 'ascending' or something else for descending
+       * (value) is 1, 0 or -1, and passed to Array.Prototype.sort
+       * */
+      sort: PropTypes.func,
+    }),
+  ),
+  /** Rows to be rendered in the table */
+  data: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default OrderableTable;

--- a/love/src/components/GeneralPurpose/OrderableTable/OrderableTable.module.css
+++ b/love/src/components/GeneralPurpose/OrderableTable/OrderableTable.module.css
@@ -1,0 +1,18 @@
+.columnHeader {
+  display: flex;
+  align-items: center;
+}
+
+.orderSymbol {
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1em;
+  margin-left: var(--small-padding);
+  color: var(--secondary-font-dimmed-color);
+  user-select: none;
+}
+
+.orderSymbol > .selected {
+  color: var(--highlighted-font-color);
+}

--- a/love/src/components/OLE/Exposure/Exposure.jsx
+++ b/love/src/components/OLE/Exposure/Exposure.jsx
@@ -27,12 +27,18 @@ import FlagIcon from 'components/icons/FlagIcon/FlagIcon';
 import AcknowledgeIcon from 'components/icons/Watcher/AcknowledgeIcon/AcknowledgeIcon';
 import DownloadIcon from 'components/icons/DownloadIcon/DownloadIcon';
 import SpinnerIcon from 'components/icons/SpinnerIcon/SpinnerIcon';
-import SimpleTable from 'components/GeneralPurpose/SimpleTable/SimpleTable';
+import OrderableTable from 'components/GeneralPurpose/OrderableTable/OrderableTable';
 import Button from 'components/GeneralPurpose/Button/Button';
 import Select from 'components/GeneralPurpose/Select/Select';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
 import Hoverable from 'components/GeneralPurpose/Hoverable/Hoverable';
-import { exposureFlagStateToStyle, TIME_FORMAT, ISO_INTEGER_DATE_FORMAT, LOG_REFRESH_INTERVAL_MS } from 'Config';
+import {
+  exposureFlagStateToStyle,
+  TIME_FORMAT,
+  ISO_INTEGER_DATE_FORMAT,
+  LOG_REFRESH_INTERVAL_MS,
+  SORT_ASCENDING,
+} from 'Config';
 import ManagerInterface, { getFilesURLs, jiraMarkdownToHtml } from 'Utils';
 import ExposureAdd from './ExposureAdd';
 import ExposureDetail from './ExposureDetail';
@@ -188,6 +194,15 @@ export default class Exposure extends Component {
           const end = Moment(row['timespan_end']);
           const duration_s = end.diff(start, 'seconds', true);
           return duration_s.toFixed(2);
+        },
+        sort: (row1, row2, sortingColumn, sortingDirection) => {
+          const start1 = Moment(row1['timespan_begin']);
+          const start2 = Moment(row2['timespan_begin']);
+          const end1 = Moment(row1['timespan_end']);
+          const end2 = Moment(row2['timespan_end']);
+          const duration1 = end1.diff(start1, 'seconds', true);
+          const duration2 = end2.diff(start2, 'seconds', true);
+          return sortingDirection === SORT_ASCENDING ? duration1 - duration2 : duration2 - duration1;
         },
       },
       {
@@ -539,7 +554,7 @@ export default class Exposure extends Component {
           Last updated: {this.state.lastUpdated ? this.state.lastUpdated.format(TIME_FORMAT) : ''}
           {updatingExposures && <SpinnerIcon className={styles.spinnerIcon} />}
         </div>
-        <SimpleTable className={styles.table} headers={headers} data={filteredData} />
+        <OrderableTable className={styles.table} headers={headers} data={filteredData} />
       </div>
     );
   }

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -40,7 +40,7 @@ import ManagerInterface, {
   formatOLETimeOfIncident,
 } from 'Utils';
 
-import SimpleTable from 'components/GeneralPurpose/SimpleTable/SimpleTable';
+import OrderableTable from 'components/GeneralPurpose/OrderableTable/OrderableTable';
 import Button from 'components/GeneralPurpose/Button/Button';
 import Input from 'components/GeneralPurpose/Input/Input';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
@@ -362,7 +362,7 @@ export default class NonExposure extends Component {
     } = this.props;
     const { logs: tableData, modeView, modeEdit } = this.state;
 
-    const headers = Object.values(this.getHeaders());
+    const headers = this.getHeaders();
     let filteredData = [...(tableData ?? [])];
 
     // Filter by type
@@ -508,7 +508,7 @@ export default class NonExposure extends Component {
           Last updated: {this.state.lastUpdated ? this.state.lastUpdated.format(TIME_FORMAT) : ''}
           {this.state.updatingLogs && <SpinnerIcon className={styles.spinnerIcon} />}
         </div>
-        <SimpleTable className={styles.table} headers={headers} data={filteredData} />
+        <OrderableTable className={styles.table} headers={headers} data={filteredData} />
       </div>
     );
   }


### PR DESCRIPTION
This PR creates a new component: `OrderableTable` which extends `SimpleTable` functionalities to allow rows sorting by certain column. Implemented on `NonExposure` and `Exposure` components.