### PR TITLE
Refactor ScriptQueueState payload into several

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v5.30.3
+-------
+
+* Refactor ScriptQueueState payload into several `<https://github.com/lsst-ts/LOVE-frontend/pull/639>`_
+
 v5.30.2
 -------
 

--- a/love/src/components/ScriptQueue/ScriptQueue.container.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.container.jsx
@@ -121,7 +121,9 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   const subscriptions = [
-    `event-ScriptQueueState-${ownProps.salindex}-stream`,
+    `event-ScriptQueueState-${ownProps.salindex}-stateStream`,
+    `event-ScriptQueueState-${ownProps.salindex}-scriptsStream`,
+    `event-ScriptQueueState-${ownProps.salindex}-availableScriptsStream`,
     `event-ScriptQueue-${ownProps.salindex}-summaryState`,
     `event-ScriptHeartbeats-${ownProps.salindex}-stream`,
     `event-ScriptQueue-${ownProps.salindex}-authList`,

--- a/love/src/redux/actions/ws.js
+++ b/love/src/redux/actions/ws.js
@@ -258,8 +258,8 @@ export const openWebsocketConnection = () => {
           }
 
           if (data.data[0].csc === 'ScriptQueueState') {
-            if (stream.stream.finished_scripts) {
-              const finishedIndices = stream.stream.finished_scripts.map((script) => script.index);
+            if (stream.scriptsStream?.finished_scripts) {
+              const finishedIndices = stream.scriptsStream.finished_scripts.map((script) => script.index);
               dispatch(removeScriptsHeartbeats(finishedIndices));
             }
           }

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -2458,7 +2458,9 @@ export const getKey = (dict, key, def) => {
 };
 
 export const getScriptQueueState = (state, salindex) => {
-  const scriptQueueData = getStreamData(state, `event-ScriptQueueState-${salindex}-stream`);
+  const scriptQueueData = getStreamData(state, `event-ScriptQueueState-${salindex}-stateStream`);
+  const scriptsData = getStreamData(state, `event-ScriptQueueState-${salindex}-scriptsStream`);
+  const availableScriptsData = getStreamData(state, `event-ScriptQueueState-${salindex}-availableScriptsStream`);
   const runningState = getKey(scriptQueueData, 'running', undefined);
   let runningLabel = 'Unknown';
   if (runningState !== undefined) {
@@ -2466,10 +2468,13 @@ export const getScriptQueueState = (state, salindex) => {
   }
   return {
     state: runningLabel,
-    availableScriptList: getKey(scriptQueueData, 'available_scripts', undefined),
-    waitingScriptList: getKey(scriptQueueData, 'waiting_scripts', undefined),
-    current: getKey(scriptQueueData, 'current', 'None'),
-    finishedScriptList: getKey(scriptQueueData, 'finished_scripts', undefined),
+    availableScriptList: getKey(availableScriptsData, 'available_scripts', undefined),
+    waitingScriptList: getKey(scriptsData, 'waiting_scripts', undefined),
+    // The ScriptQueue CSC will be extended to support multiple
+    // current scripts in the future. For now, only one is supported.
+    // See: DM-44198.
+    current: getKey(scriptsData, 'current_scripts', ['None'])[0],
+    finishedScriptList: getKey(scriptsData, 'finished_scripts', undefined),
   };
 };
 

--- a/love/src/redux/tests/heartbeats.test.js
+++ b/love/src/redux/tests/heartbeats.test.js
@@ -30,7 +30,7 @@ import {
   getCSCHeartbeats,
   getCSCHeartbeat,
 } from '../selectors';
-import * as mockData from './mock';
+import { ScriptsStateData } from './mock';
 import { HEARTBEAT_COMPONENTS } from '../../Config';
 
 let store;
@@ -251,7 +251,7 @@ it(`GIVEN 3 script heartbeats in the State,
 
   let expectedState = [];
   // Act:
-  server.send(mockData.ScriptQueueData);
+  server.send(ScriptsStateData);
   // Assert:
   expectedState = [mockHeartbeats[0], mockHeartbeats[2]];
   const heartbeatsState = getScriptHeartbeats(store.getState(), 1);

--- a/love/src/redux/tests/mock.js
+++ b/love/src/redux/tests/mock.js
@@ -17,18 +17,47 @@ You should have received a copy of the GNU General Public License along with
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export const ScriptQueueData = {
+export const ScriptQueueStateData = {
   category: 'event',
   data: [
     {
       csc: 'ScriptQueueState',
       salindex: 1,
       data: {
-        stream: {
-          max_lost_heartbeats: 5,
-          heartbeat_timeout: 15,
+        stateStream: {
+          // max_lost_heartbeats: 5,
+          // heartbeat_timeout: 15,
+          enabled: true,
+          running: true,
+        },
+      },
+    },
+  ],
+};
+
+export const AvailableScriptsStateData = {
+  category: 'event',
+  data: [
+    {
+      csc: 'ScriptQueueState',
+      salindex: 1,
+      data: {
+        availableScriptsStream: {
           available_scripts: [],
-          state: 'Running',
+        },
+      },
+    },
+  ],
+};
+
+export const ScriptsStateData = {
+  category: 'event',
+  data: [
+    {
+      csc: 'ScriptQueueState',
+      salindex: 1,
+      data: {
+        scriptsStream: {
           finished_scripts: [
             {
               index: 100001,
@@ -67,23 +96,25 @@ export const ScriptQueueData = {
               timestampRunStart: 0.0,
             },
           ],
-          current: {
-            index: 100000,
-            script_state: 'RUNNING',
-            process_state: 'RUNNING',
-            elapsed_time: 0,
-            expected_duration: 3600.0,
-            type: 'standard',
-            path: 'script1',
-            lost_heartbeats: 0,
-            setup: true,
-            last_heartbeat_timestamp: 1562278041.481556,
-            timestampConfigureEnd: 1562275970.2090635,
-            timestampConfigureStart: 1562275970.099327,
-            timestampProcessEnd: 0.0,
-            timestampProcessStart: 1562275966.864108,
-            timestampRunStart: 1562275970.2094963,
-          },
+          current_scripts: [
+            {
+              index: 100000,
+              script_state: 'RUNNING',
+              process_state: 'RUNNING',
+              elapsed_time: 0,
+              expected_duration: 3600.0,
+              type: 'standard',
+              path: 'script1',
+              lost_heartbeats: 0,
+              setup: true,
+              last_heartbeat_timestamp: 1562278041.481556,
+              timestampConfigureEnd: 1562275970.2090635,
+              timestampConfigureStart: 1562275970.099327,
+              timestampProcessEnd: 0.0,
+              timestampProcessStart: 1562275966.864108,
+              timestampRunStart: 1562275970.2094963,
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
This PR separates the ScriptQueueState payload into three different topics:

- `event-ScriptQueueState-stateStream`
- `event-ScriptQueueState-scriptsStream`
- `event-ScriptQueueState-availableScriptsStream`