### PR TITLE
Fix ampersand being parsed to html encoding by QuillJS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.3.0
 ------
 
+* Fix ampersand being parsed to html encoding by QuillJS `<https://github.com/lsst-ts/LOVE-frontend/pull/660>`_
 * Fix ATDome Nasmyth value display `<https://github.com/lsst-ts/LOVE-frontend/pull/659>`_
 * Fix GearIcon rendering on the Scheduler component `<https://github.com/lsst-ts/LOVE-frontend/pull/658>`_
 * Extend size of individual log message display `<https://github.com/lsst-ts/LOVE-frontend/pull/657>`_

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -209,6 +209,9 @@ class ExposureAdd extends Component {
       payload['tags'] = payload['tags'].map((tag) => tag.id);
     }
 
+    // Transform &amp; back to '&'. This is a workaround due to Quill editor encoding '&'.}
+    payload['message_text'] = payload['message_text'].replace(/&amp;/g, '&');
+
     this.setState({ savingLog: true });
     ManagerInterface.createMessageExposureLogs(payload).then((result) => {
       this.setState({ savingLog: false });

--- a/love/src/components/OLE/Exposure/ExposureDetail.jsx
+++ b/love/src/components/OLE/Exposure/ExposureDetail.jsx
@@ -89,6 +89,9 @@ export default class ExposureDetail extends Component {
       payload['tags'] = payload['tags'].map((tag) => tag.id);
     }
 
+    // Transform &amp; back to '&'. This is a workaround due to Quill editor encoding '&'.}
+    payload['message_text'] = payload['message_text'].replace(/&amp;/g, '&');
+
     ManagerInterface.updateMessageExposureLogs(message.id, payload).then((response) => {
       if (response) {
         this.setState((state) => {

--- a/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
+++ b/love/src/components/OLE/NonExposure/NonExposureEdit.jsx
@@ -227,6 +227,9 @@ class NonExposureEdit extends Component {
     payload['date_begin'] = beginDateISO.substring(0, beginDateISO.length - 1); // remove Zone due to backend standard
     payload['date_end'] = endDateISO.substring(0, endDateISO.length - 1); // remove Zone due to backend standard
 
+    // Transform &amp; back to '&'. This is a workaround due to Quill editor encoding '&'.}
+    payload['message_text'] = payload['message_text'].replace(/&amp;/g, '&');
+
     // Clean null and empty values to avoid API errors
     Object.keys(payload).forEach((key) => {
       if (payload[key] === null || (Array.isArray(payload[key]) && payload[key].length === 0)) {


### PR DESCRIPTION
This PR extends the methods to save and update logs on the `NonExposureEdit`, `ExposureAdd` and `ExposureDetail` components so the ampersand character (`&`) is parsed back to its original form. The QuillJS editor parses this automatically to html encoding `&` -> `&amp;`, so we added some code to parse this back.