### PR TITLE
Remove deprecated MTHexapod Offline controller state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.3.1
 ------
 
+* Remove deprecated MTHexapod Offline controller state `<https://github.com/lsst-ts/LOVE-frontend/pull/668>`_
 * Refactor M2 Selector component to fix axial and tangent actuators coordinate system `<https://github.com/lsst-ts/LOVE-frontend/pull/665>`_
 
 v6.3.0

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -1526,11 +1526,6 @@ export const hexapodControllerStateMap = {
   4: 'FAULT',
 };
 
-export const hexapodControllerStateOfflineSubStateMap = {
-  0: 'PUBLISH ONLY',
-  1: 'AVAILABLE',
-};
-
 export const hexapodControllerStateEnabledSubstateMap = {
   0: 'STATIONARY',
   1: 'MOVING POINT TO POINT',

--- a/love/src/components/MainTel/CameraHexapod/CameraHexapod.jsx
+++ b/love/src/components/MainTel/CameraHexapod/CameraHexapod.jsx
@@ -34,13 +34,11 @@ import {
   hexapodCompensationModeStatetoStyle,
   hexapodInterlockStateMap,
   hexapodControllerStateMap,
-  hexapodControllerStateOfflineSubStateMap,
   hexapodControllerStateEnabledSubstateMap,
   hexapodMTInPositionStateMap,
   hexapodMTInPositionStatetoStyle,
   hexapodConnectedStateMap,
   hexapodConnectedStatetoStyle,
-  hexapodStatusStatetoStyle,
   hexapodControllerStatetoStyle,
 } from 'Config';
 
@@ -58,8 +56,6 @@ class CameraHexapod extends Component {
     hexapodConnected: PropTypes.bool,
     /** State reported by the controller */
     hexapodControllerState: PropTypes.number,
-    /** Substate in OFFLINE mode, an OfflineSubstate enumeration value */
-    hexapodControllerStateOfflineSubstate: PropTypes.number,
     /** Substate in ENABLED mode, an EnabledSubstate enumeration value */
     hexapodConstrollerStateEnabledSubstate: PropTypes.number,
     /** Application status. A bitmask of ApplicationStatus enumeration values */
@@ -109,7 +105,6 @@ class CameraHexapod extends Component {
     hexapodCompensationMode: false,
     hexapodConnected: false,
     hexapodControllerState: 0,
-    hexapodControllerStateOfflineSubstate: 0,
     hexapodConstrollerStateEnabledSubstate: 0,
     hexapodControllerStateApplicationStatus: 0,
     hexapodInPosition: false,
@@ -289,9 +284,6 @@ class CameraHexapod extends Component {
 
     // controllerState
     let controllerSubstate = '';
-    if (controllerState === 'Offline') {
-      controllerSubstate = hexapodControllerStateOfflineSubStateMap[this.props.hexapodControllerStateOfflineSubstate];
-    }
     if (controllerState === 'Enabled') {
       controllerSubstate = hexapodControllerStateEnabledSubstateMap[this.props.hexapodConstrollerStateEnabledSubstate];
     } else {

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -972,9 +972,6 @@ export const getHexapodStatus = (state, salindex) => {
     hexapodControllerState: hexapodStatusData[`event-MTHexapod-${salindex}-controllerState`]
       ? hexapodStatusData[`event-MTHexapod-${salindex}-controllerState`][0].controllerState.value
       : 0,
-    hexapodControllerStateOfflineSubstate: hexapodStatusData[`event-MTHexapod-${salindex}-controllerState`]
-      ? hexapodStatusData[`event-MTHexapod-${salindex}-controllerState`][0].offlineSubstate.value
-      : 0,
     hexapodConstrollerStateEnabledSubstate: hexapodStatusData[`event-MTHexapod-${salindex}-controllerState`]
       ? hexapodStatusData[`event-MTHexapod-${salindex}-controllerState`][0].enabledSubstate.value
       : 0,


### PR DESCRIPTION
This PR removes a deprecated parameter of the `MTHexapod_logevent_controllerState` topic: `offlineSubstate`. This removal from the XML interface was also making other parameters to fail to retrieve their proper values.