### PR TITLE
Couple improvements for sizing big logs for the NonExposure component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.1
 -------
 
+* Couple improvements for sizing big logs for the NonExposure component `<https://github.com/lsst-ts/LOVE-frontend/pull/629>`_
 * UI/UX Improvements for the night report feature `<https://github.com/lsst-ts/LOVE-frontend/pull/627>`_
 * Fix CameraCableWrap UI swapped limits and floating points `<https://github.com/lsst-ts/LOVE-frontend/pull/628>`_
 * Fix value of MTHexapod_logevent_compensatedPosition.w setting `<https://github.com/lsst-ts/LOVE-frontend/pull/626>`_

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1927,9 +1927,7 @@ export function htmlToJiraMarkdown(html) {
   // markdown = markdown.replace(/<\/li>/g, '\n');
 
   // Parse &nbsp;
-  // Ensure to remove special &nbsp; characters
-  // Added either by a copied and pasted text from an user
-  // or by the html2jiraMarkdown function.
+  // Ensure to remove special &nbsp; characters if present
   markdown = markdown.replace(/&nbsp;/g, ' ');
 
   // Parse rest of stuff
@@ -2017,18 +2015,6 @@ export function jiraMarkdownToHtml(markdown, options = { codeFriendly: true }) {
 
     // Otherwise return the line as a paragraph
     return `<p>${p2}</p>`;
-  });
-
-  // Parse white spaces
-  // This is done to avoid white spaces being stripped by Quill,
-  // by adding non-breaking spaces. This doesn't add non-breaking
-  // spaces inside html tags to avoid breaking the html structure.
-  // Special characters are removed then on the htmlToJiraMarkdown
-  // function.
-  // This is a workaround for an issue with Quill JS. See:
-  // https://github.com/quilljs/quill/issues/1751
-  html = html.replace(/>([^<]+)</g, function (match) {
-    return match.replace(/ /g, '&nbsp;');
   });
 
   // Parse empty line

