### PR TITLE
Add Night Report implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.30.0
+-------
+
+* Add Night Report implementation `<https://github.com/lsst-ts/LOVE-frontend/pull/619>`_
+
 v5.29.3
 -------
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -61,6 +61,12 @@ export const EUIs = {
   ATDOME: 'https://atmcs-dev.cp.lsst.org',
 };
 
+// URL for TimesSquare Night Report > Obs tickets report
+// ready to be used by replacing the {DAY} with the desired date in 'YYYY-MM-DD' format
+export const TIMES_SQUARE_OBS_TICKETS_REPORT_URL =
+  'https://usdf-rsp-dev.slac.stanford.edu/times-square/github/lsst-sqre/times-square-usdf/\
+night-reports/obs-tickets?start={DAY}&duration=1&ts_hide_code=1';
+
 // Types of sorting
 export const SORT_ASCENDING = 'ascending';
 export const SORT_DESCENDING = 'descending';

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1132,6 +1132,21 @@ export default class ManagerInterface {
     });
   }
 
+  static getHistoricNightReports(day_obs_start, day_obs_end, telescope) {
+    const token = ManagerInterface.getToken();
+    if (token === null) {
+      return new Promise((resolve) => resolve(false));
+    }
+
+    const url = `${this.getApiBaseUrl()}ole/nightreport/reports/?telescopes=${telescope}&min_day_obs=${day_obs_start}&max_day_obs=${day_obs_end}`;
+    return fetch(url, {
+      method: 'GET',
+      headers: ManagerInterface.getHeaders(),
+    }).then((response) => {
+      return checkJSONResponse(response);
+    });
+  }
+
   /**************************************************/
 
   static getListImageTags() {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1061,6 +1061,39 @@ export default class ManagerInterface {
     });
   }
 
+  static saveCurrentNightReport(telescope, summary, telescope_status, confluence_url, observers_crew) {
+    const token = ManagerInterface.getToken();
+    if (token === null) {
+      return new Promise((resolve) => resolve(false));
+    }
+
+    const url = `${this.getApiBaseUrl()}ole/nightreport/reports/`;
+    return fetch(url, {
+      method: 'POST',
+      headers: ManagerInterface.getHeaders(),
+      body: JSON.stringify({
+        telescope,
+        summary,
+        telescope_status,
+        confluence_url,
+        observers_crew,
+      }),
+    }).then((response) => {
+      if (response.status === 422) {
+        return response.json().then((resp) => {
+          toast.error(resp.detail);
+          return false;
+        });
+      }
+
+      return checkJSONResponse(response, () => {
+        toast.success('Report saved succesfully.');
+      });
+    });
+  }
+
+  /**************************************************/
+
   static getListImageTags() {
     const token = ManagerInterface.getToken();
     if (token === null) {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1092,6 +1092,46 @@ export default class ManagerInterface {
     });
   }
 
+  static updateCurrentNightReport(nightreport_id, summary, telescope_status, confluence_url, observers_crew) {
+    const token = ManagerInterface.getToken();
+    if (token === null) {
+      return new Promise((resolve) => resolve(false));
+    }
+
+    const url = `${this.getApiBaseUrl()}ole/nightreport/reports/${nightreport_id}/`;
+    return fetch(url, {
+      method: 'PUT',
+      headers: ManagerInterface.getHeaders(),
+      body: JSON.stringify({
+        summary,
+        telescope_status,
+        confluence_url,
+        observers_crew,
+      }),
+    }).then((response) => {
+      return checkJSONResponse(response, () => {
+        toast.success('Report updated succesfully.');
+      });
+    });
+  }
+
+  static sendCurrentNightReport(report_id) {
+    const token = ManagerInterface.getToken();
+    if (token === null) {
+      return new Promise((resolve) => resolve(false));
+    }
+
+    const url = `${this.getApiBaseUrl()}ole/nightreport/send/${report_id}/`;
+    return fetch(url, {
+      method: 'POST',
+      headers: ManagerInterface.getHeaders(),
+    }).then((response) => {
+      return checkJSONResponse(response, () => {
+        toast.success('Report sent succesfully.');
+      });
+    });
+  }
+
   /**************************************************/
 
   static getListImageTags() {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -196,16 +196,10 @@ export default class ManagerInterface {
     if (token === null) {
       return new Promise((resolve) => resolve(false));
     }
-    const url = `${this.getApiBaseUrl()}users/`;
+    const url = `${this.getApiBaseUrl()}user/`;
     return fetch(url, {
-      method: 'POST',
+      method: 'GET',
       headers: ManagerInterface.getHeaders(),
-      body: JSON.stringify({
-        actuator_id,
-        start_date,
-        end_date,
-        efd_instance,
-      }),
     }).then((response) => {
       return checkJSONResponse(response);
     });

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1041,6 +1041,26 @@ export default class ManagerInterface {
     });
   }
 
