### PR TITLE
Adjust polling rate for external services queries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.2.0
 ------
 
+* Adjust polling rate for external services queries `<https://github.com/lsst-ts/LOVE-frontend/pull/653>`_
 * Add visual cue on CSCDetail and CSCExpanded to identify CSCs on simulation mode `<https://github.com/lsst-ts/LOVE-frontend/pull/651>`_
 
 v6.1.1

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -26,6 +26,9 @@ export const SUBPATH = process.env.PUBLIC_URL ?? '';
 // Commands Configurations
 export const hasCommandPrivileges = true;
 
+// Time rate for polling external APIs
+export const POLLING_RATE_MS = 10000;
+
 // LOVE components to monitor heartbeats
 export const HEARTBEAT_COMPONENTS = {
   MANAGER: 'Manager',

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -36,7 +36,7 @@ import ManagerInterface, {
   parseTimestamp,
   formatTimestamp,
 } from 'Utils';
-import { severityEnum } from 'Config';
+import { severityEnum, POLLING_RATE_MS } from 'Config';
 
 import { viewsStates, modes } from '../../redux/reducers/uif';
 import { tokenSwapStates } from '../../redux/reducers/auth';
@@ -167,15 +167,19 @@ class Layout extends Component {
 
     this.heartbeatInterval = setInterval(() => {
       this.checkHeartbeat();
+    }, 3000);
+
+    this.externalServicesInterval = setInterval(() => {
       this.checkEfdStatus();
       this.checkSALStatus();
-    }, 3000);
+    }, POLLING_RATE_MS);
   };
 
   componentWillUnmount = () => {
     document.removeEventListener('mousedown', this.handleClick, false);
     window.removeEventListener('resize', this.handleResize);
     window.clearInterval(this.heartbeatInterval);
+    window.clearInterval(this.externalServicesInterval);
     this.props.unsubscribeToStreams();
     this.props.stopControlLocationLoop();
   };


### PR DESCRIPTION
This PR increases the time interval for querying external services, currently: EFD and Sasquatch Rest APIs. A configuration constant `POLLING_RATE_MS` was added for this purpose.