### PR TITLE
Fix observers dropdown on the NightReport component

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.2.0
 ------
 
+* Fix observers dropdown on the NightReport component `<https://github.com/lsst-ts/LOVE-frontend/pull/655>`_
 * Fix M1M3 force dropdown selection behavior `<https://github.com/lsst-ts/LOVE-frontend/pull/654>`_
 * Adjust polling rate for external services queries `<https://github.com/lsst-ts/LOVE-frontend/pull/653>`_
 * Add visual cue on CSCDetail and CSCExpanded to identify CSCs on simulation mode `<https://github.com/lsst-ts/LOVE-frontend/pull/651>`_

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -9,7 +9,7 @@ import TextArea from 'components/GeneralPurpose/TextArea/TextArea';
 import Input from 'components/GeneralPurpose/Input/Input';
 import styles from './CreateNightReport.module.css';
 
-const MULTI_SELECT_OPTION_LENGHT = 50;
+const MULTI_SELECT_OPTION_LENGTH = 50;
 const LAST_REFRESHED_WARNING_THRESHOLD = 180;
 const STATE_UPDATE_INTERVAL = 5000;
 
@@ -55,7 +55,7 @@ function ProgressBarSection({ currentStep, currentStatusText }) {
 
 function ObserversField({ isEditDisabled, userOptions, selectedUsers, setSelectedUsers }) {
   const memoizedSelectedValueDecorator = useCallback(
-    (v) => (v.length > MULTI_SELECT_OPTION_LENGHT ? `...${v.slice(-MULTI_SELECT_OPTION_LENGHT)}` : v),
+    (v) => (v.length > MULTI_SELECT_OPTION_LENGTH ? `...${v.slice(-MULTI_SELECT_OPTION_LENGTH)}` : v),
     [],
   );
   return (

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -53,13 +53,12 @@ function ProgressBarSection({ currentStep, currentStatusText }) {
   );
 }
 
-function ObserversField({ isEditDisabled, observersFieldRef, userOptions, selectedUsers, setSelectedUsers }) {
+function ObserversField({ isEditDisabled, userOptions, selectedUsers, setSelectedUsers }) {
   return (
     <>
       <div>Observers</div>
       <MultiSelect
         disable={isEditDisabled}
-        innerRef={observersFieldRef}
         options={userOptions}
         selectedValues={selectedUsers}
         onSelect={setSelectedUsers}
@@ -129,7 +128,6 @@ function AlertsSection({ refreshWarningActive, changesNotSaved }) {
 }
 
 function AuxTelForm() {
-  const observersFieldRef = useRef();
   const [currentStep, setCurrentStep] = useState(STEPS.NOTSAVED);
   const [userOptions, setUserOptions] = useState([]);
   const [selectedUsers, setSelectedUsers] = useState([]);
@@ -260,7 +258,6 @@ function AuxTelForm() {
 
       <ObserversField
         isEditDisabled={isEditDisabled()}
-        observersFieldRef={observersFieldRef}
         userOptions={userOptions}
         selectedUsers={selectedUsers}
         setSelectedUsers={handleSelectedUsersChange}
@@ -295,7 +292,6 @@ function AuxTelForm() {
 }
 
 function SimonyiForm() {
-  const observersFieldRef = useRef();
   const [currentStep, setCurrentStep] = useState(STEPS.NOTSAVED);
   const [userOptions, setUserOptions] = useState([]);
   const [selectedUsers, setSelectedUsers] = useState([]);
@@ -430,7 +426,6 @@ function SimonyiForm() {
 
       <ObserversField
         isEditDisabled={isEditDisabled()}
-        observersFieldRef={observersFieldRef}
         userOptions={userOptions}
         selectedUsers={selectedUsers}
         setSelectedUsers={handleSelectedUsersChange}

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'moment';
 import ManagerInterface from 'Utils';
@@ -230,10 +230,10 @@ function AuxTelForm() {
     return currentStep === STEPS.SENT;
   };
 
-  const handleSelectedUsersChange = (newSelectedUsers) => {
+  const handleSelectedUsersChange = useCallback((newSelectedUsers) => {
     setSelectedUsers(newSelectedUsers);
     setChangesNotSaved(true);
-  };
+  }, []);
 
   const handleSummaryChange = (newSummary) => {
     setSummary(newSummary);
@@ -394,10 +394,10 @@ function SimonyiForm() {
     return currentStep === STEPS.SENT;
   };
 
-  const handleSelectedUsersChange = (newSelectedUsers) => {
+  const handleSelectedUsersChange = useCallback((newSelectedUsers) => {
     setSelectedUsers(newSelectedUsers);
     setChangesNotSaved(true);
-  };
+  }, []);
 
   const handleSummaryChange = (newSummary) => {
     setSummary(newSummary);

--- a/love/src/components/NightReport/CreateNightReport.jsx
+++ b/love/src/components/NightReport/CreateNightReport.jsx
@@ -54,6 +54,10 @@ function ProgressBarSection({ currentStep, currentStatusText }) {
 }
 
 function ObserversField({ isEditDisabled, userOptions, selectedUsers, setSelectedUsers }) {
+  const memoizedSelectedValueDecorator = useCallback(
+    (v) => (v.length > MULTI_SELECT_OPTION_LENGHT ? `...${v.slice(-MULTI_SELECT_OPTION_LENGHT)}` : v),
+    [],
+  );
   return (
     <>
       <div>Observers</div>
@@ -64,9 +68,7 @@ function ObserversField({ isEditDisabled, userOptions, selectedUsers, setSelecte
         onSelect={setSelectedUsers}
         onRemove={setSelectedUsers}
         placeholder="Select users that participated on the report."
-        selectedValueDecorator={(v) =>
-          v.length > MULTI_SELECT_OPTION_LENGHT ? `...${v.slice(-MULTI_SELECT_OPTION_LENGHT)}` : v
-        }
+        selectedValueDecorator={memoizedSelectedValueDecorator}
       />
     </>
   );


### PR DESCRIPTION
This PR adds some memoization to properties used by the `MultiSelect` component on the `NightReport` component. As the `NightReport` has an interval that re-renders it for triggering alerts in case some time have passed, the `MultiSelect` component was being also re-rendered leading to unexpected behaviors as trying to select users and the dropdown being closed suddenly. By memoizing props we ensure the `MultiSelect` doesn't get re-rendered on parent renders.