### PR TITLE
Fix OLE exposure components to allow all instruments to be used queried.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.3.2
+------
+
+* Fix OLE exposure components to allow all instruments to be used queried. `<https://github.com/lsst-ts/LOVE-frontend/pull/672>`_
+
 v6.3.1
 ------
 

--- a/love/src/components/OLE/Exposure/ExposureAdd.jsx
+++ b/love/src/components/OLE/Exposure/ExposureAdd.jsx
@@ -158,9 +158,7 @@ class ExposureAdd extends Component {
         });
       });
 
-      const instrumentsArray = Object.values(data)
-        .map((arr) => arr[0])
-        .filter((instrument) => instrument);
+      const instrumentsArray = Object.keys(registryMap);
 
       this.setState({
         instruments: instrumentsArray,

--- a/love/src/components/OLE/OLE.jsx
+++ b/love/src/components/OLE/OLE.jsx
@@ -174,9 +174,8 @@ export default class OLE extends Component {
           registryMap[instrument] = key;
         });
       });
-      const instrumentsArray = Object.values(data)
-        .map((arr) => arr[0])
-        .filter((instrument) => instrument);
+
+      const instrumentsArray = Object.keys(registryMap);
 
       this.setState({
         instruments: instrumentsArray,


### PR DESCRIPTION
This PR includes changes to the `ExposureAdd` and `OLE` components. This is a slight change which makes the `instrumentsArray` to consider all option instead of the first one for each registry.