### PR TITLE
Fix day obs calculation on NonExposure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.29.3
+-------
+
+* Fix day obs calculation on NonExposure `<https://github.com/lsst-ts/LOVE-frontend/pull/616>`_
+
 v5.29.2
 -------
 

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -192,7 +192,7 @@ export default class NonExposure extends Component {
         ),
         type: 'string',
         className: styles.tableHead,
-        render: (value) => getObsDayFromDate(moment(value)),
+        render: (value) => getObsDayFromDate(moment(value + 'Z')),
       },
       {
         field: 'level',


### PR DESCRIPTION
This PR fix the way day obs was being calculated from the `date_begin` field from narrative logs. Time was being considered as non UTC so this was generating inconsistencies.