### PR TITLE
Fix value of MTHexapod_logevent_compensatedPosition.w setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.30.1
+-------
+
+* Fix value of MTHexapod_logevent_compensatedPosition.w setting `<https://github.com/lsst-ts/LOVE-frontend/pull/626>`_
+
 v5.30.0
 -------
 

--- a/love/src/components/MainTel/CameraHexapod/CameraHexapod.jsx
+++ b/love/src/components/MainTel/CameraHexapod/CameraHexapod.jsx
@@ -265,7 +265,7 @@ class CameraHexapod extends Component {
     dataHexapod[2].z = this.props.hexapodCompensationOffsetZ;
     dataHexapod[2].u = this.props.hexapodCompensationOffsetU;
     dataHexapod[2].v = this.props.hexapodCompensationOffsetV;
-    dataHexapod[2].w = this.props.hexapodCompensationOffsetZ;
+    dataHexapod[2].w = this.props.hexapodCompensationOffsetW;
 
     const compensation = this.props.hexapodCompensationMode;
     const newDataHexapod = dataHexapod.filter((val, index) => index !== 2 || (index === 2 && compensation === true));


### PR DESCRIPTION
This PR makes a small fix to the `CameraHexapod` component so the `MTHexapod_logevent_compensatedPosition.w` parameter is properly set.