### PR TITLE
Fix content cleaning on RichTextEditor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.0
 -------
 
+* Fix content cleaning on RichTextEditor `<https://github.com/lsst-ts/LOVE-frontend/pull/622>`_
 * Update missing reference to the jira service `<https://github.com/lsst-ts/LOVE-frontend/pull/621>`_
 * Add Night Report implementation `<https://github.com/lsst-ts/LOVE-frontend/pull/619>`_
 

--- a/love/src/components/GeneralPurpose/RichTextEditor/RichTextEditor.jsx
+++ b/love/src/components/GeneralPurpose/RichTextEditor/RichTextEditor.jsx
@@ -37,13 +37,11 @@ const modules = {
 
 const RichTextEditor = forwardRef(
   ({ defaultValue, className, onChange = () => {}, onKeyCombination = () => {} }, ref) => {
-    const [value, setValue] = useState(defaultValue);
     const [isControlPressed, setIsControlPressed] = useState(false);
     const reactQuillRef = useRef(null);
 
     const handleChange = (value, delta, source, editor) => {
       if (source === 'user') {
-        setValue(value);
         onChange(value);
       }
     };
@@ -70,11 +68,15 @@ const RichTextEditor = forwardRef(
       }
     };
 
-    useImperativeHandle(ref, () => ({
-      cleanContent() {
-        setValue('');
-      },
-    }));
+    useImperativeHandle(ref, () => {
+      const quillRef = reactQuillRef.current.getEditor();
+      return {
+        cleanContent() {
+          quillRef.setContents([]);
+          onChange('');
+        },
+      };
+    });
 
     const attachQuillRefs = () => {
       if (typeof reactQuillRef?.current?.getEditor !== 'function') return;
@@ -104,7 +106,7 @@ const RichTextEditor = forwardRef(
           modules={modules}
           formats={['header', 'link', 'indent']}
           theme="snow"
-          defaultValue={value}
+          defaultValue={defaultValue}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           onKeyUp={handleKeyUp}


### PR DESCRIPTION
This PR adds a missing cleaning process on the `RichTextEditor`. The cleaning have been set, but after a recent update it stopped working, this changes fix that.