### PR TITLE
Remove unused heartbeats subscription on TMA, M2 and M2Table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v5.30.2
 -------
 
+* Remove unused heartbeats subscription on TMA, M2 and M2Table `<https://github.com/lsst-ts/LOVE-frontend/pull/633>`_
 * Memoize DigitalClock and AnalogClock components `<https://github.com/lsst-ts/LOVE-frontend/pull/632>`_
 
 v5.30.1

--- a/love/src/components/MainTel/M2/M2.container.jsx
+++ b/love/src/components/MainTel/M2/M2.container.jsx
@@ -84,7 +84,6 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   const subscriptions = [
-    'event-Heartbeat-0-stream',
     'event-MTM2-0-commandableByDDS',
     'event-MTM2-0-forceBalanceSystemStatus',
     'event-MTM2-0-inclinationTelemetrySource',

--- a/love/src/components/MainTel/M2/M2Table.container.jsx
+++ b/love/src/components/MainTel/M2/M2Table.container.jsx
@@ -64,7 +64,6 @@ const mapDispatchToProps = (dispatch) => {
     'telemetry-MTM2-0-netMomentsTotal',
     'telemetry-MTM2-0-position',
     'telemetry-MTM2-0-positionIMS',
-    'event-Heartbeat-0-stream',
   ];
   return {
     subscriptions,

--- a/love/src/components/MainTel/TMA/TMA.container.jsx
+++ b/love/src/components/MainTel/TMA/TMA.container.jsx
@@ -91,7 +91,6 @@ const mapDispatchToProps = (dispatch) => {
     'event-MTMount-0-elevationSystemState',
     'event-MTMount-0-mirrorCoversMotionState',
     'event-MTMount-0-target',
-    'event-Heartbeat-0-stream',
     'event-MTMount-0-summaryState',
   ];
   return {


### PR DESCRIPTION
This PR removes a special heartbeats subscription on the `TMA`, `M2` and `M2Table` components. This subscription starts listening to all heartbeats of all CSCs, generating unnecessary load on the components.