### PR TITLE
Fix CameraCableWrap UI swapped limits and floating points

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.1
 -------
 
+* Fix CameraCableWrap UI swapped limits and floating points `<https://github.com/lsst-ts/LOVE-frontend/pull/628>`_
 * Fix value of MTHexapod_logevent_compensatedPosition.w setting `<https://github.com/lsst-ts/LOVE-frontend/pull/626>`_
 
 v5.30.0

--- a/love/src/components/MainTel/CableWraps/CableWraps.jsx
+++ b/love/src/components/MainTel/CableWraps/CableWraps.jsx
@@ -21,7 +21,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as d3 from 'd3';
 import { MAX_CCW_FOLLOWING_ERROR } from 'Constants';
-import { defaultNumberFormatter } from 'Utils';
+import { fixedFloat } from 'Utils';
 import CSCDetail from 'components/CSCSummary/CSCDetail/CSCDetail';
 import styles from './CableWraps.module.css';
 import CameraCableWrap from './CameraCableWrap/CameraCableWrap';
@@ -120,8 +120,8 @@ class CableWraps extends Component {
     const rotatorSummaryState = CSCDetail.states[this.props.rotatorSummaryState];
     const mountSummaryState = CSCDetail.states[this.props.mountSummaryState];
     const cameraCableWrapState = CSCDetail.states[this.props.cameraCableWrapState];
-    const rotatorPosition = defaultNumberFormatter(this.props.rotatorPosition ?? 0);
-    const ccwPosition = defaultNumberFormatter(this.props.ccwPosition ?? 0);
+    const rotatorPosition = fixedFloat(this.props.rotatorPosition ?? 0, 4);
+    const ccwPosition = fixedFloat(this.props.ccwPosition ?? 0, 4);
 
     return (
       <div className={styles.cableWrapsContainer}>

--- a/love/src/components/MainTel/CableWraps/CameraCableWrap/CameraCableWrap.jsx
+++ b/love/src/components/MainTel/CableWraps/CameraCableWrap/CameraCableWrap.jsx
@@ -93,7 +93,7 @@ class CameraCableWrap extends Component {
     this.ccwArc = ccwArc;
 
     const theta = degrees(Math.PI / 2);
-    this.props.drawLimits(g, radio, theta, -theta);
+    this.props.drawLimits(g, radio, -theta, theta);
 
     this.background = this.g
       .append('path')


### PR DESCRIPTION
This PR makes a couple fixes on the CameraCableWrap component. First, the floating points were fixed to 4, but if the received value was an integer, floating points were dismissed, this generated a visual difference when comparing both values (check [LOVE-328](https://rubinobs.atlassian.net/browse/LOVE-328)). Also both limits of the component were swapped, so they were adjusted.

[LOVE-328]: https://rubinobs.atlassian.net/browse/LOVE-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