### PR TITLE
Adjust Auxtel Mount SummaryPanel component to start using ATPneumatics_mainAirSourcePressure topic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.1
 -------
 
+* Adjust Auxtel Mount SummaryPanel component to start using ATPneumatics_mainAirSourcePressure topic `<https://github.com/lsst-ts/LOVE-frontend/pull/630>`_
 * Couple improvements for sizing big logs for the NonExposure component `<https://github.com/lsst-ts/LOVE-frontend/pull/629>`_
 * UI/UX Improvements for the night report feature `<https://github.com/lsst-ts/LOVE-frontend/pull/627>`_
 * Fix CameraCableWrap UI swapped limits and floating points `<https://github.com/lsst-ts/LOVE-frontend/pull/628>`_

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -111,13 +111,10 @@ export const MTMountLimits = {
 };
 
 export const ATPneumaticsLimits = {
-  cellLoad: {
-    min: 3.83,
-    max: 117.8,
-  },
-  pressure: {
-    min: 47160.14,
-    max: 182159.49,
+  mainAirSourcePressure: {
+    /* Measured in Pa */
+    min: 275790,
+    max: 413000,
   },
 };
 

--- a/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.container.jsx
+++ b/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.container.jsx
@@ -35,30 +35,6 @@ export const schema = {
       isPrivate: false,
       default: 'AT summary',
     },
-    cellLoadMin: {
-      type: 'number',
-      description: 'Min cell load value as a number',
-      isPrivate: false,
-      default: 3.83,
-    },
-    cellLoadMax: {
-      type: 'number',
-      description: 'Max cell load value as a number',
-      isPrivate: false,
-      default: 117.8,
-    },
-    pressureMin: {
-      type: 'number',
-      description: 'Min pressure value as a number',
-      isPrivate: false,
-      default: 47160.14,
-    },
-    pressureMax: {
-      type: 'number',
-      description: 'Max pressure value as a number',
-      isPrivate: false,
-      default: 182159.49,
-    },
     EUI: {
       type: 'boolean',
       description: 'Whether the component has a EUI link',

--- a/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.jsx
+++ b/love/src/components/AuxTel/Mount/SummaryPanel/SummaryPanel.jsx
@@ -56,6 +56,7 @@ export default class SummaryTable extends Component {
     dropoutDoorState: PropTypes.number,
     mainDoorState: PropTypes.number,
     mountTrackingState: PropTypes.number,
+    systemAirPressure: PropTypes.number,
   };
 
   static defaultProps = {};
@@ -224,33 +225,18 @@ export default class SummaryTable extends Component {
           <StatusText status={stateToStyleMount[instrumentState]}>{instrumentState}</StatusText>
         </Value>
 
-        <Label>Cell load</Label>
-        <Value>{this.props.loadCell}</Value>
+        <Label>Total Air Pressure</Label>
+        <Value>{this.props.systemAirPressure}</Value>
         <Row>
           <Limits
-            lowerLimit={this.props.cellLoadMin}
-            upperLimit={this.props.cellLoadMax}
-            currentValue={this.props.loadCell.value}
+            lowerLimit={ATPneumaticsLimits.mainAirSourcePressure.min}
+            upperLimit={ATPneumaticsLimits.mainAirSourcePressure.max}
+            currentValue={this.props.systemAirPressure.value}
             targetValue="Unknown"
             height={30}
             displayLabels={true}
-            displayLabelsUnit=" kg"
-            limitWarning={4.2}
-          />
-        </Row>
-
-        <Label>M1 Air pressure</Label>
-        <Value>{this.props.m1AirPressure}</Value>
-        <Row>
-          <Limits
-            lowerLimit={this.props.pressureMin}
-            upperLimit={this.props.pressureMax}
-            currentValue={this.props.m1AirPressure.value}
-            targetValue={this.props.m1SetPressure}
-            height={30}
-            displayLabels={true}
             displayLabelsUnit=" Pa"
-            limitWarning={5000}
+            limitWarning={7000}
           />
         </Row>
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -628,8 +628,7 @@ export const getMountSubscriptions = (index) => {
     `event-ATPneumatics-${index}-instrumentState`,
     `event-ATPneumatics-${index}-m1CoverLimitSwitches`,
     `event-ATPneumatics-${index}-m1VentsLimitSwitches`,
-    `telemetry-ATPneumatics-${index}-loadCell`,
-    `telemetry-ATPneumatics-${index}-m1AirPressure`,
+    `telemetry-ATPneumatics-${index}-mainAirSourcePressure`,
     // ATMCS
     `event-ATMCS-${index}-m3InPosition`,
     `event-ATMCS-${index}-m3State`,
@@ -671,8 +670,10 @@ export const getMountState = (state, index) => {
   const hexapodReadyForCommand = mountData[`event-ATPneumatics-${index}-readyForCommand`];
   const m1VentsLimitSwitches = mountData[`event-ATPneumatics-${index}-m1VentsLimitSwitches`];
   const m1CoverLimitSwitches = mountData[`event-ATPneumatics-${index}-m1CoverLimitSwitches`];
+  const systemAirPressure = mountData[`telemetry-ATPneumatics-${index}-mainAirSourcePressure`];
   const correctionOffsets = mountData[`event-ATAOS-${index}-correctionOffsets`];
   const correctionEnabled = mountData[`event-ATAOS-${index}-correctionEnabled`];
+
   return {
     // ATHexapod
     hexapodInPosition: hexapodInPosition ? hexapodInPosition[hexapodInPosition.length - 1].inPosition.value : 0,
@@ -693,12 +694,7 @@ export const getMountState = (state, index) => {
     instrumentState: instrumentState ? instrumentState[instrumentState.length - 1].state.value : 0,
     m1CoverLimitSwitches: m1CoverLimitSwitches ? m1CoverLimitSwitches[m1CoverLimitSwitches.length - 1] : {},
     m1VentsLimitSwitches: m1VentsLimitSwitches ? m1VentsLimitSwitches[m1VentsLimitSwitches.length - 1] : {},
-    loadCell: mountData[`telemetry-ATPneumatics-${index}-loadCell`]
-      ? mountData[`telemetry-ATPneumatics-${index}-loadCell`].cellLoad
-      : 'Unknown',
-    m1AirPressure: mountData[`telemetry-ATPneumatics-${index}-m1AirPressure`]
-      ? mountData[`telemetry-ATPneumatics-${index}-m1AirPressure`].pressure
-      : 'Unknown',
+    systemAirPressure: systemAirPressure?.pressure ?? {},
     // ATMCS
     m3InPosition: m3InPosition ? m3InPosition[m3InPosition.length - 1].inPosition.value : 0,
     nasmyth1RotatorInPosition: nasmyth1RotatorInPosition


### PR DESCRIPTION
This PR removes two old topics that were not giving too much information: `ATPneumatics_cellLoad` and `ATPneumatics_m1AirPressure`. In replacement the `ATPneumatics_mainAirSourcePressure`topic was added into a bar-limit UI. Details on: [LOVE-312](https://rubinobs.atlassian.net/browse/LOVE-312).

[LOVE-312]: https://rubinobs.atlassian.net/browse/LOVE-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