+  static getCurrentNightReport() {
+    const token = ManagerInterface.getToken();
+    if (token === null) {
+      return new Promise((resolve) => resolve(false));
+    }
+
+    const currentDate = Moment().utc();
+    const currentObsDayInt = parseInt(getObsDayFromDate(currentDate), 10);
+
+    const url = `${this.getApiBaseUrl()}ole/nightreport/reports/?min_day_obs=${currentObsDayInt}&max_day_obs=${
+      currentObsDayInt + 1
+    }`;
+    return fetch(url, {
+      method: 'GET',
+      headers: ManagerInterface.getHeaders(),
+    }).then((response) => {
+      return checkJSONResponse(response);
+    });
+  }
+
   static getListImageTags() {
     const token = ManagerInterface.getToken();
     if (token === null) {
@@ -1959,7 +1979,9 @@ export function simpleHtmlTokenizer(html) {
  * Function to get the OBS day from a date
  * If the date is after 12:00 UTC, the day is the same day
  * If the date is before 12:00 UTC, the day is the previous day
- * @param {object} date date, as a Moment object, to be parsed
+ * @param {object} date UTC date, it can be:
+ * - string in ISO format with the Z suffix
+ * - moment date object in UTC
  * @returns {string} OBS day in format YYYYMMDD
  */
 export function getObsDayFromDate(date) {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1041,7 +1041,7 @@ export default class ManagerInterface {
     });
   }
 
-  static getCurrentNightReport() {
+  static getCurrentNightReport(telescope) {
     const token = ManagerInterface.getToken();
     if (token === null) {
       return new Promise((resolve) => resolve(false));
@@ -1050,7 +1050,7 @@ export default class ManagerInterface {
     const currentDate = Moment().utc();
     const currentObsDayInt = parseInt(getObsDayFromDate(currentDate), 10);
 
-    const url = `${this.getApiBaseUrl()}ole/nightreport/reports/?min_day_obs=${currentObsDayInt}&max_day_obs=${
+    const url = `${this.getApiBaseUrl()}ole/nightreport/reports/?telescopes=${telescope}&min_day_obs=${currentObsDayInt}&max_day_obs=${
       currentObsDayInt + 1
     }`;
     return fetch(url, {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -191,6 +191,26 @@ export default class ManagerInterface {
     });
   }
 
+  static getUsers() {
+    const token = ManagerInterface.getToken();
+    if (token === null) {
+      return new Promise((resolve) => resolve(false));
+    }
+    const url = `${this.getApiBaseUrl()}users/`;
+    return fetch(url, {
+      method: 'POST',
+      headers: ManagerInterface.getHeaders(),
+      body: JSON.stringify({
+        actuator_id,
+        start_date,
+        end_date,
+        efd_instance,
+      }),
+    }).then((response) => {
+      return checkJSONResponse(response);
+    });
+  }
+
   static getXMLMetadata() {
     const token = ManagerInterface.getToken();
     if (token === null) {

--- a/love/src/components/EnvironmentSummary/Cartoons/WindDirection.jsx
+++ b/love/src/components/EnvironmentSummary/Cartoons/WindDirection.jsx
@@ -25,7 +25,7 @@ export class WindDirection extends Component {
   render() {
     const { windSpeed, windDirection } = this.props;
     const minSpeed = 0;
-    const maxSpeed = 30;
+    const maxSpeed = 5;
     const currentSpeed = windSpeed;
     const maxArrowHeight = 680;
     const arrowHeight = (currentSpeed / maxSpeed) * maxArrowHeight;

--- a/love/src/components/NightReport/CreateNightReport.container.jsx
+++ b/love/src/components/NightReport/CreateNightReport.container.jsx
@@ -1,0 +1,65 @@
+/** 
+This file is part of LOVE-frontend.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React from 'react';
+import { connect } from 'react-redux';
+import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
+import { addGroup, removeGroup } from 'redux/actions/ws';
+import CreateNightReport from './CreateNightReport';
+
+export const schema = {
+  description: 'Night report writting service',
+  defaultSize: [77, 32],
+  props: {
+    title: {
+      type: 'string',
+      description: 'Name displayed in the title bar (if visible)',
+      isPrivate: false,
+      default: 'Log Service',
+    },
+    hasRawMode: {
+      type: 'boolean',
+      description: 'Whether the component has a raw mode version',
+      isPrivate: true,
+      default: false,
+    },
+  },
+};
+
+const CreateNightReportContainer = ({ subscribeToStreams, unsubscribeToStreams, ...props }) => {
+  if (props.isRaw) {
+    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
+  }
+  return (
+    <CreateNightReport subscribeToStreams={subscribeToStreams} unsubscribeToStreams={unsubscribeToStreams} {...props} />
+  );
+};
+
+const mapDispatchToProps = (dispatch) => {
+  const subscriptions = [];
+  return {
+    subscriptions,
+    subscribeToStreams: () => {
+      subscriptions.forEach((s) => dispatch(addGroup(s)));
+    },
+    unsubscribeToStreams: () => {
+      subscriptions.forEach((s) => dispatch(removeGroup(s)));
+    },
+  };
+};
+
+export default connect(null, mapDispatchToProps)(CreateNightReportContainer);

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -15,6 +15,92 @@ const STEPS = {
   SENT: 3,
 };
 
+const getCurrentStatusText = (currentStep) => {
+  if (currentStep === STEPS.NOTSAVED) {
+    return ['Not saved', 'Today report has not been drafted yet.'];
+  }
+  if (currentStep === STEPS.SAVED) {
+    return ['Saved', 'A report draft has been saved.'];
+  }
+  if (currentStep === STEPS.SENT) {
+    return ['Sent', 'The report was sent.'];
+  }
+};
+
+function ProgressBarSection({ currentStep, currentStatusText }) {
+  return (
+    <>
+      <div className={styles.progressBar}>
+        <div className={[styles.step, currentStep === 1 ? styles.selectedStep : ''].join(' ')}>
+          <span>1</span>
+        </div>
+        <div className={[styles.step, currentStep === 2 ? styles.selectedStep : ''].join(' ')}>
+          <span>2</span>
+        </div>
+        <div className={[styles.step, currentStep === 3 ? styles.selectedStep : ''].join(' ')}>
+          <span>3</span>
+        </div>
+      </div>
+      <div className={styles.currentStatusText}>
+        <div>{currentStatusText[0]}</div>
+        <div>{currentStatusText[1]}</div>
+      </div>
+    </>
+  );
+}
+
+function ObserversField({ isEditDisabled, observersFieldRef, userOptions, selectedUsers, setSelectedUsers }) {
+  return (
+    <>
+      <div>Observers</div>
+      <MultiSelect
+        disable={isEditDisabled}
+        innerRef={observersFieldRef}
+        options={userOptions}
+        selectedValues={selectedUsers}
+        onSelect={setSelectedUsers}
+        onRemove={setSelectedUsers}
+        placeholder="Select users that participated on the report."
+        selectedValueDecorator={(v) =>
+          v.length > MULTI_SELECT_OPTION_LENGHT ? `...${v.slice(-MULTI_SELECT_OPTION_LENGHT)}` : v
+        }
+      />
+    </>
+  );
+}
+
+function SummaryField({ isEditDisabled, summary, setSummary }) {
+  return (
+    <>
+      <div>Summary</div>
+      <TextArea readOnly={isEditDisabled} value={summary} callback={setSummary} className={styles.reportSummary} />
+    </>
+  );
+}
+
+function TelescopeStatusField({ isEditDisabled, telescopeStatus, setTelescopeStatus }) {
+  return (
+    <>
+      <div>Telescope Status</div>
+      <TextArea
+        readOnly={isEditDisabled}
+        value={telescopeStatus}
+        callback={setTelescopeStatus}
+        className={styles.reportTelescopeStatus}
+      />
+    </>
+  );
+}
+
+function ConfluenceURLField({ isEditDisabled, confluenceURL, setConfluenceURL }) {
+  return (
+    <div className={styles.inputField}>
+      <div>Confluence URL</div>
+      <Input disabled={isEditDisabled} value={confluenceURL} onChange={(e) => setConfluenceURL(e.target.value)} />
+    </div>
+  );
+}
+
 function AuxTelForm() {
   const observersFieldRef = useRef();
   const [currentStep, setCurrentStep] = useState(STEPS.NOTSAVED);
@@ -30,7 +116,7 @@ function AuxTelForm() {
       setUserOptions(users.map((u) => `${u.first_name} ${u.last_name}`));
     });
 
-    ManagerInterface.getCurrentNightReport().then((reports) => {
+    ManagerInterface.getCurrentNightReport('AuxTel').then((reports) => {
       if (reports.length > 0) {
         const report = reports[0];
         if (report.date_sent) {
@@ -74,19 +160,114 @@ function AuxTelForm() {
     }
   };
 
-  const getCurrentStatusText = () => {
-    if (currentStep === STEPS.NOTSAVED) {
-      return ['Not saved', 'Today report has not been drafted yet.'];
-    }
+  const isAbleToSave = () => {
+    return currentStep === STEPS.NOTSAVED || currentStep === STEPS.SAVED;
+  };
+
+  const isAbleToSend = () => {
+    return currentStep === STEPS.SAVED;
+  };
+
+  const isEditDisabled = () => {
+    return currentStep === STEPS.SENT;
+  };
+
+  return (
+    <form className={styles.form}>
+      <ProgressBarSection currentStep={currentStep} currentStatusText={getCurrentStatusText(currentStep)} />
+
+      <ObserversField
+        isEditDisabled={isEditDisabled()}
+        observersFieldRef={observersFieldRef}
+        userOptions={userOptions}
+        selectedUsers={selectedUsers}
+        setSelectedUsers={setSelectedUsers}
+      />
+
+      <SummaryField isEditDisabled={isEditDisabled()} summary={summary} setSummary={setSummary} />
+
+      <TelescopeStatusField
+        isEditDisabled={isEditDisabled()}
+        telescopeStatus={telescopeStatus}
+        setTelescopeStatus={setTelescopeStatus}
+      />
+
+      <ConfluenceURLField
+        isEditDisabled={isEditDisabled()}
+        confluenceURL={confluenceURL}
+        setConfluenceURL={setConfluenceURL}
+      />
+
+      <div className={styles.buttons}>
+        <Button onClick={handleSave} disabled={!isAbleToSave()}>
+          Save
+        </Button>
+        <Button onClick={handleSent} disabled={!isAbleToSend()}>
+          Send
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function SimonyiForm() {
+  const observersFieldRef = useRef();
+  const [currentStep, setCurrentStep] = useState(STEPS.NOTSAVED);
+  const [userOptions, setUserOptions] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [summary, setSummary] = useState('');
+  const [telescopeStatus, setTelescopeStatus] = useState('');
+  const [confluenceURL, setConfluenceURL] = useState('');
+  const [reportID, setReportID] = useState();
+
+  useEffect(() => {
+    ManagerInterface.getUsers().then((users) => {
+      setUserOptions(users.map((u) => `${u.first_name} ${u.last_name}`));
+    });
+
+    ManagerInterface.getCurrentNightReport('Simonyi').then((reports) => {
+      if (reports.length > 0) {
+        const report = reports[0];
+        if (report.date_sent) {
+          setCurrentStep(STEPS.SENT);
+        } else {
+          setCurrentStep(STEPS.SAVED);
+        }
+
+        setReportID(report.id);
+        setSelectedUsers(report.observers_crew);
+        setSummary(report.summary);
+        setTelescopeStatus(report.telescope_status);
+        setConfluenceURL(report.confluence_url);
+      }
+    });
+  }, []);
+
+  const handleSent = (event) => {
+    event.preventDefault();
     if (currentStep === STEPS.SAVED) {
-      return ['Saved', 'The report draft has been saved.'];
-    }
-    if (currentStep === STEPS.SENT) {
-      return ['Sent', 'The report has been sent.'];
+      ManagerInterface.sendCurrentNightReport(reportID).then((resp) => {
+        if (resp) {
+          setCurrentStep(STEPS.SENT);
+        }
+      });
     }
   };
 
-  const currentStatusText = getCurrentStatusText();
+  const handleSave = (event) => {
+    event.preventDefault();
+    if (currentStep === STEPS.NOTSAVED) {
+      ManagerInterface.saveCurrentNightReport('Simonyi', summary, telescopeStatus, confluenceURL, selectedUsers).then(
+        (resp) => {
+          if (resp) {
+            setCurrentStep(STEPS.SAVED);
+          }
+        },
+      );
+    } else {
+      ManagerInterface.updateCurrentNightReport(reportID, summary, telescopeStatus, confluenceURL, selectedUsers);
+    }
+  };
 
   const isAbleToSave = () => {
     return currentStep === STEPS.NOTSAVED || currentStep === STEPS.SAVED;
@@ -102,139 +283,30 @@ function AuxTelForm() {
 
   return (
     <form className={styles.form}>
-      <div className={styles.progressBar}>
-        <div className={[styles.step, currentStep === 1 ? styles.selectedStep : ''].join(' ')}>
-          <span>1</span>
-        </div>
-        <div className={[styles.step, currentStep === 2 ? styles.selectedStep : ''].join(' ')}>
-          <span>2</span>
-        </div>
-        <div className={[styles.step, currentStep === 3 ? styles.selectedStep : ''].join(' ')}>
-          <span>3</span>
-        </div>
-      </div>
-      <div className={styles.currentStatusText}>
-        <div>{currentStatusText[0]}</div>
-        <div>{currentStatusText[1]}</div>
-      </div>
-      <div>Observers</div>
-      <MultiSelect
-        disable={isEditDisabled()}
-        innerRef={observersFieldRef}
-        options={userOptions}
-        selectedValues={selectedUsers}
-        onSelect={setSelectedUsers}
-        onRemove={setSelectedUsers}
-        placeholder="Select users that participated on the report."
-        selectedValueDecorator={(v) =>
-          v.length > MULTI_SELECT_OPTION_LENGHT ? `...${v.slice(-MULTI_SELECT_OPTION_LENGHT)}` : v
-        }
+      <ProgressBarSection currentStep={currentStep} currentStatusText={getCurrentStatusText(currentStep)} />
+
+      <ObserversField
+        isEditDisabled={isEditDisabled()}
+        observersFieldRef={observersFieldRef}
+        userOptions={userOptions}
+        selectedUsers={selectedUsers}
+        setSelectedUsers={setSelectedUsers}
       />
-      <div>Summary</div>
-      <TextArea readOnly={isEditDisabled()} value={summary} callback={setSummary} className={styles.reportSummary} />
-      <div>Telescope Status</div>
-      <TextArea
-        readOnly={isEditDisabled()}
-        value={telescopeStatus}
-        callback={setTelescopeStatus}
-        className={styles.reportTelescopeStatus}
+
+      <SummaryField isEditDisabled={isEditDisabled()} summary={summary} setSummary={setSummary} />
+
+      <TelescopeStatusField
+        isEditDisabled={isEditDisabled()}
+        telescopeStatus={telescopeStatus}
+        setTelescopeStatus={setTelescopeStatus}
       />
-      <div className={styles.inputField}>
-        <div>Confluence URL</div>
-        <Input disabled={isEditDisabled()} value={confluenceURL} onChange={(e) => setConfluenceURL(e.target.value)} />
-      </div>
-      <div className={styles.buttons}>
-        <Button onClick={handleSave} disabled={!isAbleToSave()}>
-          Save
-        </Button>
-        <Button onClick={handleSent} disabled={!isAbleToSend()}>
-          Send
-        </Button>
-      </div>
-    </form>
-  );
-}
 
-function SimonyiForm() {
-  const observersFieldRef = useRef();
-  const [currentStep, setCurrentStep] = useState(1);
-  const [userOptions, setUserOptions] = useState([]);
-  const [selectedUsers, setSelectedUsers] = useState([]);
-  const [summary, setSummary] = useState('');
-  const [telescopeStatus, setTelescopeStatus] = useState('');
-  const [confluenceURL, setConfluenceURL] = useState('');
-
-  useEffect(() => {
-    ManagerInterface.getUsers().then((users) => {
-      setUserOptions(users.map((u) => `${u.first_name} ${u.last_name}`));
-    });
-  }, []);
-
-  const handleSent = (event) => {
-    event.preventDefault();
-  };
-
-  const handleSave = (event) => {
-    event.preventDefault();
-  };
-
-  const getCurrentStatusText = () => {
-    if (currentStep === 1) {
-      return ['Not saved', 'The report has not been saved yet.'];
-    }
-    if (currentStep === 2) {
-      return ['Saved', 'The report has been saved.'];
-    }
-    if (currentStep === 3) {
-      return ['Sent', 'The report has been sent.'];
-    }
-  };
-
-  const currentStatusText = getCurrentStatusText();
-
-  const isAbleToSave = () => {
-    return currentStep === 1 || currentStep === 2;
-  };
-
-  const isAbleToSend = () => {
-    return currentStep === 2;
-  };
-
-  return (
-    <form className={styles.form}>
-      <div className={styles.progressBar}>
-        <div className={[styles.step, currentStep === 1 ? styles.selectedStep : ''].join(' ')}>
-          <span>1</span>
-        </div>
-        <div className={[styles.step, currentStep === 2 ? styles.selectedStep : ''].join(' ')}>
-          <span>2</span>
-        </div>
-        <div className={[styles.step, currentStep === 3 ? styles.selectedStep : ''].join(' ')}>
-          <span>3</span>
-        </div>
-      </div>
-      <div className={styles.currentStatusText}>
-        <div>{currentStatusText[0]}</div>
-        <div>{currentStatusText[1]}</div>
-      </div>
-      <div>Observers</div>
-      <MultiSelect
-        innerRef={observersFieldRef}
-        options={userOptions}
-        selectedValues={selectedUsers}
-        onSelect={setSelectedUsers}
-        onRemove={setSelectedUsers}
-        placeholder="Select users that participated on the report."
-        selectedValueDecorator={(v) => (v.length > 10 ? `...${v.slice(-10)}` : v)}
+      <ConfluenceURLField
+        isEditDisabled={isEditDisabled()}
+        confluenceURL={confluenceURL}
+        setConfluenceURL={setConfluenceURL}
       />
-      <div>Summary</div>
-      <TextArea value={summary} callback={setSummary} />
-      <div>Telescope Status</div>
-      <TextArea value={telescopeStatus} callback={setTelescopeStatus} />
-      <div className={styles.inputField}>
-        <div>Confluence URL</div>
-        <Input />
-      </div>
+
       <div className={styles.buttons}>
         <Button onClick={handleSave} disabled={!isAbleToSave()}>
           Save

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -51,10 +51,10 @@ function AuxTelForm() {
 
   const getCurrentStatusText = () => {
     if (currentStep === 1) {
-      return ['Not saved', 'The report has not been saved yet.'];
+      return ['Not saved', 'Today report has not been drafted yet.'];
     }
     if (currentStep === 2) {
-      return ['Saved', 'The report has been saved.'];
+      return ['Saved', 'The report draft has been saved.'];
     }
     if (currentStep === 3) {
       return ['Sent', 'The report has been sent.'];
@@ -101,9 +101,9 @@ function AuxTelForm() {
         }
       />
       <div>Summary</div>
-      <TextArea value={summary} callback={setSummary} />
+      <TextArea value={summary} callback={setSummary} className={styles.reportSummary} />
       <div>Telescope Status</div>
-      <TextArea value={telescopeStatus} callback={setTelescopeStatus} />
+      <TextArea value={telescopeStatus} callback={setTelescopeStatus} className={styles.reportTelescopeStatus} />
       <div className={styles.inputField}>
         <div>Confluence URL</div>
         <Input value={confluenceURL} onChange={setConfluenceURL} />

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -7,6 +7,8 @@ import TextArea from 'components/GeneralPurpose/TextArea/TextArea';
 import Input from 'components/GeneralPurpose/Input/Input';
 import styles from './CreateNightReport.module.css';
 
+const MULTI_SELECT_OPTION_LENGHT = 50;
+
 function AuxTelForm() {
   const observersFieldRef = useRef();
   const [currentStep, setCurrentStep] = useState(1);
@@ -17,10 +19,9 @@ function AuxTelForm() {
   const [confluenceURL, setConfluenceURL] = useState('');
 
   useEffect(() => {
-    // ManagerInterface.getUsers().then((users) => {
-    //   setUserOptions(users.map((u) => u.username));
-    // });
-    setUserOptions(['user1', 'user2', 'user3', 'user4', 'user5']);
+    ManagerInterface.getUsers().then((users) => {
+      setUserOptions(users.map((u) => `${u.first_name} ${u.last_name}`));
+    });
   }, []);
 
   const handleSent = (event) => {
@@ -78,7 +79,9 @@ function AuxTelForm() {
         onSelect={setSelectedUsers}
         onRemove={setSelectedUsers}
         placeholder="Select users that participated on the report."
-        selectedValueDecorator={(v) => (v.length > 10 ? `...${v.slice(-10)}` : v)}
+        selectedValueDecorator={(v) =>
+          v.length > MULTI_SELECT_OPTION_LENGHT ? `...${v.slice(-MULTI_SELECT_OPTION_LENGHT)}` : v
+        }
       />
       <div>Summary</div>
       <TextArea value={summary} callback={setSummary} />
@@ -110,10 +113,9 @@ function SimonyiForm() {
   const [confluenceURL, setConfluenceURL] = useState('');
 
   useEffect(() => {
-    // ManagerInterface.getUsers().then((users) => {
-    //   setUserOptions(users.map((u) => u.username));
-    // });
-    setUserOptions(['user1', 'user2', 'user3', 'user4', 'user5']);
+    ManagerInterface.getUsers().then((users) => {
+      setUserOptions(users.map((u) => `${u.first_name} ${u.last_name}`));
+    });
   }, []);
 
   const handleSent = (event) => {

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -22,6 +22,23 @@ function AuxTelForm() {
     ManagerInterface.getUsers().then((users) => {
       setUserOptions(users.map((u) => `${u.first_name} ${u.last_name}`));
     });
+
+    ManagerInterface.getCurrentNightReport().then((reports) => {
+      if (reports.length > 0) {
+        const report = reports[0];
+        if (report.status === 'sent') {
+          setCurrentStep(3);
+        }
+        setCurrentStep(2);
+
+        // setSelectedUsers(report.observers);
+        setSummary(report.summary);
+        setTelescopeStatus(report.telescope_status);
+        setConfluenceURL(report.confluence_url);
+      } else {
+        setCurrentStep(1);
+      }
+    });
   }, []);
 
   const handleSent = (event) => {
@@ -89,7 +106,7 @@ function AuxTelForm() {
       <TextArea value={telescopeStatus} callback={setTelescopeStatus} />
       <div className={styles.inputField}>
         <div>Confluence URL</div>
-        <Input />
+        <Input value={confluenceURL} onChange={setConfluenceURL} />
       </div>
       <div className={styles.buttons}>
         <Button onClick={handleSave} disabled={!isAbleToSave()}>

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -1,0 +1,219 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import ManagerInterface from 'Utils';
+import Button from 'components/GeneralPurpose/Button/Button';
+import MultiSelect from 'components/GeneralPurpose/MultiSelect/MultiSelect';
+import TextArea from 'components/GeneralPurpose/TextArea/TextArea';
+import Input from 'components/GeneralPurpose/Input/Input';
+import styles from './CreateNightReport.module.css';
+
+function AuxTelForm() {
+  const observersFieldRef = useRef();
+  const [currentStep, setCurrentStep] = useState(1);
+  const [userOptions, setUserOptions] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [summary, setSummary] = useState('');
+  const [telescopeStatus, setTelescopeStatus] = useState('');
+  const [confluenceURL, setConfluenceURL] = useState('');
+
+  useEffect(() => {
+    // ManagerInterface.getUsers().then((users) => {
+    //   setUserOptions(users.map((u) => u.username));
+    // });
+    setUserOptions(['user1', 'user2', 'user3', 'user4', 'user5']);
+  }, []);
+
+  const handleSent = (event) => {
+    event.preventDefault();
+  };
+
+  const handleSave = (event) => {
+    event.preventDefault();
+  };
+
+  const getCurrentStatusText = () => {
+    if (currentStep === 1) {
+      return ['Not saved', 'The report has not been saved yet.'];
+    }
+    if (currentStep === 2) {
+      return ['Saved', 'The report has been saved.'];
+    }
+    if (currentStep === 3) {
+      return ['Sent', 'The report has been sent.'];
+    }
+  };
+
+  const currentStatusText = getCurrentStatusText();
+
+  const isAbleToSave = () => {
+    return currentStep === 1 || currentStep === 2;
+  };
+
+  const isAbleToSend = () => {
+    return currentStep === 2;
+  };
+
+  return (
+    <form className={styles.form}>
+      <div className={styles.progressBar}>
+        <div className={[styles.step, currentStep === 1 ? styles.selectedStep : ''].join(' ')}>
+          <span>1</span>
+        </div>
+        <div className={[styles.step, currentStep === 2 ? styles.selectedStep : ''].join(' ')}>
+          <span>2</span>
+        </div>
+        <div className={[styles.step, currentStep === 3 ? styles.selectedStep : ''].join(' ')}>
+          <span>3</span>
+        </div>
+      </div>
+      <div className={styles.currentStatusText}>
+        <div>{currentStatusText[0]}</div>
+        <div>{currentStatusText[1]}</div>
+      </div>
+      <div>Observers</div>
+      <MultiSelect
+        innerRef={observersFieldRef}
+        options={userOptions}
+        selectedValues={selectedUsers}
+        onSelect={setSelectedUsers}
+        onRemove={setSelectedUsers}
+        placeholder="Select users that participated on the report."
+        selectedValueDecorator={(v) => (v.length > 10 ? `...${v.slice(-10)}` : v)}
+      />
+      <div>Summary</div>
+      <TextArea value={summary} callback={setSummary} />
+      <div>Telescope Status</div>
+      <TextArea value={telescopeStatus} callback={setTelescopeStatus} />
+      <div className={styles.inputField}>
+        <div>Confluence URL</div>
+        <Input />
+      </div>
+      <div className={styles.buttons}>
+        <Button onClick={handleSave} disabled={!isAbleToSave()}>
+          Save
+        </Button>
+        <Button onClick={handleSent} disabled={!isAbleToSend()}>
+          Send
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function SimonyiForm() {
+  const observersFieldRef = useRef();
+  const [currentStep, setCurrentStep] = useState(1);
+  const [userOptions, setUserOptions] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [summary, setSummary] = useState('');
+  const [telescopeStatus, setTelescopeStatus] = useState('');
+  const [confluenceURL, setConfluenceURL] = useState('');
+
+  useEffect(() => {
+    // ManagerInterface.getUsers().then((users) => {
+    //   setUserOptions(users.map((u) => u.username));
+    // });
+    setUserOptions(['user1', 'user2', 'user3', 'user4', 'user5']);
+  }, []);
+
+  const handleSent = (event) => {
+    event.preventDefault();
+  };
+
+  const handleSave = (event) => {
+    event.preventDefault();
+  };
+
+  const getCurrentStatusText = () => {
+    if (currentStep === 1) {
+      return ['Not saved', 'The report has not been saved yet.'];
+    }
+    if (currentStep === 2) {
+      return ['Saved', 'The report has been saved.'];
+    }
+    if (currentStep === 3) {
+      return ['Sent', 'The report has been sent.'];
+    }
+  };
+
+  const currentStatusText = getCurrentStatusText();
+
+  const isAbleToSave = () => {
+    return currentStep === 1 || currentStep === 2;
+  };
+
+  const isAbleToSend = () => {
+    return currentStep === 2;
+  };
+
+  return (
+    <form className={styles.form}>
+      <div className={styles.progressBar}>
+        <div className={[styles.step, currentStep === 1 ? styles.selectedStep : ''].join(' ')}>
+          <span>1</span>
+        </div>
+        <div className={[styles.step, currentStep === 2 ? styles.selectedStep : ''].join(' ')}>
+          <span>2</span>
+        </div>
+        <div className={[styles.step, currentStep === 3 ? styles.selectedStep : ''].join(' ')}>
+          <span>3</span>
+        </div>
+      </div>
+      <div className={styles.currentStatusText}>
+        <div>{currentStatusText[0]}</div>
+        <div>{currentStatusText[1]}</div>
+      </div>
+      <div>Observers</div>
+      <MultiSelect
+        innerRef={observersFieldRef}
+        options={userOptions}
+        selectedValues={selectedUsers}
+        onSelect={setSelectedUsers}
+        onRemove={setSelectedUsers}
+        placeholder="Select users that participated on the report."
+        selectedValueDecorator={(v) => (v.length > 10 ? `...${v.slice(-10)}` : v)}
+      />
+      <div>Summary</div>
+      <TextArea value={summary} callback={setSummary} />
+      <div>Telescope Status</div>
+      <TextArea value={telescopeStatus} callback={setTelescopeStatus} />
+      <div className={styles.inputField}>
+        <div>Confluence URL</div>
+        <Input />
+      </div>
+      <div className={styles.buttons}>
+        <Button onClick={handleSave} disabled={!isAbleToSave()}>
+          Save
+        </Button>
+        <Button onClick={handleSent} disabled={!isAbleToSend()}>
+          Send
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function NightReport(props) {
+  const [selectedTab, setSelectedTab] = useState('auxtel');
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.tabs}>
+        <div className={selectedTab == 'auxtel' ? styles.selectedTab : ''} onClick={() => setSelectedTab('auxtel')}>
+          AuxTel
+        </div>
+        <div className={selectedTab == 'simonyi' ? styles.selectedTab : ''} onClick={() => setSelectedTab('simonyi')}>
+          Simonyi
+        </div>
+      </div>
+      <div className={styles.content}>
+        {selectedTab == 'auxtel' && <AuxTelForm />}
+        {selectedTab == 'simonyi' && <SimonyiForm />}
+      </div>
+    </div>
+  );
+}
+
+NightReport.propTypes = {};
+
+export default NightReport;

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -27,7 +27,7 @@ const getCurrentStatusText = (currentStep) => {
   }
 };
 
-function ProgressBarSection({ currentStep, currentStatusText }) {
+function ProgressBarSection({ currentStep, currentStatusText, changesNotSaved }) {
   return (
     <>
       <div className={styles.progressBar}>
@@ -45,6 +45,9 @@ function ProgressBarSection({ currentStep, currentStatusText }) {
         <div>{currentStatusText[0]}</div>
         <div>{currentStatusText[1]}</div>
       </div>
+      {changesNotSaved && (
+        <div className={styles.changesNotSaved}>Changes on the current draft have not been saved</div>
+      )}
     </>
   );
 }
@@ -110,6 +113,7 @@ function AuxTelForm() {
   const [telescopeStatus, setTelescopeStatus] = useState('');
   const [confluenceURL, setConfluenceURL] = useState('');
   const [reportID, setReportID] = useState();
+  const [changesNotSaved, setChangesNotSaved] = useState(false);
 
   useEffect(() => {
     ManagerInterface.getUsers().then((users) => {
@@ -152,11 +156,18 @@ function AuxTelForm() {
         (resp) => {
           if (resp) {
             setCurrentStep(STEPS.SAVED);
+            setChangesNotSaved(false);
           }
         },
       );
     } else {
-      ManagerInterface.updateCurrentNightReport(reportID, summary, telescopeStatus, confluenceURL, selectedUsers);
+      ManagerInterface.updateCurrentNightReport(reportID, summary, telescopeStatus, confluenceURL, selectedUsers).then(
+        (resp) => {
+          if (resp) {
+            setChangesNotSaved(false);
+          }
+        },
+      );
     }
   };
 
@@ -165,37 +176,61 @@ function AuxTelForm() {
   };
 
   const isAbleToSend = () => {
-    return currentStep === STEPS.SAVED;
+    return currentStep === STEPS.SAVED && !changesNotSaved;
   };
 
   const isEditDisabled = () => {
     return currentStep === STEPS.SENT;
   };
 
+  const handleSelectedUsersChange = (newSelectedUsers) => {
+    setSelectedUsers(newSelectedUsers);
+    setChangesNotSaved(true);
+  };
+
+  const handleSummaryChange = (newSummary) => {
+    setSummary(newSummary);
+    setChangesNotSaved(true);
+  };
+
+  const handleTelescopeStatusChange = (newTelescopeStatus) => {
+    setTelescopeStatus(newTelescopeStatus);
+    setChangesNotSaved(true);
+  };
+
+  const handleConfluenceURLChange = (newConfluenceURL) => {
+    setConfluenceURL(newConfluenceURL);
+    setChangesNotSaved(true);
+  };
+
   return (
     <form className={styles.form}>
-      <ProgressBarSection currentStep={currentStep} currentStatusText={getCurrentStatusText(currentStep)} />
+      <ProgressBarSection
+        currentStep={currentStep}
+        currentStatusText={getCurrentStatusText(currentStep)}
+        changesNotSaved={changesNotSaved}
+      />
 
       <ObserversField
         isEditDisabled={isEditDisabled()}
         observersFieldRef={observersFieldRef}
         userOptions={userOptions}
         selectedUsers={selectedUsers}
-        setSelectedUsers={setSelectedUsers}
+        setSelectedUsers={handleSelectedUsersChange}
       />
 
-      <SummaryField isEditDisabled={isEditDisabled()} summary={summary} setSummary={setSummary} />
+      <SummaryField isEditDisabled={isEditDisabled()} summary={summary} setSummary={handleSummaryChange} />
 
       <TelescopeStatusField
         isEditDisabled={isEditDisabled()}
         telescopeStatus={telescopeStatus}
-        setTelescopeStatus={setTelescopeStatus}
+        setTelescopeStatus={handleTelescopeStatusChange}
       />
 
       <ConfluenceURLField
         isEditDisabled={isEditDisabled()}
         confluenceURL={confluenceURL}
-        setConfluenceURL={setConfluenceURL}
+        setConfluenceURL={handleConfluenceURLChange}
       />
 
       <div className={styles.buttons}>
@@ -219,6 +254,7 @@ function SimonyiForm() {
   const [telescopeStatus, setTelescopeStatus] = useState('');
   const [confluenceURL, setConfluenceURL] = useState('');
   const [reportID, setReportID] = useState();
+  const [changesNotSaved, setChangesNotSaved] = useState(false);
 
   useEffect(() => {
     ManagerInterface.getUsers().then((users) => {
@@ -261,11 +297,18 @@ function SimonyiForm() {
         (resp) => {
           if (resp) {
             setCurrentStep(STEPS.SAVED);
+            setChangesNotSaved(false);
           }
         },
       );
     } else {
-      ManagerInterface.updateCurrentNightReport(reportID, summary, telescopeStatus, confluenceURL, selectedUsers);
+      ManagerInterface.updateCurrentNightReport(reportID, summary, telescopeStatus, confluenceURL, selectedUsers).then(
+        (resp) => {
+          if (resp) {
+            setChangesNotSaved(false);
+          }
+        },
+      );
     }
   };
 
@@ -274,37 +317,61 @@ function SimonyiForm() {
   };
 
   const isAbleToSend = () => {
-    return currentStep === STEPS.SAVED;
+    return currentStep === STEPS.SAVED && !changesNotSaved;
   };
 
   const isEditDisabled = () => {
     return currentStep === STEPS.SENT;
   };
 
+  const handleSelectedUsersChange = (newSelectedUsers) => {
+    setSelectedUsers(newSelectedUsers);
+    setChangesNotSaved(true);
+  };
+
+  const handleSummaryChange = (newSummary) => {
+    setSummary(newSummary);
+    setChangesNotSaved(true);
+  };
+
+  const handleTelescopeStatusChange = (newTelescopeStatus) => {
+    setTelescopeStatus(newTelescopeStatus);
+    setChangesNotSaved(true);
+  };
+
+  const handleConfluenceURLChange = (newConfluenceURL) => {
+    setConfluenceURL(newConfluenceURL);
+    setChangesNotSaved(true);
+  };
+
   return (
     <form className={styles.form}>
-      <ProgressBarSection currentStep={currentStep} currentStatusText={getCurrentStatusText(currentStep)} />
+      <ProgressBarSection
+        currentStep={currentStep}
+        currentStatusText={getCurrentStatusText(currentStep)}
+        changesNotSaved={changesNotSaved}
+      />
 
       <ObserversField
         isEditDisabled={isEditDisabled()}
         observersFieldRef={observersFieldRef}
         userOptions={userOptions}
         selectedUsers={selectedUsers}
-        setSelectedUsers={setSelectedUsers}
+        setSelectedUsers={handleSelectedUsersChange}
       />
 
-      <SummaryField isEditDisabled={isEditDisabled()} summary={summary} setSummary={setSummary} />
+      <SummaryField isEditDisabled={isEditDisabled()} summary={summary} setSummary={handleSummaryChange} />
 
       <TelescopeStatusField
         isEditDisabled={isEditDisabled()}
         telescopeStatus={telescopeStatus}
-        setTelescopeStatus={setTelescopeStatus}
+        setTelescopeStatus={handleTelescopeStatusChange}
       />
 
       <ConfluenceURLField
         isEditDisabled={isEditDisabled()}
         confluenceURL={confluenceURL}
-        setConfluenceURL={setConfluenceURL}
+        setConfluenceURL={handleConfluenceURLChange}
       />
 
       <div className={styles.buttons}>

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -30,8 +30,7 @@ function AuxTelForm() {
           setCurrentStep(3);
         }
         setCurrentStep(2);
-
-        // setSelectedUsers(report.observers);
+        setSelectedUsers(report.observers_crew);
         setSummary(report.summary);
         setTelescopeStatus(report.telescope_status);
         setConfluenceURL(report.confluence_url);
@@ -47,6 +46,17 @@ function AuxTelForm() {
 
   const handleSave = (event) => {
     event.preventDefault();
+    if (currentStep === 1) {
+      ManagerInterface.saveCurrentNightReport('AuxTel', summary, telescopeStatus, confluenceURL, selectedUsers).then(
+        (resp) => {
+          if (resp) {
+            setCurrentStep(2);
+          }
+        },
+      );
+    } else {
+      console.log('Update report');
+    }
   };
 
   const getCurrentStatusText = () => {
@@ -106,7 +116,7 @@ function AuxTelForm() {
       <TextArea value={telescopeStatus} callback={setTelescopeStatus} className={styles.reportTelescopeStatus} />
       <div className={styles.inputField}>
         <div>Confluence URL</div>
-        <Input value={confluenceURL} onChange={setConfluenceURL} />
+        <Input value={confluenceURL} onChange={(e) => setConfluenceURL(e.target.value)} />
       </div>
       <div className={styles.buttons}>
         <Button onClick={handleSave} disabled={!isAbleToSave()}>

--- a/love/src/components/NightReport/CreateNightReport.module.css
+++ b/love/src/components/NightReport/CreateNightReport.module.css
@@ -13,6 +13,7 @@
   border: 1px solid var(--secondary-font-dimmed-color);
   border-top-left-radius: 0.5em;
   border-top-right-radius: 0.5em;
+  margin-bottom: -1px;
 }
 
 .tabs > :first-child {
@@ -24,7 +25,8 @@
 }
 
 .selectedTab {
-  background-color: red;
+  border-bottom-color: var(--second-secondary-background-color);
+  z-index: 1;
 }
 
 .content {
@@ -46,25 +48,29 @@
   background-color: var(--second-tertiary-background-color);
 }
 
+.form > *:not(:last-child, .progressBar) {
+  margin-bottom: var(--small-padding);
+}
+
 .progressBar {
   width: 80%;
-  margin: 0 auto;
   display: flex;
   align-items: center;
-  margin-bottom: var(--content-padding);
+  margin: var(--content-padding) auto;
 }
 
 .progressBar > .step {
   width: 33%;
   height: 1em;
-  background-color: gray;
+  background-color: var(--quinary-background-color);
   display: flex;
   align-items: center;
   justify-content: center;
+  color: white;
 }
 
 .progressBar > .step:not(:last-child) {
-  border-right: 1px lightgray solid;
+  border-right: 1px var(--primary-active-hover-background-color) solid;
 }
 
 .progressBar > .step > :first-child {
@@ -77,8 +83,21 @@
   justify-content: center;
 }
 
+.progressBar > .step.selectedStep,
 .progressBar > .step.selectedStep > :first-child {
+  /* color: var(--quinary-background-color); */
   background-color: var(--primary-active-hover-background-color);
+  animation: mymove 1s infinite;
+  animation-direction: alternate;
+}
+
+@keyframes mymove {
+  from {
+    background-color: var(--primary-active-hover-background-color);
+  }
+  to {
+    background-color: var(--quinary-background-color);
+  }
 }
 
 .currentStatusText {
@@ -106,4 +125,12 @@
   display: flex;
   justify-content: space-between;
   margin-top: var(--content-padding);
+}
+
+.reportSummary {
+  min-height: 16ch;
+}
+
+.reportTelescopeStatus {
+  min-height: 10ch;
 }

--- a/love/src/components/NightReport/CreateNightReport.module.css
+++ b/love/src/components/NightReport/CreateNightReport.module.css
@@ -100,10 +100,15 @@
   }
 }
 
-.currentStatusText {
+.currentStatusText,
+.changesNotSaved {
   width: 80%;
   margin: 0 auto;
   text-align: center;
+}
+
+.changesNotSaved {
+  color: var(--status-alert-color);
 }
 
 .currentStatusText > :first-child {

--- a/love/src/components/NightReport/CreateNightReport.module.css
+++ b/love/src/components/NightReport/CreateNightReport.module.css
@@ -1,0 +1,109 @@
+.tabs {
+  display: flex;
+}
+
+.tabs > * {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  padding: 0 0.5em;
+  cursor: pointer;
+  height: 3em;
+  background-color: var(--second-secondary-background-color);
+  border: 1px solid var(--secondary-font-dimmed-color);
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+}
+
+.tabs > :first-child {
+  margin-left: 2em;
+}
+
+.tabs > *:not(:last-child) {
+  margin-right: 2em;
+}
+
+.selectedTab {
+  background-color: red;
+}
+
+.content {
+  background-color: var(--second-secondary-background-color);
+  border: 1px solid var(--second-senary-background-dimmed-color);
+  border-radius: 0.5em;
+  padding: var(--content-padding);
+  text-align: left;
+}
+
+.select {
+  background-color: var(--second-secondary-background-color);
+  color: var(--base-font-color);
+  border-radius: 0.2em;
+}
+
+.form {
+  padding: var(--content-padding);
+  background-color: var(--second-tertiary-background-color);
+}
+
+.progressBar {
+  width: 80%;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--content-padding);
+}
+
+.progressBar > .step {
+  width: 33%;
+  height: 1em;
+  background-color: gray;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.progressBar > .step:not(:last-child) {
+  border-right: 1px lightgray solid;
+}
+
+.progressBar > .step > :first-child {
+  background-color: var(--quinary-background-color);
+  width: 2em;
+  height: 2em;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.progressBar > .step.selectedStep > :first-child {
+  background-color: var(--primary-active-hover-background-color);
+}
+
+.currentStatusText {
+  width: 80%;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.currentStatusText > :first-child {
+  color: var(--primary-active-hover-background-color);
+  font-weight: bold;
+}
+
+.inputField {
+  display: flex;
+  align-items: center;
+}
+
+.inputField > :first-child {
+  white-space: nowrap;
+  margin-right: var(--small-padding);
+}
+
+.buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--content-padding);
+}

--- a/love/src/components/NightReport/HistoricNightReport.container.jsx
+++ b/love/src/components/NightReport/HistoricNightReport.container.jsx
@@ -1,0 +1,69 @@
+/** 
+This file is part of LOVE-frontend.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React from 'react';
+import { connect } from 'react-redux';
+import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
+import { addGroup, removeGroup } from 'redux/actions/ws';
+import HistoricNightReport from './HistoricNightReport';
+
+export const schema = {
+  description: 'Night report historic service',
+  defaultSize: [77, 32],
+  props: {
+    title: {
+      type: 'string',
+      description: 'Name displayed in the title bar (if visible)',
+      isPrivate: false,
+      default: 'Log Service',
+    },
+    hasRawMode: {
+      type: 'boolean',
+      description: 'Whether the component has a raw mode version',
+      isPrivate: true,
+      default: false,
+    },
+  },
+};
+
+const HistoricNightReportContainer = ({ subscribeToStreams, unsubscribeToStreams, ...props }) => {
+  if (props.isRaw) {
+    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
+  }
+  return (
+    <HistoricNightReport
+      subscribeToStreams={subscribeToStreams}
+      unsubscribeToStreams={unsubscribeToStreams}
+      {...props}
+    />
+  );
+};
+
+const mapDispatchToProps = (dispatch) => {
+  const subscriptions = [];
+  return {
+    subscriptions,
+    subscribeToStreams: () => {
+      subscriptions.forEach((s) => dispatch(addGroup(s)));
+    },
+    unsubscribeToStreams: () => {
+      subscriptions.forEach((s) => dispatch(removeGroup(s)));
+    },
+  };
+};
+
+export default connect(null, mapDispatchToProps)(HistoricNightReportContainer);

--- a/love/src/components/NightReport/HistoricNightReport.jsx
+++ b/love/src/components/NightReport/HistoricNightReport.jsx
@@ -1,114 +1,145 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import ManagerInterface from 'Utils';
+import Moment from 'moment';
+import ManagerInterface, { getObsDayFromDate } from 'Utils';
+import { TIMES_SQUARE_OBS_TICKETS_REPORT_URL } from 'Config';
 import Button from 'components/GeneralPurpose/Button/Button';
 import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
 import Select from 'components/GeneralPurpose/Select/Select';
 import styles from './HistoricNightReport.module.css';
 
-const DUMMY_DATA = [
-  {
-    obsday: 20240101,
-    status: 'started',
-    summary: 'This is a summary',
-    telescope_status: 'Telescope is working',
-    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-01+Night+Report',
-    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-01',
-    participants: ['user1', 'user2', 'user3'],
-  },
-  {
-    obsday: 20240102,
-    status: 'started',
-    summary: 'This is a summary',
-    telescope_status: 'Telescope is working',
-    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-02+Night+Report',
-    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-02',
-    participants: ['user1', 'user2', 'user3'],
-  },
-  {
-    obsday: 20240103,
-    status: 'started',
-    summary: 'This is a summary',
-    telescope_status: 'Telescope is working',
-    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-03+Night+Report',
-    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-03',
-    participants: ['user1', 'user2', 'user3'],
-  },
-  {
-    obsday: 20240104,
-    status: 'started',
-    summary: 'This is a summary',
-    telescope_status: 'Telescope is working',
-    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-04+Night+Report',
-    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-04',
-    participants: ['user1', 'user2', 'user3'],
-  },
-  {
-    obsday: 20240105,
-    status: 'started',
-    summary: 'This is a summary',
-    telescope_status: 'Telescope is working',
-    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-05+Night+Report',
-    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-05',
-    participants: ['user1', 'user2', 'user3'],
-  },
-  {
-    obsday: 20240106,
-    status: 'started',
-    summary: 'This is a summary',
-    telescope_status: 'Telescope is working',
-    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-06+Night+Report',
-    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-06',
-    participants: ['user1', 'user2', 'user3'],
-  },
-];
+const TELESCOPES = {
+  simonyi: 'Simonyi',
+  auxtel: 'AuxTel',
+};
 
 function Report(data, index) {
+  const status = data.date_sent ? 'Sent' : 'Draft';
   return (
     <div key={index} className={styles.report}>
       <div className={styles.reportMetadata}>
-        <div>Observation day</div>
-        <div>{data.obsday}</div>
-        <div>Status</div>
-        <div>{data.status}</div>
-        <div>Confluence page</div>
-        <div>{data.confluence_url}</div>
-        <div>Rolex entries</div>
-        <div>{data.rolex_url}</div>
+        <div className={styles.label}>Observation day</div>
+        <div className={styles.value}>{data.day_obs}</div>
+        <div className={styles.label}>Status</div>
+        <div className={styles.value}>{status}</div>
+        <div className={styles.label}>Obs fault report</div>
+        <div className={styles.value}>
+          <a href={data.obs_fault_url} target="_blank" rel="noreferrer">
+            {data.obs_fault_url}
+          </a>
+        </div>
+        <div className={styles.label}>Confluence page</div>
+        <div className={styles.value}>
+          <a href={data.confluence_url} target="_blank" rel="noreferrer">
+            {data.confluence_url}
+          </a>
+        </div>
+        <div className={styles.label}>Rolex entries</div>
+        <div className={styles.value}>
+          <a href={data.rolex_url} target="_blank" rel="noreferrer">
+            {data.rolex_url}
+          </a>
+        </div>
       </div>
       <div className={styles.reportTelescopeStatus}>
-        <div>Telescope Status</div>
-        <div>{data.telescope_status}</div>
+        <div className={styles.label}>Telescope Status</div>
+        <div className={styles.value}>{data.telescope_status}</div>
       </div>
       <div className={styles.reportSummary}>
-        <div>Summary</div>
-        <div>{data.summary}</div>
+        <div className={styles.label}>Summary</div>
+        <div className={styles.value}>{data.summary}</div>
       </div>
       <div className={styles.reportParticipants}>
-        <div>Participants</div>
-        <div>{data.participants.join(', ')}</div>
+        <div className={styles.label}>Participants</div>
+        <div className={styles.value}>{data.observers_crew.join(', ')}</div>
       </div>
     </div>
   );
 }
 
+/**
+ * Formats the reports by adding some extra properties to each report.
+ * The rolex_url is constructed using the current window location
+ * and the day part of the date_added property.
+ * The obs_fault_url is constructed using the TIMES_SQUARE_OBS_TICKETS_REPORT_URL
+ * and the day part of the date_added property.
+ * @param {Array} reports - The array of reports to be formatted.
+ * @returns {Array} - The formatted array of reports.
+ */
+function formatReports(reports) {
+  return reports.map((report) => ({
+    ...report,
+    rolex_url: `${window.location.origin}/rolex?log_date=${report.date_added.split('T')[0]}`,
+    obs_fault_url: TIMES_SQUARE_OBS_TICKETS_REPORT_URL.replace('{DAY}', report.date_added.split('T')[0]),
+  }));
+}
+
 function HistoricNightReport(props) {
+  const [dateStart, setDateStart] = useState(Moment());
+  const [dateEnd, setDateEnd] = useState(Moment());
+  const [selectedTelescope, setSelectedTelescope] = useState(TELESCOPES.auxtel);
   const [lastUpdated, setLastUpdated] = useState(new Date());
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    queryNightReport();
+  }, []);
+
+  const queryNightReport = () => {
+    setLoading(true);
+    const dayObsStart = dateStart.format('YYYYMMDD');
+    const dayObsEnd = Moment(dateEnd).add(1, 'd').format('YYYYMMDD');
+    ManagerInterface.getHistoricNightReports(dayObsStart, dayObsEnd, selectedTelescope).then((data) => {
+      if (data) {
+        setReports(formatReports(data));
+        setLastUpdated(new Date());
+      }
+      setLoading(false);
+    });
+  };
+
+  const handleDateChange = (date, type) => {
+    if (type === 'start') {
+      setDateStart(date);
+    } else {
+      setDateEnd(date);
+    }
+  };
 
   return (
     <div className={styles.container}>
       <div className={styles.filters}>
-        <DateTimeRange />
+        <DateTimeRange
+          label="From"
+          startDate={dateStart}
+          endDate={dateEnd}
+          startDateProps={{
+            timeFormat: false,
+            maxDate: Moment(),
+          }}
+          endDateProps={{
+            timeFormat: false,
+            maxDate: Moment(),
+          }}
+          onChange={handleDateChange}
+        />
         <Select
+          value={selectedTelescope}
+          onChange={({ value }) => setSelectedTelescope(value)}
           options={[
-            { value: 'simonyi', label: 'Simonyi' },
-            { value: 'auxtel', label: 'Auxtel' },
+            { value: TELESCOPES.simonyi, label: 'Simonyi' },
+            { value: TELESCOPES.auxtel, label: 'Auxtel' },
           ]}
         />
-        <Button>Refresh data</Button>
-        <span>Last updated {lastUpdated.toISOString()}</span>
       </div>
-      <div className={styles.content}>{DUMMY_DATA.map((item, index) => Report(item, index))}</div>
+      <div className={styles.refresh}>
+        <Button onClick={queryNightReport} disabled={loading}>
+          Refresh data
+        </Button>
+        <span>Last updated {lastUpdated.toISOString().split('.')[0]}</span>
+      </div>
+      <div className={styles.content}>{reports.map((report, index) => Report(report, index))}</div>
     </div>
   );
 }

--- a/love/src/components/NightReport/HistoricNightReport.jsx
+++ b/love/src/components/NightReport/HistoricNightReport.jsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import ManagerInterface from 'Utils';
+import Button from 'components/GeneralPurpose/Button/Button';
+import DateTimeRange from 'components/GeneralPurpose/DateTimeRange/DateTimeRange';
+import Select from 'components/GeneralPurpose/Select/Select';
+import styles from './HistoricNightReport.module.css';
+
+const DUMMY_DATA = [
+  {
+    obsday: 20240101,
+    status: 'started',
+    summary: 'This is a summary',
+    telescope_status: 'Telescope is working',
+    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-01+Night+Report',
+    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-01',
+    participants: ['user1', 'user2', 'user3'],
+  },
+  {
+    obsday: 20240102,
+    status: 'started',
+    summary: 'This is a summary',
+    telescope_status: 'Telescope is working',
+    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-02+Night+Report',
+    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-02',
+    participants: ['user1', 'user2', 'user3'],
+  },
+  {
+    obsday: 20240103,
+    status: 'started',
+    summary: 'This is a summary',
+    telescope_status: 'Telescope is working',
+    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-03+Night+Report',
+    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-03',
+    participants: ['user1', 'user2', 'user3'],
+  },
+  {
+    obsday: 20240104,
+    status: 'started',
+    summary: 'This is a summary',
+    telescope_status: 'Telescope is working',
+    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-04+Night+Report',
+    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-04',
+    participants: ['user1', 'user2', 'user3'],
+  },
+  {
+    obsday: 20240105,
+    status: 'started',
+    summary: 'This is a summary',
+    telescope_status: 'Telescope is working',
+    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-05+Night+Report',
+    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-05',
+    participants: ['user1', 'user2', 'user3'],
+  },
+  {
+    obsday: 20240106,
+    status: 'started',
+    summary: 'This is a summary',
+    telescope_status: 'Telescope is working',
+    confluence_url: 'https://confluence.lsstcorp.org/display/SIM/2024-01-06+Night+Report',
+    rolex_url: 'https://rolex.lsstcorp.org/night/2024-01-06',
+    participants: ['user1', 'user2', 'user3'],
+  },
+];
+
+function Report(data, index) {
+  return (
+    <div key={index} className={styles.report}>
+      <div className={styles.reportMetadata}>
+        <div>Observation day</div>
+        <div>{data.obsday}</div>
+        <div>Status</div>
+        <div>{data.status}</div>
+        <div>Confluence page</div>
+        <div>{data.confluence_url}</div>
+        <div>Rolex entries</div>
+        <div>{data.rolex_url}</div>
+      </div>
+      <div className={styles.reportTelescopeStatus}>
+        <div>Telescope Status</div>
+        <div>{data.telescope_status}</div>
+      </div>
+      <div className={styles.reportSummary}>
+        <div>Summary</div>
+        <div>{data.summary}</div>
+      </div>
+      <div className={styles.reportParticipants}>
+        <div>Participants</div>
+        <div>{data.participants.join(', ')}</div>
+      </div>
+    </div>
+  );
+}
+
+function HistoricNightReport(props) {
+  const [lastUpdated, setLastUpdated] = useState(new Date());
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.filters}>
+        <DateTimeRange />
+        <Select
+          options={[
+            { value: 'simonyi', label: 'Simonyi' },
+            { value: 'auxtel', label: 'Auxtel' },
+          ]}
+        />
+        <Button>Refresh data</Button>
+        <span>Last updated {lastUpdated.toISOString()}</span>
+      </div>
+      <div className={styles.content}>{DUMMY_DATA.map((item, index) => Report(item, index))}</div>
+    </div>
+  );
+}
+
+HistoricNightReport.propTypes = {};
+
+export default HistoricNightReport;

--- a/love/src/components/NightReport/HistoricNightReport.module.css
+++ b/love/src/components/NightReport/HistoricNightReport.module.css
@@ -1,0 +1,55 @@
+.container {
+  padding: var(--content-padding);
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--content-padding);
+}
+
+.report {
+  text-align: left;
+  background-color: var(--second-tertiary-background-color);
+  padding: 1em;
+  display: grid;
+  grid-template-columns: 4fr 1fr;
+  grid-template-rows: auto;
+  grid-template-areas:
+    'metadata telescope-status'
+    'summary summary'
+    'participants participants';
+}
+
+.reportMetadata {
+  grid-area: metadata;
+  display: grid;
+  grid-template-columns: minmax(min-content, auto) 1fr;
+  margin-bottom: var(--small-padding);
+}
+
+.reportMetadata > :nth-child(odd) {
+  white-space: nowrap;
+  margin-right: var(--small-padding);
+}
+
+.reportTelescopeStatus {
+  grid-area: telescope-status;
+  background-color: var(--second-quaternary-background-color);
+  margin-bottom: var(--small-padding);
+}
+
+.reportSummary {
+  grid-area: summary;
+  background-color: var(--second-quaternary-background-color);
+  padding: var(--small-padding);
+  margin-bottom: var(--small-padding);
+}
+
+.reportParticipants {
+  grid-area: participants;
+}
+
+.report:not(:last-child) {
+  margin-bottom: var(--small-padding);
+}

--- a/love/src/components/NightReport/HistoricNightReport.module.css
+++ b/love/src/components/NightReport/HistoricNightReport.module.css
@@ -43,7 +43,7 @@
   grid-area: summary;
   background-color: var(--second-quaternary-background-color);
   padding: var(--small-padding);
-  margin-bottom: var(--small-padding);
+  margin: var(--small-padding) 0;
 }
 
 .reportParticipants {

--- a/love/src/components/NightReport/HistoricNightReport.module.css
+++ b/love/src/components/NightReport/HistoricNightReport.module.css
@@ -2,10 +2,12 @@
   padding: var(--content-padding);
 }
 
-.filters {
+.filters,
+.refresh {
   display: flex;
   align-items: center;
   margin-bottom: var(--content-padding);
+  gap: var(--small-padding);
 }
 
 .report {
@@ -19,6 +21,7 @@
     'metadata telescope-status'
     'summary summary'
     'participants participants';
+  border-radius: 0.5em;
 }
 
 .reportMetadata {
@@ -37,13 +40,16 @@
   grid-area: telescope-status;
   background-color: var(--second-quaternary-background-color);
   margin-bottom: var(--small-padding);
+  padding: var(--content-padding);
+  border-radius: 0.5em;
 }
 
 .reportSummary {
   grid-area: summary;
   background-color: var(--second-quaternary-background-color);
-  padding: var(--small-padding);
   margin: var(--small-padding) 0;
+  padding: var(--content-padding);
+  border-radius: 0.5em;
 }
 
 .reportParticipants {
@@ -52,4 +58,21 @@
 
 .report:not(:last-child) {
   margin-bottom: var(--small-padding);
+}
+
+.label {
+  color: var(--secondary-font-color);
+  font-weight: bold;
+}
+
+.value {
+  color: var(--base-font-color);
+}
+
+.value a {
+  color: var(--base-font-color);
+}
+
+.value a:hover {
+  color: var(--secondary-font-color);
 }

--- a/love/src/components/UIF/ComponentIndex.jsx
+++ b/love/src/components/UIF/ComponentIndex.jsx
@@ -372,6 +372,26 @@ export const observatoryIndex = {
       },
     },
   },
+  CreateNightReport: {
+    component: require('../NightReport/CreateNightReport.container').default,
+    schema: {
+      ...require('../NightReport/CreateNightReport.container').schema,
+      props: {
+        ...defaultSchemaProps,
+        ...require('../NightReport/CreateNightReport.container').schema.props,
+      },
+    },
+  },
+  HistoricNightReport: {
+    component: require('../NightReport/HistoricNightReport.container').default,
+    schema: {
+      ...require('../NightReport/HistoricNightReport.container').schema,
+      props: {
+        ...defaultSchemaProps,
+        ...require('../NightReport/HistoricNightReport.container').schema.props,
+      },
+    },
+  },
   ObservatorySummary: {
     component: require('../ObservatorySummary/ObservatorySummary.container').default,
     schema: {

--- a/love/src/redux/reducers/auth.js
+++ b/love/src/redux/reducers/auth.js
@@ -85,6 +85,8 @@ export default function (state = initialState, action) {
         return {
           ...state,
           username: action.username,
+          first_name: action.first_name,
+          last_name: action.last_name,
           token: action.token,
           status: tokenStates.RECEIVED,
           permissions: initialState.permissions,

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -24,6 +24,8 @@ export const getToken = (state) => state.auth.token;
 
 export const getUsername = (state) => state.auth.username;
 
+export const getUserFullName = (state) => `${state.auth.first_name} ${state.auth.last_name}`;
+
 export const getTaiToUtc = (state) => state.time.server_time.tai_to_utc;
 
 export const getServerTimeRequest = (state) => state.time.request_time;


### PR DESCRIPTION
This PR adds the `NightReport` module with two components: `CreateNightReport` and `HistoricNightReport`, the first one for managing drafts of night summary reports that can be sent at the end of the night, and the second one to look into past sent reports.