### PR TITLE
Fix the feature to convert Jira ticket names into hyperlinks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.0
 -------
 
+* Fix the feature to convert Jira ticket names into hyperlinks `<https://github.com/lsst-ts/LOVE-frontend/pull/623>`_
 * Fix content cleaning on RichTextEditor `<https://github.com/lsst-ts/LOVE-frontend/pull/622>`_
 * Update missing reference to the jira service `<https://github.com/lsst-ts/LOVE-frontend/pull/621>`_
 * Add Night Report implementation `<https://github.com/lsst-ts/LOVE-frontend/pull/619>`_

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -43,6 +43,17 @@ if (Array.prototype.flat === undefined) {
 }
 
 /**
+ * Applies a series of functions to a value, passing the result of each function as the argument to the next function.
+ *
+ * @param {...Function} fns - The functions to be applied.
+ * @returns {Function} A new function that applies the given functions in sequence.
+ */
+export const pipe =
+  (...fns) =>
+  (x) =>
+    fns.reduce((v, f) => f(v), x);
+
+/**
    MIT License
 Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
 
@@ -1911,15 +1922,6 @@ export function htmlToJiraMarkdown(html) {
     return `{code}${p1}{code}`;
   });
 
-  // Parse Jira tickets names
-  // At this point, hyperlinks have been already parsed.
-  // The following regex allows us to parse Jira tickets names that are not hyperlinks
-  const jiraTicketRegexString = `(?<!\\[[^\\]]*)(${AUTO_HYPERLINK_JIRA_PROJECTS.join('|')})+-\\d+\\b`;
-  const jiraTicketRegex = new RegExp(jiraTicketRegexString, 'g');
-  markdown = markdown.replace(jiraTicketRegex, (match) => {
-    return `[${match}|${JIRA_TICKETS_BASE_URL}/${match}]`;
-  });
-
   // TODO: DM-41265
   // markdown = markdown.replace(/<ul>|<\/ul>|<ol>|<\/ol>|<li>/g, '');
   // markdown = markdown.replace(/<\/li>/g, '\n');
@@ -2033,6 +2035,25 @@ export function jiraMarkdownToHtml(markdown, options = { codeFriendly: true }) {
   html = html.replace(/\r\n\r\n/g, '<br>');
 
   return html;
+}
+
+/**
+ * Converts Jira ticket names to hyperlinks.
+ * Jira ticket names are expected to be in the format <JIRA_PROJECT>-<NUMBER>.
+ * The JIRA_PROJECT is expected to be one of the projects defined in the AUTO_HYPERLINK_JIRA_PROJECTS constant.
+ * This function only conver Jira ticket names that are not hyperlinks.
+ * THE INPUT TEXT MUST BE IN MARKDOWN FORMAT.
+ * @param {string} markdown - The text in markdown format containing Jira ticket names.
+ * @returns {string} - The text with Jira ticket names converted to hyperlinks in markdown format.
+ */
+export function convertJiraTicketNamesToHyperlinks(markdown) {
+  // The following regex matches Jira tickets that are not inside markdown hyperlinks
+  // by using a negative lookbehind assertion.
+  const jiraTicketRegexString = `(?<!\\[[^\\]]*)(${AUTO_HYPERLINK_JIRA_PROJECTS.join('|')})+-\\d+\\b`;
+  const jiraTicketRegex = new RegExp(jiraTicketRegexString, 'g');
+  return markdown.replace(jiraTicketRegex, (match) => {
+    return `[${match}|${JIRA_TICKETS_BASE_URL}/${match}]`;
+  });
 }
 
 /**

--- a/love/src/Utils.test.js
+++ b/love/src/Utils.test.js
@@ -1,4 +1,4 @@
-import { htmlToJiraMarkdown, jiraMarkdownToHtml } from './Utils';
+import { htmlToJiraMarkdown, jiraMarkdownToHtml, convertJiraTicketNamesToHyperlinks } from './Utils';
 import { JIRA_TICKETS_BASE_URL } from './Config';
 
 describe('htmlToJiraMarkdown', () => {
@@ -23,22 +23,6 @@ describe('htmlToJiraMarkdown', () => {
       'This is a string with mixed content\r\n' +
       'h1. This is a heading.\r\n' +
       'This is a [link|http://google.com/].\r\n';
-    expect(htmlToJiraMarkdown(input)).toEqual(expectedOutput);
-  });
-
-  it('should convert Jira tickets to links', () => {
-    const input =
-      '<p>This is a string with mixed content</p>' +
-      '<h1>This is a heading.</h1>' +
-      '<p>This is an already formatted link <a href="https://jira.lsstcorp.org/browse/DM-41184" rel="noopener noreferrer" target="_blank">DM-41184</a>.</p>' +
-      '<p>This is a ticket name not yet formatted DM-41184.</p>' +
-      '<p>This is an already parsed link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].</p>';
-    const expectedOutput =
-      'This is a string with mixed content\r\n' +
-      'h1. This is a heading.\r\n' +
-      'This is an already formatted link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n' +
-      `This is a ticket name not yet formatted [DM-41184|${JIRA_TICKETS_BASE_URL}/DM-41184].\r\n` +
-      'This is an already parsed link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n';
     expect(htmlToJiraMarkdown(input)).toEqual(expectedOutput);
   });
 
@@ -142,5 +126,19 @@ describe('jiraMarkdownToHtml', () => {
       '<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This&nbsp;is&nbsp;a&nbsp;double&nbsp;indented&nbsp;line.</p>' +
       '<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This&nbsp;is&nbsp;a&nbsp;triple&nbsp;indented&nbsp;line.</p>';
     expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
+  });
+});
+
+describe('convertJiraTicketNamesToHyperlinks', () => {
+  it('should convert Jira tickets to hyperlinks', () => {
+    const input =
+      'This is a string with mixed content.\r\n' +
+      'This is a ticket name not yet formatted DM-41184.\r\n' +
+      'This is an already parsed link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n';
+    const expectedOutput =
+      'This is a string with mixed content.\r\n' +
+      `This is a ticket name not yet formatted [DM-41184|${JIRA_TICKETS_BASE_URL}/DM-41184].\r\n` +
+      'This is an already parsed link [DM-41184|https://jira.lsstcorp.org/browse/DM-41184].\r\n';
+    expect(convertJiraTicketNamesToHyperlinks(input)).toEqual(expectedOutput);
   });
 });

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -38,6 +38,8 @@ import ManagerInterface, {
   jiraMarkdownToHtml,
   getObsDayFromDate,
   formatOLETimeOfIncident,
+  pipe,
+  convertJiraTicketNamesToHyperlinks,
 } from 'Utils';
 
 import OrderableTable from 'components/GeneralPurpose/OrderableTable/OrderableTable';
@@ -215,7 +217,8 @@ export default class NonExposure extends Component {
         className: styles.tableHead,
         render: (value, row) => {
           const files = getFilesURLs(row.urls);
-          const parsedValue = jiraMarkdownToHtml(value);
+          // We ensure to convert Jira ticket names to hyperlinks before converting the markdown to html
+          const parsedValue = pipe(convertJiraTicketNamesToHyperlinks, jiraMarkdownToHtml)(value);
           return (
             <>
               <div


### PR DESCRIPTION
This PR makes some adjustments in order to fix a couple bad behaviors on the feature to convert Jira ticket names to hyperlinks. First, parsed hyperlinks were being iserted into logs saved in the database, which was not expected as this is only a feature to be seen on the UI, not persisted on logs, this was acomplished by removing the Jira tickets names parsing from the `htmlToJiraMarkdown` function. Second, a `pipe` function was added in order to concatenate two parsing functions, making first the Jira ticket names conversion to markdown hyperlinks and then the HTML conversion (for Quill compliance), note that this is now being parsed only in the section that shows the logs.