### PR TITLE
Memoize DigitalClock and AnalogClock components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.30.2
+-------
+
+* Memoize DigitalClock and AnalogClock components `<https://github.com/lsst-ts/LOVE-frontend/pull/632>`_
+
 v5.30.1
 -------
 

--- a/love/src/components/GeneralPurpose/AnalogClock/AnalogClock.jsx
+++ b/love/src/components/GeneralPurpose/AnalogClock/AnalogClock.jsx
@@ -17,24 +17,10 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import React from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import styles from './AnalogClock.module.css';
-import { DateTime } from 'luxon';
 import { parseTimestamp } from '../../../Utils';
-
-/**
- * Component that displays time and optionally the date below
- */
-AnalogClock.propTypes = {
-  /** Date-able object or float, if float it must be in milliseconds */
-  timestamp: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
-};
-
-AnalogClock.defaultProps = {
-  timestamp: DateTime.local(),
-  showDate: true,
-};
 
 const renderMarkers = () => {
   const markers = [];
@@ -81,7 +67,7 @@ const renderMarkers = () => {
   return markers;
 };
 
-export default function AnalogClock({ timestamp }) {
+const AnalogClock = memo(function AnalogClock({ timestamp }) {
   const t = parseTimestamp(timestamp);
   const markers = renderMarkers();
   const second = t.second;
@@ -117,4 +103,14 @@ export default function AnalogClock({ timestamp }) {
       </g>
     </svg>
   );
-}
+});
+
+/**
+ * Component that displays time and optionally the date below
+ */
+AnalogClock.propTypes = {
+  /** Date-able object or float, if float it must be in milliseconds */
+  timestamp: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
+};
+
+export default AnalogClock;

--- a/love/src/components/GeneralPurpose/DigitalClock/DigitalClock.jsx
+++ b/love/src/components/GeneralPurpose/DigitalClock/DigitalClock.jsx
@@ -17,28 +17,15 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import React from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import styles from './DigitalClock.module.css';
-import { DateTime } from 'luxon';
 import { parseTimestamp } from '../../../Utils';
 
 /**
  * Component that displays time and optionally the date below
  */
-DigitalClock.propTypes = {
-  /** Date-able object or float, if float it must be in milliseconds */
-  timestamp: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
-  /** Flag to hide or not the date, false by default */
-  hideDate: PropTypes.bool,
-};
-
-DigitalClock.defaultProps = {
-  timestamp: DateTime.local(),
-  hideDate: false,
-};
-
-export default function DigitalClock({ timestamp, hideDate }) {
+const DigitalClock = memo(function DigitalClock({ timestamp, hideDate }) {
   const t = timestamp === 0 ? 0 : parseTimestamp(timestamp);
   return (
     <div className={styles.container}>
@@ -46,4 +33,13 @@ export default function DigitalClock({ timestamp, hideDate }) {
       {!hideDate && <div className={styles.date}>{t ? t.toFormat('EEE, MMM dd yyyy') : '---'}</div>}
     </div>
   );
-}
+});
+
+DigitalClock.propTypes = {
+  /** Date-able object or float, if float it must be in milliseconds */
+  timestamp: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
+  /** Flag to hide or not the date, false by default */
+  hideDate: PropTypes.bool,
+};
+
+export default DigitalClock;


### PR DESCRIPTION
This PR adds the React.memo function to the `DigitalClock` and `AnalogClock` components to improve the rendering of both components.