### PR TITLE
Update missing reference to the jira service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.0
 -------
 
+* Update missing reference to the jira service `<https://github.com/lsst-ts/LOVE-frontend/pull/621>`_
 * Add Night Report implementation `<https://github.com/lsst-ts/LOVE-frontend/pull/619>`_
 
 v5.29.3

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1917,7 +1917,7 @@ export function htmlToJiraMarkdown(html) {
   const jiraTicketRegexString = `(?<!\\[[^\\]]*)(${AUTO_HYPERLINK_JIRA_PROJECTS.join('|')})+-\\d+\\b`;
   const jiraTicketRegex = new RegExp(jiraTicketRegexString, 'g');
   markdown = markdown.replace(jiraTicketRegex, (match) => {
-    return `[${match}|https://jira.lsstcorp.org/browse/${match}]`;
+    return `[${match}|${JIRA_TICKETS_BASE_URL}/${match}]`;
   });
 
   // TODO: DM-41265

--- a/love/src/Utils.test.js
+++ b/love/src/Utils.test.js
@@ -1,4 +1,5 @@
 import { htmlToJiraMarkdown, jiraMarkdownToHtml } from './Utils';
+import { JIRA_TICKETS_BASE_URL } from './Config';
 
 describe('htmlToJiraMarkdown', () => {
   it('should handle links', () => {
@@ -36,7 +37,7 @@ describe('htmlToJiraMarkdown', () => {
       'This is a string with mixed content\r\n' +
       'h1. This is a heading.\r\n' +
       'This is an already formatted link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n' +
-      'This is a ticket name not yet formatted [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n' +
+      `This is a ticket name not yet formatted [DM-41184|${JIRA_TICKETS_BASE_URL}/DM-41184].\r\n` +
       'This is an already parsed link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n';
     expect(htmlToJiraMarkdown(input)).toEqual(expectedOutput);
   });


### PR DESCRIPTION
This PR updates the `htmlToJiraMarkdown` function to use the new jira cloud hostname instead of the old one.