--- a/love/src/Utils.test.js
+++ b/love/src/Utils.test.js
@@ -72,13 +72,13 @@ describe('jiraMarkdownToHtml', () => {
   it('should handle links', () => {
     const input = 'This is a [link to site|https://example.com].\r\n';
     const expectedOutput =
-      '<p>This&nbsp;is&nbsp;a&nbsp;<a href="https://example.com" rel="noopener noreferrer" target="_blank">link&nbsp;to&nbsp;site</a>.</p>';
+      '<p>This is a <a href="https://example.com" rel="noopener noreferrer" target="_blank">link to site</a>.</p>';
     expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 
   it('should handle headings', () => {
     const input = 'h1. This is a heading.\r\n';
-    const expectedOutput = '<p><h1>This&nbsp;is&nbsp;a&nbsp;heading.</h1></p>';
+    const expectedOutput = '<p><h1>This is a heading.</h1></p>';
     expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 
@@ -88,9 +88,9 @@ describe('jiraMarkdownToHtml', () => {
       'h1. This is a heading.\r\n' +
       'This is a [link to site|http://google.com/].\r\n';
     const expectedOutput =
-      '<p>This&nbsp;is&nbsp;a&nbsp;string&nbsp;with&nbsp;mixed&nbsp;content</p>' +
-      '<p><h1>This&nbsp;is&nbsp;a&nbsp;heading.</h1></p>' +
-      '<p>This&nbsp;is&nbsp;a&nbsp;<a href="http://google.com/" rel="noopener noreferrer" target="_blank">link&nbsp;to&nbsp;site</a>.</p>';
+      '<p>This is a string with mixed content</p>' +
+      '<p><h1>This is a heading.</h1></p>' +
+      '<p>This is a <a href="http://google.com/" rel="noopener noreferrer" target="_blank">link to site</a>.</p>';
     expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 
@@ -102,29 +102,30 @@ describe('jiraMarkdownToHtml', () => {
       '\t\tThis is a double indented line.\r\n' +
       '\t\t\tThis is a triple indented line.\r\n';
     const expectedOutput =
-      '<p>This&nbsp;is&nbsp;a&nbsp;string&nbsp;with&nbsp;mixed&nbsp;content</p>' +
-      '<p><h1>This&nbsp;is&nbsp;a&nbsp;heading.</h1></p>' +
-      '<p>This&nbsp;is&nbsp;a&nbsp;<a href="http://google.com/" rel="noopener noreferrer" target="_blank">link&nbsp;to&nbsp;site</a>.</p>' +
-      '<p class="ql-indent-1">This&nbsp;is&nbsp;an&nbsp;indented&nbsp;line.</p>' +
-      '<p class="ql-indent-2">This&nbsp;is&nbsp;a&nbsp;double&nbsp;indented&nbsp;line.</p>' +
-      '<p class="ql-indent-3">This&nbsp;is&nbsp;a&nbsp;triple&nbsp;indented&nbsp;line.</p>';
+      '<p>This is a string with mixed content</p>' +
+      '<p><h1>This is a heading.</h1></p>' +
+      '<p>This is a <a href="http://google.com/" rel="noopener noreferrer" target="_blank">link to site</a>.</p>' +
+      '<p class="ql-indent-1">This is an indented line.</p>' +
+      '<p class="ql-indent-2">This is a double indented line.</p>' +
+      '<p class="ql-indent-3">This is a triple indented line.</p>';
     expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 
   it('should handle indentation with spaces', () => {
     const input =
       'This is a string with mixed content\r\n' +
-      'h1. This is a heading.\r\nThis is a [link to site|http://google.com/].\r\n' +
+      'h1. This is a heading.\r\n' +
+      'This is a [link to site|http://google.com/].\r\n' +
       '    This is an indented line.\r\n' +
       '        This is a double indented line.\r\n' +
       '            This is a triple indented line.\r\n';
     const expectedOutput =
-      '<p>This&nbsp;is&nbsp;a&nbsp;string&nbsp;with&nbsp;mixed&nbsp;content</p>' +
-      '<p><h1>This&nbsp;is&nbsp;a&nbsp;heading.</h1></p>' +
-      '<p>This&nbsp;is&nbsp;a&nbsp;<a href="http://google.com/" rel="noopener noreferrer" target="_blank">link&nbsp;to&nbsp;site</a>.</p>' +
-      '<p>&nbsp;&nbsp;&nbsp;&nbsp;This&nbsp;is&nbsp;an&nbsp;indented&nbsp;line.</p>' +
-      '<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This&nbsp;is&nbsp;a&nbsp;double&nbsp;indented&nbsp;line.</p>' +
-      '<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This&nbsp;is&nbsp;a&nbsp;triple&nbsp;indented&nbsp;line.</p>';
+      '<p>This is a string with mixed content</p>' +
+      '<p><h1>This is a heading.</h1></p>' +
+      '<p>This is a <a href="http://google.com/" rel="noopener noreferrer" target="_blank">link to site</a>.</p>' +
+      '<p>    This is an indented line.</p>' +
+      '<p>        This is a double indented line.</p>' +
+      '<p>            This is a triple indented line.</p>';
     expect(jiraMarkdownToHtml(input, options)).toEqual(expectedOutput);
   });
 });

--- a/love/src/components/OLE/NonExposure/NonExposure.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposure.jsx
@@ -214,7 +214,7 @@ export default class NonExposure extends Component {
         field: 'message_text',
         title: 'Message',
         type: 'string',
-        className: styles.tableHead,
+        className: [styles.tableHead, styles.messageColumn].join(' '),
         render: (value, row) => {
           const files = getFilesURLs(row.urls);
           // We ensure to convert Jira ticket names to hyperlinks before converting the markdown to html

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -402,6 +402,11 @@ th.tableHead {
   font-weight: bold;
 }
 
+th.messageColumn,
+td.messageColumn {
+  max-width: 60em;
+}
+
 .iconFill {
   fill: var(--default-font-color);
 }

--- a/love/src/components/OLE/NonExposure/NonExposure.module.css
+++ b/love/src/components/OLE/NonExposure/NonExposure.module.css
@@ -65,17 +65,9 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 }
 
 .content {
-  --grid-layout-gap: 5px;
-  --grid-column-count: 2;
-  --grid-item--min-width: 640px;
-
-  --gap-count: calc(var(--grid-column-count) - 1);
-  --total-gap-width: calc(var(--gap-count) * var(--grid-layout-gap));
-  --grid-item--max-width: calc((100% - var(--total-gap-width)) / var(--grid-column-count));
-
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(max(var(--grid-item--min-width), var(--grid-item--max-width)), 1fr));
-  grid-row: auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: var(--content-padding);
 }
 
 .contentMenu {
@@ -93,17 +85,13 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   grid-template-columns: 1fr 2fr;
   grid-auto-rows: max-content;
   grid-row-gap: 1em;
-  padding-top: 15px;
   margin-left: var(--content-padding);
 }
 
 .description {
   background-color: var(--second-quaternary-background-color);
   border-radius: 6px;
-  display: flexbox;
-  margin: 7px;
   padding: var(--content-padding);
-  margin-right: 0;
 }
 
 .footer {

--- a/love/src/index.css
+++ b/love/src/index.css
@@ -375,3 +375,14 @@ body {
 .Toastify__toast.Toastify__toast--error .Toastify__progress-bar {
   background-color: var(--status-alert-color);
 }
+
+/* Quill */
+.ql-clipboard {
+  left: -100000px;
+  height: 1px;
+  overflow-y: hidden;
+  position: absolute;
+  top: 50%;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
This PR add some code fixes which improves the way big logs are rendered on the `NonExposure` component. It also fixes an issue with the React Quill editor (385f8a06eb1bcdee088524618db0a92bbf7118e4) that stripped white spaces at the beginning of each line of a log, the fix was retrieved from https://github.com/quilljs/quill/issues/1752#issuecomment-1006681723.