### PR TITLE
Fix links parsing on the htmlToJiraMarkdown function so it properly parse more than one link in the string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.3.1
 ------
 
+* Fix links parsing on the htmlToJiraMarkdown function so it properly parse more than one link in the string `<https://github.com/lsst-ts/LOVE-frontend/pull/667>`_
 * Remove deprecated MTHexapod Offline controller state `<https://github.com/lsst-ts/LOVE-frontend/pull/668>`_
 * Refactor M2 Selector component to fix axial and tangent actuators coordinate system `<https://github.com/lsst-ts/LOVE-frontend/pull/665>`_
 

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1845,7 +1845,7 @@ export function htmlToJiraMarkdown(html) {
 
   // Parse links
   markdown = markdown.replace(
-    /<a href="(.*)" rel="noopener noreferrer" target="_blank">(.*)<\/a>/g,
+    /<a href="([^"]*)" rel="noopener noreferrer" target="_blank">([^<]*)<\/a>/g,
     (match, p1, p2) => {
       return `[${p2}|${p1}]`;
     },

--- a/love/src/Utils.test.js
+++ b/love/src/Utils.test.js
@@ -3,8 +3,10 @@ import { JIRA_TICKETS_BASE_URL } from './Config';
 
 describe('htmlToJiraMarkdown', () => {
   it('should handle links', () => {
-    const input = '<p>This is a <a href="https://example.com" rel="noopener noreferrer" target="_blank">link</a>.</p>';
-    const expectedOutput = 'This is a [link|https://example.com].\r\n';
+    const input =
+      '<p>This is a <a href="https://example.com" rel="noopener noreferrer" target="_blank">link</a>' +
+      ' and this is another <a href="https://example2.com" rel="noopener noreferrer" target="_blank">link</a>.</p>';
+    const expectedOutput = 'This is a [link|https://example.com] and this is another [link|https://example2.com].\r\n';
     expect(htmlToJiraMarkdown(input)).toEqual(expectedOutput);
   });
 


### PR DESCRIPTION
This PR fixes an issue with the `htmlToJiraMarkdown` that was no properly parsing more than one link in a string. This made some OLE entries to be saved with bad content when an user added more than one link in the log. The code for parsing html links was improved to make it more robust.