### PR TITLE
Rename Confluence URL to Night Plan URL on the CreateNightReport component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.1.1
 ------
 
+* Rename Confluence URL to Night Plan URL on the CreateNightReport component `<https://github.com/lsst-ts/LOVE-frontend/pull/649>`_
 * Bump ws from 7.5.9 to 7.5.10 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/648>`_
 * Bump braces from 3.0.2 to 3.0.3 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/647>`_
 * Bump ejs from 3.1.9 to 3.1.10 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/638>`_

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -99,7 +99,7 @@ function TelescopeStatusField({ isEditDisabled, telescopeStatus, setTelescopeSta
 function ConfluenceURLField({ isEditDisabled, confluenceURL, setConfluenceURL }) {
   return (
     <div className={styles.inputField}>
-      <div>Confluence URL</div>
+      <div>Night Plan URL</div>
       <Input disabled={isEditDisabled} value={confluenceURL} onChange={(e) => setConfluenceURL(e.target.value)} />
     </div>
   );


### PR DESCRIPTION
This PR renames the `Confluence URL` field per `Night Plan URL` as it is a more general name and will avoid confusions due to not using confluence pages for night planning anymore (and use Zephyr Scale links instead).