### PR TITLE
Fix ATDome Nasmyth value display

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.3.0
 ------
 
+* Fix ATDome Nasmyth value display `<https://github.com/lsst-ts/LOVE-frontend/pull/659>`_
 * Fix GearIcon rendering on the Scheduler component `<https://github.com/lsst-ts/LOVE-frontend/pull/658>`_
 * Extend size of individual log message display `<https://github.com/lsst-ts/LOVE-frontend/pull/657>`_
 * Add RA, Dec and Rotator parameters to the ATDome component `<https://github.com/lsst-ts/LOVE-frontend/pull/656>`_

--- a/love/src/components/AuxTel/Dome/Dome.container.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.container.jsx
@@ -78,6 +78,14 @@ const DomeContainer = ({
   m3State,
   minEl,
   maxEl,
+  minAz,
+  maxAz,
+  minNas1,
+  maxNas1,
+  minNas2,
+  maxNas2,
+  minM3,
+  maxM3,
   timeAzLim,
   timeRotLim,
   timeUnobservable,
@@ -123,6 +131,14 @@ const DomeContainer = ({
       m3State={m3State}
       minEl={minEl}
       maxEl={maxEl}
+      minAz={minAz}
+      maxAz={maxAz}
+      minNas1={minNas1}
+      maxNas1={maxNas1}
+      minNas2={minNas2}
+      maxNas2={maxNas2}
+      minM3={minM3}
+      maxM3={maxM3}
       timeAzLim={timeAzLim}
       timeRotLim={timeRotLim}
       timeUnobservable={timeUnobservable}

--- a/love/src/components/AuxTel/Dome/Dome.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.jsx
@@ -69,20 +69,12 @@ export default class Dome extends Component {
     targetNasmyth2: PropTypes.number,
     /** M3 state */
     m3State: PropTypes.string,
-    /** Min elevation */
-    minEl: PropTypes.number,
-    /** Min azimuth */
-    minAz: PropTypes.number,
     /** Min nasmyth1 */
     minNas1: PropTypes.number,
     /** Min nasmyth2 */
     minNas2: PropTypes.number,
     /** Min M3 */
     minM3: PropTypes.number,
-    /** Max elevation */
-    maxEl: PropTypes.number,
-    /** Max azimuth */
-    maxAz: PropTypes.number,
     /** Max nasmyth1 */
     maxNas1: PropTypes.number,
     /** Max nasmyth2 */
@@ -292,13 +284,9 @@ export default class Dome extends Component {
       targetNasmyth1,
       targetNasmyth2,
       m3State,
-      // minEl,
-      minAz,
       minNas1,
       minNas2,
       minM3,
-      // maxEl,
-      maxAz,
       maxNas1,
       maxNas2,
       maxM3,
@@ -459,12 +447,12 @@ export default class Dome extends Component {
             timeUnobservable={timeUnobservable}
             timeElHighLimit={timeElHighLimit}
             maxEl={85}
-            maxAz={maxAz}
+            maxAz={360}
             maxNas1={maxNas1}
             maxNas2={maxNas2}
             maxM3={maxM3}
             minEl={5}
-            minAz={minAz}
+            minAz={0}
             minNas1={minNas1}
             minNas2={minNas2}
             minM3={minM3}

--- a/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
+++ b/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
@@ -98,12 +98,10 @@ export default class DomeSummaryTable extends Component {
       maxAz,
       maxNas1,
       maxNas2,
-      maxM3,
       minEl,
       minAz,
       minNas1,
       minNas2,
-      minM3,
       atDomeSummaryState,
       ATMCSSummaryState,
       domeTracking,
@@ -127,15 +125,15 @@ export default class DomeSummaryTable extends Component {
       m3State === 1
         ? {
             name: '(1)',
-            current: Math.abs(currentPointing.nasmyth1),
-            target: Math.abs(targetPointing.nasmyth1),
+            current: currentPointing.nasmyth1,
+            target: targetPointing.nasmyth1,
             minRot: minNas1,
             maxRot: maxNas1,
           }
         : {
             name: '(2)',
-            current: Math.abs(currentPointing.nasmyth2),
-            target: Math.abs(targetPointing.nasmyth2),
+            current: currentPointing.nasmyth2,
+            target: targetPointing.nasmyth2,
             minRot: minNas2,
             maxRot: maxNas2,
           };
@@ -196,22 +194,6 @@ export default class DomeSummaryTable extends Component {
         <Value>
           <CurrentTargetValue currentValue={domeAz.current} targetValue={domeAz.target} isChanging={true} />
         </Value>
-        {/* <span className={[styles.subRow, styles.wide].join(' ')} title={`Time to limit: ${2} min`}>
-          <span>
-            <Limits
-              lowerLimit={0}
-              upperLimit={360}
-              currentValue={domeAz.current}
-              targetValue={domeAz.target}
-              height={30}
-              displayLabels={false}
-            />
-          </span>
-          <span>
-            <span>Time to limit: </span>
-            <span className={styles.highlight}>2 min</span>
-          </span>
-        </span> */}
         {/* Mount */}
         <Title>ATMCS CSC</Title>
         <Value>


### PR DESCRIPTION
This PR fixes the Nasmyth display on the `DomeSummaryTable` component, as values were not being read from the telemetry and one value was being casted to its absolute whereas that shouldn't be done.

Some code cleaning and improvement on the `Dome` & `DomeSummaryTable` was done too.