### PR TITLE
Add dashboard name to page title

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Version History
 ===============
 
-v6.0.1
+v6.1.0
 ------
 
+* Add dashboard name to page title `<https://github.com/lsst-ts/LOVE-frontend/pull/644>`_
 * Fix Weatherforecast last 48 hours feature `<https://github.com/lsst-ts/LOVE-frontend/pull/643>`_
 * Update CSC hierarchy by removing Archiver references and adding missing CSCs `<https://github.com/lsst-ts/LOVE-frontend/pull/642>`_
 

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -254,6 +254,11 @@ class Layout extends Component {
     if (this.state.heartbeatStatus?.[managerKey] === 'alert' && prevState.heartbeatStatus?.[managerKey] !== 'alert') {
       this.props.resetSubscriptions();
     }
+
+    // Update the title of the page
+    if (this.state.title !== prevState.title) {
+      document.title = this.state.title ? `LOVE - ${this.state.title}` : 'LOVE';
+    }
   };
 
   moveCustomTopbar = () => {


### PR DESCRIPTION
This PR extends the `Layout` component to update the page/tab title with the name of the current displayed dashboard. This way it will be easier for Operators to identify the dasbhoards they currently have open and access specific ones.