### PR TITLE
Add visual cue on CSCDetail and CSCExpanded to identify CSCs on simulation mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.2.0
+------
+
+* Add visual cue on CSCDetail and CSCExpanded to identify CSCs on simulation mode `<https://github.com/lsst-ts/LOVE-frontend/pull/651>`_
+
 v6.1.1
 ------
 

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
@@ -135,16 +135,13 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const withWarning = getCSCWithWarning(state, ownProps.name, ownProps.salindex);
-  let summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`);
-  let heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
   const serverTime = getServerTime(state);
-  if (!summaryStateData) {
-    summaryStateData = {};
-  }
+  const withWarning = getCSCWithWarning(state, ownProps.name, ownProps.salindex);
+  const heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
+  const summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`)?.[0];
 
   return {
-    summaryStateData: summaryStateData[0],
+    summaryStateData,
     heartbeatData,
     withWarning,
     serverTime,

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
@@ -92,6 +92,7 @@ const CSCDetailContainer = ({
   serverTime,
   embedded,
   withWarning,
+  simulationMode,
   isRaw,
   subscriptions,
 }) => {
@@ -112,6 +113,7 @@ const CSCDetailContainer = ({
       embedded={embedded}
       withWarning={withWarning}
       serverTime={serverTime}
+      simulationMode={simulationMode}
     />
   );
 };
@@ -121,6 +123,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     `event-${ownProps.name}-${ownProps.salindex}-summaryState`,
     `event-${ownProps.name}-${ownProps.salindex}-logMessage`,
     `event-${ownProps.name}-${ownProps.salindex}-errorCode`,
+    `event-${ownProps.name}-${ownProps.salindex}-simulationMode`,
     `event-Heartbeat-0-stream`,
   ];
   return {
@@ -139,9 +142,11 @@ const mapStateToProps = (state, ownProps) => {
   const withWarning = getCSCWithWarning(state, ownProps.name, ownProps.salindex);
   const heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
   const summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`)?.[0];
+  const simulationMode = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-simulationMode`)?.[0];
 
   return {
     summaryStateData,
+    simulationMode,
     heartbeatData,
     withWarning,
     serverTime,

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
@@ -26,23 +26,41 @@ import styles from './CSCDetail.module.css';
 
 export default class CSCDetail extends Component {
   static propTypes = {
+    /** Name of the CSC */
     name: PropTypes.string,
+    /** Belonging group of the CSC */
     group: PropTypes.string,
+    /** Index of the CSC */
     salindex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /** Function to execute when the CSC is clicked
+     * It will be called with an object containing the following keys:
+     * - group: The group of the CSC
+     * - csc: The name of the CSC
+     * - salindex: The index of the CSC
+     */
     onCSCClick: PropTypes.func,
+    /** Heartbeat stream */
     heartbeatData: PropTypes.object,
+    /** Summary State stream */
     summaryStateData: PropTypes.object,
+    /** Function to subscribe to streams */
     subscribeToStreams: PropTypes.func,
+    /** Function to unsubscribe to streams */
     unsubscribeToStreams: PropTypes.func,
+    /** Whereas to apply a minWidth */
     embedded: PropTypes.bool,
+    /** Make heartbeat display optional  */
+    hasHeartbeat: PropTypes.bool,
+    /** Whereas to show a warning icon */
+    withWarning: PropTypes.bool,
+    /** Server time object */
+    serverTime: PropTypes.object,
   };
 
   static defaultProps = {
     name: '',
     group: '',
-    onCSCClick: () => 0,
-    heartbeatData: null,
-    summaryStateData: undefined,
+    onCSCClick: () => {},
     subscribeToStreams: () => {},
     unsubscribeToStreams: () => {},
     embedded: false,

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
@@ -55,6 +55,8 @@ export default class CSCDetail extends Component {
     withWarning: PropTypes.bool,
     /** Server time object */
     serverTime: PropTypes.object,
+    /** Simulation Mode stream */
+    simulationMode: PropTypes.object,
   };
 
   static defaultProps = {
@@ -129,6 +131,7 @@ export default class CSCDetail extends Component {
       hasHeartbeat,
       withWarning,
       serverTime,
+      simulationMode,
     } = this.props;
     let heartbeatStatus = 'unknown';
     let nLost = 0;
@@ -172,10 +175,15 @@ export default class CSCDetail extends Component {
     }
 
     const heartbeatIsOk = heartbeatStatus === 'ok';
+    const isSimulated = simulationMode?.mode.value > 0;
     return (
       <div
         onClick={() => onCSCClick({ group: group, csc: name, salindex: salindex })}
-        className={[styles.CSCDetailContainer, embedded ? styles.minWidth : ''].join(' ')}
+        className={[
+          styles.CSCDetailContainer,
+          embedded ? styles.minWidth : '',
+          isSimulated ? styles.simulated : '',
+        ].join(' ')}
       >
         <div className={[styles.summaryStateSection, summaryState.class].join(' ')}>
           <span className={styles.summaryState} title={summaryState.userReadable}>
@@ -188,7 +196,10 @@ export default class CSCDetail extends Component {
           </div>
         </div>
 
-        <div className={[styles.nameSection, stateClass].join(' ')} title={name + '.' + salindex}>
+        <div
+          className={[styles.nameSection, stateClass].join(' ')}
+          title={name + '.' + salindex + (isSimulated ? ' (SIMULATED)' : '')}
+        >
           {cscText(name, salindex)}
         </div>
 

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
@@ -106,27 +106,40 @@ export default class CSCDetail extends Component {
   };
 
   componentDidMount = () => {
-    this.props.subscribeToStreams(this.props.name, this.props.salindex);
+    const { name, salindex, subscribeToStreams } = this.props;
+    subscribeToStreams(name, salindex);
   };
 
   componentWillUnmount = () => {
-    this.props.unsubscribeToStreams(this.props.name, this.props.salindex);
+    const { name, salindex, unsubscribeToStreams } = this.props;
+    unsubscribeToStreams(name, salindex);
   };
 
   render() {
-    const { props } = this;
+    const {
+      group,
+      name,
+      salindex,
+      summaryStateData,
+      heartbeatData,
+      onCSCClick,
+      embedded,
+      hasHeartbeat,
+      withWarning,
+      serverTime,
+    } = this.props;
     let heartbeatStatus = 'unknown';
     let nLost = 0;
     let timeDiff = null;
     let timeDiffText = 'No heartbeat from producer.';
 
-    if (this.props.heartbeatData) {
-      nLost = this.props.heartbeatData.lost;
-      if (this.props.heartbeatData.last_heartbeat_timestamp === -1) timeDiff = -1;
-      else timeDiff = Math.ceil(props.serverTime.tai * 1000 - this.props.heartbeatData.last_heartbeat_timestamp);
-      heartbeatStatus = this.props.heartbeatData.lost > 0 || timeDiff < 0 ? 'alert' : 'ok';
+    if (heartbeatData) {
+      nLost = heartbeatData.lost;
+      if (heartbeatData.last_heartbeat_timestamp === -1) timeDiff = -1;
+      else timeDiff = Math.ceil(serverTime.tai * 1000 - heartbeatData.last_heartbeat_timestamp);
+      heartbeatStatus = heartbeatData.lost > 0 || timeDiff < 0 ? 'alert' : 'ok';
     }
-    if (props.hasHeartbeat === false) {
+    if (hasHeartbeat === false) {
       heartbeatStatus = 'ok';
     }
 
@@ -136,22 +149,22 @@ export default class CSCDetail extends Component {
       timeDiffText = timeDiff < 0 ? 'Stale' : `${timeDiff} seconds ago`;
     }
 
-    let title = `${cscText(this.props.name, this.props.salindex)} heartbeat\nLost: ${nLost}\n`;
+    let title = `${cscText(name, salindex)} heartbeat\nLost: ${nLost}\n`;
 
     if (timeDiff === null) {
       title += `${timeDiffText}`;
     } else {
       title += timeDiff < 0 ? `Last seen: ${timeDiffText}` : `${timeDiffText}`;
     }
-    const summaryStateValue = this.props.summaryStateData ? this.props.summaryStateData.summaryState.value : 0;
+    const summaryStateValue = summaryStateData ? summaryStateData.summaryState.value : 0;
     const summaryState = CSCDetail.states[summaryStateValue];
     let stateClass = heartbeatStatus === 'alert' ? styles.alert : summaryState.class;
     if (heartbeatStatus === 'unknown') stateClass = CSCDetail.states[0].class;
     if (summaryState.name === 'UNKNOWN') stateClass = CSCDetail.states[0].class;
     return (
       <div
-        onClick={() => this.props.onCSCClick({ group: props.group, csc: props.name, salindex: props.salindex })}
-        className={[styles.CSCDetailContainer, this.props.embedded ? styles.minWidth : ''].join(' ')}
+        onClick={() => onCSCClick({ group: group, csc: name, salindex: salindex })}
+        className={[styles.CSCDetailContainer, embedded ? styles.minWidth : ''].join(' ')}
       >
         <div className={[styles.summaryStateSection, summaryState.class].join(' ')}>
           <span className={styles.summaryState} title={summaryState.userReadable}>
@@ -162,22 +175,22 @@ export default class CSCDetail extends Component {
           <div
             className={[
               styles.heartbeatIconWrapper,
-              heartbeatStatus === 'ok' && props.hasHeartbeat !== false ? styles.hidden : '',
+              heartbeatStatus === 'ok' && hasHeartbeat !== false ? styles.hidden : '',
             ].join(' ')}
           >
             <HeartbeatIcon
-              status={heartbeatStatus === 'alert' || props.hasHeartbeat === false ? 'unknown' : heartbeatStatus}
+              status={heartbeatStatus === 'alert' || hasHeartbeat === false ? 'unknown' : heartbeatStatus}
               title={title}
             />
           </div>
         </div>
 
-        <div className={[styles.nameSection, stateClass].join(' ')} title={this.props.name + '.' + this.props.salindex}>
-          {cscText(this.props.name, this.props.salindex)}
+        <div className={[styles.nameSection, stateClass].join(' ')} title={name + '.' + salindex}>
+          {cscText(name, salindex)}
         </div>
 
         <div className={[styles.warningIconSection, stateClass].join(' ')}>
-          <div className={[styles.warningIconWrapper, props.withWarning !== true ? styles.hidden : ''].join(' ')}>
+          <div className={[styles.warningIconWrapper, withWarning !== true ? styles.hidden : ''].join(' ')}>
             <WarningIcon title="warning" />
           </div>
         </div>

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.jsx
@@ -29,30 +29,23 @@ export default class CSCDetail extends Component {
     name: PropTypes.string,
     group: PropTypes.string,
     salindex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    data: PropTypes.object,
     onCSCClick: PropTypes.func,
     heartbeatData: PropTypes.object,
     summaryStateData: PropTypes.object,
     subscribeToStreams: PropTypes.func,
     unsubscribeToStreams: PropTypes.func,
     embedded: PropTypes.bool,
-    /* Whether the component should subscribe to streams*/
-    shouldSubscribe: PropTypes.bool,
-    isRaw: PropTypes.bool,
   };
 
   static defaultProps = {
     name: '',
     group: '',
-    data: {},
     onCSCClick: () => 0,
     heartbeatData: null,
     summaryStateData: undefined,
     subscribeToStreams: () => {},
     unsubscribeToStreams: () => {},
     embedded: false,
-    shouldSubscribe: true,
-    isRaw: false,
   };
 
   static states = {

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.module.css
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.module.css
@@ -141,3 +141,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .hidden {
   display: none;
 }
+
+.simulated {
+  border: 0.2em dashed var(--info-background-color);
+}

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -85,6 +85,7 @@ const CSCExpandedContainer = ({
   subscribeToStreams,
   unsubscribeToStreams,
   heartbeatData,
+  simulationMode,
   displaySummaryState = true,
   hideTitle = false,
 }) => {
@@ -107,6 +108,7 @@ const CSCExpandedContainer = ({
       logMessageData={logMessageData}
       heartbeatData={heartbeatData}
       clearCSCLogMessages={clearCSCLogMessages}
+      simulationMode={simulationMode}
       displaySummaryState={displaySummaryState}
       hideTitle={hideTitle}
     />
@@ -124,6 +126,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(addGroup(`event-${cscName}-${index}-softwareVersions`));
       dispatch(addGroup(`event-${cscName}-${index}-configurationsAvailable`));
       dispatch(addGroup(`event-${cscName}-${index}-configurationApplied`));
+      dispatch(addGroup(`event-${cscName}-${index}-simulationMode`));
     },
     unsubscribeToStreams: (cscName, index) => {
       dispatch(removeGroup('event-Heartbeat-0-stream'));
@@ -134,6 +137,7 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(removeGroup(`event-${cscName}-${index}-softwareVersions`));
       dispatch(removeGroup(`event-${cscName}-${index}-configurationsAvailable`));
       dispatch(removeGroup(`event-${cscName}-${index}-configurationApplied`));
+      dispatch(removeGroup(`event-${cscName}-${index}-simulationMode`));
     },
     clearCSCLogMessages: (csc, salindex) => {
       dispatch(removeCSCLogMessages(csc, salindex));
@@ -152,29 +156,30 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  let summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`);
-  let heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
-  let softwareVersions = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-softwareVersions`);
-  let configurationsAvailable = getStreamData(
+  const heartbeatData = getCSCHeartbeat(state, ownProps.name, ownProps.salindex);
+  const logMessageData = getCSCLogMessages(state, ownProps.name, ownProps.salindex);
+  const errorCodeData = getCSCErrorCodeData(state, ownProps.name, ownProps.salindex);
+
+  const summaryStateData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-summaryState`);
+  const softwareVersions = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-softwareVersions`);
+  const configurationsAvailable = getStreamData(
     state,
     `event-${ownProps.name}-${ownProps.salindex}-configurationsAvailable`,
   );
-  let configurationApplied = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-configurationApplied`);
-  let cscLogLevelData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-logLevel`);
-
-  const logMessageData = getCSCLogMessages(state, ownProps.name, ownProps.salindex);
-  const errorCodeData = getCSCErrorCodeData(state, ownProps.name, ownProps.salindex);
-  summaryStateData = summaryStateData ? summaryStateData : {};
+  const configurationApplied = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-configurationApplied`);
+  const cscLogLevelData = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-logLevel`);
+  const simulationMode = getStreamData(state, `event-${ownProps.name}-${ownProps.salindex}-simulationMode`);
 
   return {
-    summaryStateData: summaryStateData ? summaryStateData?.[0] : undefined,
-    softwareVersions: softwareVersions ? softwareVersions?.[0] : undefined,
-    configurationsAvailable: configurationsAvailable ? configurationsAvailable?.[0] : undefined,
-    configurationApplied: configurationApplied ? configurationApplied?.[0] : undefined,
-    cscLogLevelData: cscLogLevelData ? cscLogLevelData?.[0] : undefined,
     heartbeatData,
     logMessageData,
     errorCodeData,
+    summaryStateData: summaryStateData?.[0],
+    softwareVersions: softwareVersions?.[0],
+    configurationsAvailable: configurationsAvailable?.[0],
+    configurationApplied: configurationApplied?.[0],
+    cscLogLevelData: cscLogLevelData?.[0],
+    simulationMode: simulationMode?.[0],
   };
 };
 

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -70,6 +70,8 @@ export default class CSCExpanded extends PureComponent {
     configurationsAvailable: PropTypes.object,
     /** CSC Log Level stream */
     cscLogLevelData: PropTypes.object,
+    /** Simulation Mode stream */
+    simulationMode: PropTypes.object,
     /** Function to subscribe to streams */
     subscribeToStreams: PropTypes.func,
     /** Function to unsubscribe to streams */
@@ -84,16 +86,12 @@ export default class CSCExpanded extends PureComponent {
     name: '',
     salindex: undefined,
     group: '',
-    onCSCClick: () => 0,
-    clearCSCErrorCodes: () => 0,
-    clearCSCLogMessages: () => 0,
-    requestSALCommand: () => 0,
-    summaryStateData: undefined,
-    softwareVersions: undefined,
-    configurationsAvailable: undefined,
+    onCSCClick: () => {},
+    clearCSCErrorCodes: () => {},
+    clearCSCLogMessages: () => {},
+    requestSALCommand: () => {},
     logMessageData: [],
     errorCodeData: [],
-    cscLogLevelData: undefined,
   };
 
   componentDidMount = () => {
@@ -228,8 +226,9 @@ export default class CSCExpanded extends PureComponent {
       summaryStateData,
       softwareVersions,
       configurationsAvailable: configurationsAvailableData,
-      cscLogLevelData,
       configurationApplied: configurationAppliedData,
+      cscLogLevelData,
+      simulationMode,
       heartbeatData,
       logMessageData,
       errorCodeData,
@@ -287,6 +286,7 @@ export default class CSCExpanded extends PureComponent {
       heartbeatTitle += `Last seen: ${timeDiffText}`;
     }
 
+    const isSimulated = simulationMode?.mode.value > 0;
     return (
       <div className={styles.CSCGroupContainer}>
         <div className={styles.CSCExpandedContainer}>
@@ -304,7 +304,12 @@ export default class CSCExpanded extends PureComponent {
                     <span> &#62; </span>
                   </>
                 )}
-                {!hideTitle && <span>{cscText(name, salindex)}</span>}
+                {!hideTitle && (
+                  <>
+                    <span>{cscText(name, salindex)}</span>
+                    {isSimulated ? <span className={styles.simulatedLabel}> (SIMULATED)</span> : ''}
+                  </>
+                )}
               </div>
               {displaySummaryState && (
                 <div className={[styles.stateContainer].join(' ')}>

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -39,22 +39,45 @@ export default class CSCExpanded extends PureComponent {
   }
 
   static propTypes = {
+    /** Name of the CSC */
     name: PropTypes.string,
+    /** Index of the CSC */
     salindex: PropTypes.number,
+    /** Belonging group of the CSC */
     group: PropTypes.string,
+    /** Function to execute when the CSC is clicked
+     * It will be called with an object containing the following keys:
+     * - group: The group of the CSC
+     * - csc: The name of the CSC
+     * - salindex: The index of the CSC
+     */
     onCSCClick: PropTypes.func,
+    /** Function to clear the error codes */
     clearCSCErrorCodes: PropTypes.func,
+    /** Function to clear the log messages */
     clearCSCLogMessages: PropTypes.func,
+    /** Function to send SAL commands */
     requestSALCommand: PropTypes.func,
+    /** Summary State stream */
     summaryStateData: PropTypes.object,
+    /** Log Messages array */
     logMessageData: PropTypes.array,
+    /** Error code array */
     errorCodeData: PropTypes.array,
+    /** Software versions stream */
     softwareVersions: PropTypes.object,
+    /** Configuration applied stream */
     configurationsAvailable: PropTypes.object,
+    /** CSC Log Level stream */
+    cscLogLevelData: PropTypes.object,
+    /** Function to subscribe to streams */
     subscribeToStreams: PropTypes.func,
+    /** Function to unsubscribe to streams */
     unsubscribeToStreams: PropTypes.func,
-    summaryStateCommand: PropTypes.string,
-    cscLogLevelData: PropTypes.number,
+    /** Whether to display the summary state */
+    displaySummaryState: PropTypes.bool,
+    /** Whether to display the title of  */
+    hideTitle: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -70,7 +93,6 @@ export default class CSCExpanded extends PureComponent {
     configurationsAvailable: undefined,
     logMessageData: [],
     errorCodeData: [],
-    summaryStateCommand: undefined,
     cscLogLevelData: undefined,
   };
 

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -97,17 +97,20 @@ export default class CSCExpanded extends PureComponent {
   };
 
   componentDidMount = () => {
-    this.props.subscribeToStreams(this.props.name, this.props.salindex);
+    const { name, salindex, subscribeToStreams } = this.props;
+    subscribeToStreams(name, salindex);
   };
 
   componentWillUnmount = () => {
-    this.props.unsubscribeToStreams(this.props.name, this.props.salindex);
+    const { name, salindex, unsubscribeToStreams } = this.props;
+    unsubscribeToStreams(name, salindex);
   };
 
   componentDidUpdate = (prevProps, prevState) => {
-    if (prevProps.name !== this.props.name || prevProps.salindex !== this.props.salindex) {
-      this.props.unsubscribeToStreams(prevProps.name, prevProps.salindex);
-      this.props.subscribeToStreams(this.props.name, this.props.salindex);
+    const { name, salindex, subscribeToStreams, unsubscribeToStreams } = this.props;
+    if (prevProps.name !== name || prevProps.salindex !== salindex) {
+      unsubscribeToStreams(prevProps.name, prevProps.salindex);
+      subscribeToStreams(name, salindex);
     }
   };
 
@@ -196,68 +199,80 @@ export default class CSCExpanded extends PureComponent {
   }
 
   sendSummaryStateCommand(event) {
-    this.props.requestSALCommand({
-      cmd: `cmd_${this.state.summaryStateCommand}`,
-      csc: this.props.name,
-      salindex: this.props.salindex,
-      params:
-        this.state.summaryStateCommand === 'start'
-          ? {
-              configurationOverride: this.state.configurationOverride,
-            }
-          : {},
+    const { name, salindex, requestSALCommand } = this.props;
+    const { summaryStateCommand, configurationOverride } = this.state;
+    requestSALCommand({
+      cmd: `cmd_${summaryStateCommand}`,
+      csc: name,
+      salindex: salindex,
+      params: summaryStateCommand === 'start' ? { configurationOverride } : {},
     });
   }
 
   sendSetLogLevel(event) {
-    this.props.requestSALCommand({
+    const { name, salindex, requestSALCommand } = this.props;
+    const { logLevel } = this.state;
+    requestSALCommand({
       cmd: 'cmd_setLogLevel',
-      csc: this.props.name,
-      salindex: this.props.salindex,
-      params: {
-        level: this.state.logLevel,
-      },
+      csc: name,
+      salindex: salindex,
+      params: { level: logLevel },
     });
   }
 
   render() {
-    const summaryStateValue = this.props.summaryStateData ? this.props.summaryStateData.summaryState.value : 0;
-    const cscVersion = this.props.softwareVersions ? this.props.softwareVersions.cscVersion.value : 'Unknown';
-    const xmlVersion = this.props.softwareVersions ? this.props.softwareVersions.xmlVersion.value : 'Unknown';
-    const salVersion = this.props.softwareVersions ? this.props.softwareVersions.salVersion.value : 'Unknown';
-    const openSpliceVersion = this.props.softwareVersions
-      ? this.props.softwareVersions.openSpliceVersion.value
-      : 'Unknown';
-    const configurationsAvailable = this.props.configurationsAvailable
-      ? this.props.configurationsAvailable.overrides.value.split(',')
+    const {
+      group,
+      name,
+      salindex,
+      summaryStateData,
+      softwareVersions,
+      configurationsAvailable: configurationsAvailableData,
+      cscLogLevelData,
+      configurationApplied: configurationAppliedData,
+      heartbeatData,
+      logMessageData,
+      errorCodeData,
+      onCSCClick,
+      clearCSCErrorCodes,
+      clearCSCLogMessages,
+      displaySummaryState,
+      hideTitle,
+    } = this.props;
+    const { summaryStateCommand } = this.state;
+
+    const summaryStateValue = summaryStateData ? summaryStateData.summaryState.value : 0;
+    const cscVersion = softwareVersions ? softwareVersions.cscVersion.value : 'Unknown';
+    const xmlVersion = softwareVersions ? softwareVersions.xmlVersion.value : 'Unknown';
+    const salVersion = softwareVersions ? softwareVersions.salVersion.value : 'Unknown';
+    const openSpliceVersion = softwareVersions ? softwareVersions.openSpliceVersion.value : 'Unknown';
+    const configurationsAvailable = configurationsAvailableData
+      ? configurationsAvailableData.overrides.value.split(',')
       : null;
     const summaryState = CSCExpanded.states[summaryStateValue];
-    const cscLogLevel = this.props.cscLogLevelData ? this.props.cscLogLevelData.level.value : null;
+    const cscLogLevel = cscLogLevelData ? cscLogLevelData.level.value : null;
 
-    const configurationApplied = this.props.configurationApplied?.configurations.value;
-    const configurationVersion = this.props.configurationApplied?.version.value;
-    const configurationUrl = this.props.configurationApplied?.url.value;
-    const configurationSchemaVersion = this.props.configurationApplied?.schemaVersion.value;
-    const configurationOtherInfo = this.props.configurationApplied?.otherInfo.value.replaceAll(',', ', ');
+    const configurationApplied = configurationAppliedData?.configurations.value;
+    const configurationVersion = configurationAppliedData?.version.value;
+    const configurationUrl = configurationAppliedData?.url.value;
+    const configurationSchemaVersion = configurationAppliedData?.schemaVersion.value;
+    const configurationOtherInfo = configurationAppliedData?.otherInfo.value.replaceAll(',', ', ');
 
     const configurationsAvailableMenuOptions =
-      configurationsAvailable !== null && configurationsAvailable.length > 0
-        ? [...[''], ...configurationsAvailable]
-        : null;
+      configurationsAvailable?.length > 0 ? ['', ...configurationsAvailable] : null;
 
     let heartbeatStatus = 'unknown';
     let nLost = 0;
     let timeDiff = -1;
-    if (this.props.heartbeatData) {
-      nLost = this.props.heartbeatData.lost;
-      if (this.props.heartbeatData.last_heartbeat_timestamp < 0) timeDiff = -1;
-      if (this.props.heartbeatData.last_heartbeat_timestamp === -2) timeDiff = -2;
-      else timeDiff = Math.ceil(new Date().getTime() / 1000 - this.props.heartbeatData.last_heartbeat_timestamp);
-      heartbeatStatus = this.props.heartbeatData.lost > 0 || timeDiff < 0 ? 'alert' : 'ok';
+    if (heartbeatData) {
+      nLost = heartbeatData.lost;
+      if (heartbeatData.last_heartbeat_timestamp < 0) timeDiff = -1;
+      if (heartbeatData.last_heartbeat_timestamp === -2) timeDiff = -2;
+      else timeDiff = Math.ceil(new Date().getTime() / 1000 - heartbeatData.last_heartbeat_timestamp);
+      heartbeatStatus = heartbeatData.lost > 0 || timeDiff < 0 ? 'alert' : 'ok';
     }
 
     let timeDiffText = 'Unknown';
-
     if (timeDiff === -2) {
       timeDiffText = 'No heartbeat event in Remote.';
     } else if (timeDiff === -1) {
@@ -266,8 +281,7 @@ export default class CSCExpanded extends PureComponent {
       timeDiffText = timeDiff < 0 ? 'Never' : `${timeDiff} seconds ago`;
     }
 
-    let heartbeatTitle = `${cscText(this.props.name, this.props.salindex)} heartbeat\nLost: ${nLost}\n`;
-
+    let heartbeatTitle = `${cscText(name, salindex)} heartbeat\nLost: ${nLost}\n`;
     if (timeDiff === -2) {
       heartbeatTitle += `${timeDiffText}`;
     } else {
@@ -280,26 +294,20 @@ export default class CSCExpanded extends PureComponent {
           <div className={styles.topBarContainerWrapper}>
             <div className={styles.topBarContainer}>
               <div className={styles.breadcrumContainer}>
-                {this.props.group && (
+                {group && (
                   <>
-                    <div
-                      className={styles.backArrowIconWrapper}
-                      onClick={() => this.props.onCSCClick({ group: this.props.group })}
-                    >
+                    <div className={styles.backArrowIconWrapper} onClick={() => onCSCClick({ group: group })}>
                       <BackArrowIcon />
                     </div>
-                    <span
-                      className={styles.breadcrumbGroup}
-                      onClick={() => this.props.onCSCClick({ group: this.props.group, csc: 'all' })}
-                    >
-                      {this.props.group}
+                    <span className={styles.breadcrumbGroup} onClick={() => onCSCClick({ group: group, csc: 'all' })}>
+                      {group}
                     </span>
                     <span> &#62; </span>
                   </>
                 )}
-                {!this.props.hideTitle && <span>{cscText(this.props.name, this.props.salindex)}</span>}
+                {!hideTitle && <span>{cscText(name, salindex)}</span>}
               </div>
-              {this.props.displaySummaryState && (
+              {displaySummaryState && (
                 <div className={[styles.stateContainer].join(' ')}>
                   <div>
                     <span
@@ -316,7 +324,7 @@ export default class CSCExpanded extends PureComponent {
               )}
             </div>
           </div>
-          {this.props.name !== 'Script' && (
+          {name !== 'Script' && (
             <div className={styles.topBarContainerWrapper}>
               <div className={styles.topBarContainer}>
                 <div className={styles.breadcrumContainer}>
@@ -328,7 +336,7 @@ export default class CSCExpanded extends PureComponent {
               </div>
             </div>
           )}
-          {this.props.name !== 'Script' && this.props.configurationApplied && (
+          {name !== 'Script' && configurationApplied && (
             <div className={styles.topBarContainerWrapper}>
               <div className={styles.topBarContainer}>
                 <div className={styles.breadcrumContainer}>
@@ -346,7 +354,7 @@ export default class CSCExpanded extends PureComponent {
               </div>
             </div>
           )}
-          {this.props.name !== 'Script' && (
+          {name !== 'Script' && (
             <div className={styles.topBarContainerWrapper}>
               <div className={styles.topBarContainer}>
                 <div className={styles.breadcrumContainer}>
@@ -358,7 +366,7 @@ export default class CSCExpanded extends PureComponent {
                     placeholder="Select state"
                   />
                 </div>
-                {configurationsAvailableMenuOptions !== null && this.state.summaryStateCommand === 'start' && (
+                {configurationsAvailableMenuOptions !== null && summaryStateCommand === 'start' && (
                   <div className={styles.breadcrumContainer}>
                     <div className={styles.titlePadding}>Configurations available:</div>
                     <Select
@@ -376,7 +384,7 @@ export default class CSCExpanded extends PureComponent {
                     status="info"
                     shape="rounder"
                     padding="30px"
-                    disabled={this.state.summaryStateCommand === null}
+                    disabled={summaryStateCommand === null}
                     onClick={(event) => {
                       this.sendSummaryStateCommand(event);
                     }}
@@ -389,7 +397,7 @@ export default class CSCExpanded extends PureComponent {
             </div>
           )}
 
-          {this.state.summaryStateCommand !== null && (
+          {summaryStateCommand !== null && (
             <div className={styles.topBarContainerWrapper}>
               <div className={styles.topBarContainer}>
                 <div className={styles.breadcrumContainer}>
@@ -398,7 +406,7 @@ export default class CSCExpanded extends PureComponent {
                       <span className={styles.warningIcon}>
                         <WarningIcon></WarningIcon>
                       </span>
-                      <span>CSC must be in {CSCExpanded.validState[this.state.summaryStateCommand]}.</span>
+                      <span>CSC must be in {CSCExpanded.validState[summaryStateCommand]}.</span>
                     </span>
                   </div>
                 </div>
@@ -406,7 +414,7 @@ export default class CSCExpanded extends PureComponent {
             </div>
           )}
 
-          {(cscLogLevel !== null || this.props.name === 'Script') && (
+          {(cscLogLevel !== null || name === 'Script') && (
             <div className={styles.topBarContainerWrapper}>
               <div className={styles.topBarContainer}>
                 <div className={styles.breadcrumContainer}>
@@ -445,21 +453,18 @@ export default class CSCExpanded extends PureComponent {
             </div>
           )}
 
-          {this.props.errorCodeData.length > 0 && (
+          {errorCodeData.length > 0 && (
             <div className={[styles.logContainer, styles.errorCodeContainer].join(' ')}>
               <div className={styles.logContainerTopBar}>
                 <div>ERROR CODE</div>
                 <div>
-                  <Button
-                    size="extra-small"
-                    onClick={() => this.props.clearCSCErrorCodes(this.props.name, this.props.salindex)}
-                  >
+                  <Button size="extra-small" onClick={() => clearCSCErrorCodes(name, salindex)}>
                     CLEAR
                   </Button>
                 </div>
               </div>
               <div className={[styles.log, styles.messageLogContent].join(' ')}>
-                {this.props.errorCodeData.map((msg, index) => {
+                {errorCodeData.map((msg, index) => {
                   return (
                     <div key={`${msg.private_rcvStamp.value}-${index}`} className={styles.logMessage}>
                       <div className={styles.errorCode} title={`Error code ${msg.errorCode.value}`}>
@@ -480,8 +485,8 @@ export default class CSCExpanded extends PureComponent {
           )}
 
           <LogMessageDisplay
-            logMessageData={this.props.logMessageData}
-            clearCSCLogMessages={() => this.props.clearCSCLogMessages(this.props.name, this.props.salindex)}
+            logMessageData={logMessageData}
+            clearCSCLogMessages={() => clearCSCLogMessages(name, salindex)}
           />
         </div>
       </div>

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -256,7 +256,6 @@ export default class CSCExpanded extends PureComponent {
     const configurationVersion = configurationAppliedData?.version.value;
     const configurationUrl = configurationAppliedData?.url.value;
     const configurationSchemaVersion = configurationAppliedData?.schemaVersion.value;
-    const configurationOtherInfo = configurationAppliedData?.otherInfo.value.replaceAll(',', ', ');
 
     const configurationsAvailableMenuOptions =
       configurationsAvailable?.length > 0 ? ['', ...configurationsAvailable] : null;
@@ -347,9 +346,6 @@ export default class CSCExpanded extends PureComponent {
                       {configurationUrl}
                     </a>
                   </div>
-                  {/* <div className={styles.titlePadding}>
-                    Configurations applied other info: {configurationOtherInfo}
-                  </div> */}
                 </div>
               </div>
             </div>

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.module.css
@@ -294,3 +294,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 .preText {
   white-space: pre-wrap;
 }
+
+.simulatedLabel {
+  font-weight: bold;
+  color: var(--info-background-color);
+}


### PR DESCRIPTION
This PR extends the `CSCDetail` and `CSCExpanded` components to read the `logevent_simulationMode` event and provide a visual cue for those CSCs which have the simulation mode enabled. Also the code of both components was refactored for better readability.