### PR TITLE
Add M1M3HardpointsDataTable component.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ Version History
 v6.4.0
 ------
 
-* Add M1M3Compact and M2Compact components `<https://github.com/lsst-ts/LOVE-frontend/pull/673>`_
+* Add M1M3HardpointsDataTable component. `<https://github.com/lsst-ts/LOVE-frontend/pull/674>`_
+* Add M1M3Compact and M2Compact components. `<https://github.com/lsst-ts/LOVE-frontend/pull/673>`_
 
 v6.3.2
 ------

--- a/love/src/components/MainTel/M1M3/M1M3Compact.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3Compact.jsx
@@ -209,92 +209,99 @@ function M1M3Compact({
 
   return (
     <div className={styles.container}>
-      <svg viewBox={`0 0 ${width} ${height}`}>
-        <defs>
-          <pattern id="disabledPattern" x="0" y="0" width="6" height="6" patternUnits="userSpaceOnUse">
-            <line x1="0" y1="0" x2="6" y2="6" stroke="var(--status-alert-color)" strokeWidth="0.2" />
-            <line x1="6" y1="0" x2="0" y2="6" stroke="var(--status-alert-color)" strokeWidth="0.2" />
-          </pattern>
-        </defs>
+      {!showForcesSelector && (
+        <div className={styles.selectedForce}>
+          Selected parameters: {selectedForce} - {selectedForceParameter}
+        </div>
+      )}
+      <div className={styles.diagrams}>
+        <svg viewBox={`0 0 ${width} ${height}`}>
+          <defs>
+            <pattern id="disabledPattern" x="0" y="0" width="6" height="6" patternUnits="userSpaceOnUse">
+              <line x1="0" y1="0" x2="6" y2="6" stroke="var(--status-alert-color)" strokeWidth="0.2" />
+              <line x1="6" y1="0" x2="0" y2="6" stroke="var(--status-alert-color)" strokeWidth="0.2" />
+            </pattern>
+          </defs>
 
-        <g>
-          {actuators.map((act, i) => {
-            const actuatorForce = getActuatorForceByParameter(selectedForceParameter, i);
-            const actuatorForceText = defaultNumberFormatter(actuatorForce, 2);
-            return (
-              <g key={act.id}>
-                <circle
-                  cx={act.position[0] + xRadius + margin}
-                  cy={act.position[1] + yRadius + margin}
-                  fill={fillActuator(i)}
-                  stroke="black"
-                  r={maxRadius / 16}
-                />
-                <text
-                  className={styles.actuatorId}
-                  x={act.position[0] + xRadius + margin}
-                  y={act.position[1] + yRadius + margin}
-                  textAnchor="middle"
-                  alignmentBaseline="middle"
-                >
-                  {act.id}
-                </text>
-                {showActuatorsForces && forceParameterIsScalar && !forceParameterHasBigNumbers && (
+          <g>
+            {actuators.map((act, i) => {
+              const actuatorForce = getActuatorForceByParameter(selectedForceParameter, i);
+              const actuatorForceText = defaultNumberFormatter(actuatorForce, 2);
+              return (
+                <g key={act.id}>
+                  <circle
+                    cx={act.position[0] + xRadius + margin}
+                    cy={act.position[1] + yRadius + margin}
+                    fill={fillActuator(i)}
+                    stroke="black"
+                    r={maxRadius / 16}
+                  />
                   <text
-                    className={styles.actuatorForce}
+                    className={styles.actuatorId}
                     x={act.position[0] + xRadius + margin}
-                    y={act.position[1] + yRadius + margin + 5}
+                    y={act.position[1] + yRadius + margin}
                     textAnchor="middle"
                     alignmentBaseline="middle"
                   >
-                    {actuatorForceText}
+                    {act.id}
                   </text>
-                )}
-              </g>
-            );
-          })}
-        </g>
-      </svg>
-      <div className={styles.forceGradientContainer}>
-        {showForceGradient && <LinearGradient forceData={forceData} unit={forceParameterValueUnit} />}
-      </div>
-      {showForcesSelector && (
-        <div className={[styles.forcesSelector, 'nonDraggable'].join(' ')}>
-          <div>
-            {forceInputs.map((force) => (
-              <div key={force}>
-                <input
-                  type="radio"
-                  id={force}
-                  name="force"
-                  value={force}
-                  checked={selectedForce === force}
-                  onChange={() => {
-                    setSelectedForce(force);
-                    setSelectedForceParameter();
-                  }}
-                />
-                <label htmlFor={force}>{M1M3ActuatorForcesLabels[force]}</label>
-              </div>
-            ))}
-          </div>
-          <div>
-            {forceParameters.map((forceParameter) => (
-              <div key={forceParameter}>
-                <input
-                  type="radio"
-                  id={forceParameter}
-                  name="forceParameter"
-                  value={forceParameter}
-                  checked={selectedForceParameter === forceParameter}
-                  onChange={() => setSelectedForceParameter(forceParameter)}
-                />
-                <label htmlFor={forceParameter}>{forceParameter}</label>
-              </div>
-            ))}
-          </div>
+                  {showActuatorsForces && forceParameterIsScalar && !forceParameterHasBigNumbers && (
+                    <text
+                      className={styles.actuatorForce}
+                      x={act.position[0] + xRadius + margin}
+                      y={act.position[1] + yRadius + margin + 5}
+                      textAnchor="middle"
+                      alignmentBaseline="middle"
+                    >
+                      {actuatorForceText}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+        <div className={styles.forceGradientContainer}>
+          {showForceGradient && <LinearGradient forceData={forceData} unit={forceParameterValueUnit} />}
         </div>
-      )}
+        {showForcesSelector && (
+          <div className={[styles.forcesSelector, 'nonDraggable'].join(' ')}>
+            <div>
+              {forceInputs.map((force) => (
+                <div key={force}>
+                  <input
+                    type="radio"
+                    id={force}
+                    name="force"
+                    value={force}
+                    checked={selectedForce === force}
+                    onChange={() => {
+                      setSelectedForce(force);
+                      setSelectedForceParameter();
+                    }}
+                  />
+                  <label htmlFor={force}>{M1M3ActuatorForcesLabels[force]}</label>
+                </div>
+              ))}
+            </div>
+            <div>
+              {forceParameters.map((forceParameter) => (
+                <div key={forceParameter}>
+                  <input
+                    type="radio"
+                    id={forceParameter}
+                    name="forceParameter"
+                    value={forceParameter}
+                    checked={selectedForceParameter === forceParameter}
+                    onChange={() => setSelectedForceParameter(forceParameter)}
+                  />
+                  <label htmlFor={forceParameter}>{forceParameter}</label>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/love/src/components/MainTel/M1M3/M1M3Compact.module.css
+++ b/love/src/components/MainTel/M1M3/M1M3Compact.module.css
@@ -19,8 +19,24 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .container {
   padding: var(--content-padding);
-  display: flex;
   height: calc(100% - 30px);
+}
+
+.container:has(.selectedForce) {
+  height: calc(100% - 60px);
+}
+
+.container .diagrams {
+  display: flex;
+  height: 100%;
+}
+
+.selectedForce {
+  margin-bottom: var(--content-padding);
+  color: var(--highlighted-font-color);
+  font-weight: bold;
+  text-align: left;
+  font-size: var(--font-size-large);
 }
 
 .actuatorId {

--- a/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.container.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.container.jsx
@@ -1,0 +1,79 @@
+/** 
+This file is part of LOVE-frontend.
+
+Developed for the LSST Telescope and Site Systems.
+This product includes software developed by the LSST Project
+ (https://www.lsst.org).
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { addGroup, removeGroup } from 'redux/actions/ws';
+import {
+  getM1M3HardpointActuatorData,
+  getM1M3HardpointMonitorData,
+  getM1M3HardpointActuatorWarningData,
+} from 'redux/selectors';
+import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
+import M1M3HardpointsDataTable from './M1M3HardpointsDataTable';
+
+export const schema = {
+  description: `Table containing low level information about the Simonyi M1M3 Hardpoints measures.`,
+  defaultSize: [55, 14],
+  props: {
+    title: {
+      type: 'string',
+      description: 'Name diplayed in the title bar (if visible)',
+      isPrivate: false,
+      default: 'Simonyi M1M3 Hardpoints Data Table',
+    },
+  },
+};
+
+const M1M3HardpointsDataTableContainer = ({ ...props }) => {
+  if (props.isRaw) {
+    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
+  }
+  return <M1M3HardpointsDataTable {...props} />;
+};
+
+const mapStateToProps = (state) => {
+  const m1m3HardpointActuatorData = getM1M3HardpointActuatorData(state);
+  const m1m3HardpointMonitorData = getM1M3HardpointMonitorData(state);
+  const m1m3HardpointActuatorWarningData = getM1M3HardpointActuatorWarningData(state);
+  return {
+    ...m1m3HardpointActuatorData,
+    ...m1m3HardpointMonitorData,
+    ...m1m3HardpointActuatorWarningData,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  const subscriptions = [
+    'telemetry-MTM1M3-0-hardpointActuatorData',
+    'telemetry-MTM1M3-0-hardpointMonitorData',
+    'event-MTM1M3-0-hardpointActuatorWarning',
+  ];
+  return {
+    subscriptions,
+    subscribeToStreams: () => {
+      subscriptions.forEach((stream) => dispatch(addGroup(stream)));
+    },
+    unsubscribeToStreams: () => {
+      subscriptions.forEach((stream) => dispatch(removeGroup(stream)));
+    },
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(M1M3HardpointsDataTableContainer);

--- a/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.container.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.container.jsx
@@ -21,7 +21,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { addGroup, removeGroup } from 'redux/actions/ws';
 import {
+  getM1M3ForceControllerState,
   getM1M3HardpointActuatorData,
+  getM1M3HardpointActuatorSettings,
   getM1M3HardpointMonitorData,
   getM1M3HardpointActuatorWarningData,
 } from 'redux/selectors';
@@ -49,11 +51,15 @@ const M1M3HardpointsDataTableContainer = ({ ...props }) => {
 };
 
 const mapStateToProps = (state) => {
+  const m1m3ForceControllerState = getM1M3ForceControllerState(state);
   const m1m3HardpointActuatorData = getM1M3HardpointActuatorData(state);
+  const m1m3HardpointActuatorSettings = getM1M3HardpointActuatorSettings(state);
   const m1m3HardpointMonitorData = getM1M3HardpointMonitorData(state);
   const m1m3HardpointActuatorWarningData = getM1M3HardpointActuatorWarningData(state);
   return {
+    ...m1m3ForceControllerState,
     ...m1m3HardpointActuatorData,
+    ...m1m3HardpointActuatorSettings,
     ...m1m3HardpointMonitorData,
     ...m1m3HardpointActuatorWarningData,
   };
@@ -64,6 +70,8 @@ const mapDispatchToProps = (dispatch) => {
     'telemetry-MTM1M3-0-hardpointActuatorData',
     'telemetry-MTM1M3-0-hardpointMonitorData',
     'event-MTM1M3-0-hardpointActuatorWarning',
+    'event-MTM1M3-0-forceControllerState',
+    'event-MTM1M3-0-hardpointActuatorSettings',
   ];
   return {
     subscriptions,

--- a/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.jsx
@@ -238,6 +238,105 @@ function M1M3HardpointsDataTable({
   );
 }
 
-M1M3HardpointsDataTable.propTypes = {};
+M1M3HardpointsDataTable.propTypes = {
+  /** If the balance forces are applied or not */
+  balanceForcesApplied: PropTypes.bool,
+  /** Number of steps queued */
+  hardpointsStepsQueued: PropTypes.arrayOf(PropTypes.number),
+  /** Number of steps commanded */
+  hardpointsStepsCommanded: PropTypes.arrayOf(PropTypes.number),
+  /** Encoder data */
+  hardpointsEncoder: PropTypes.arrayOf(PropTypes.number),
+  /** Measured force data */
+  hardpointsMeasuredForce: PropTypes.arrayOf(PropTypes.number),
+  /** Displacement data */
+  hardpointsDisplacement: PropTypes.arrayOf(PropTypes.number),
+  /** Breakaway LVDT data */
+  hardpointsBreakawayLVDT: PropTypes.arrayOf(PropTypes.number),
+  /** Displacement LVDT data */
+  hardpointsDisplacementLVDT: PropTypes.arrayOf(PropTypes.number),
+  /** Breakaway pressure data */
+  hardpointsBreakawayPressure: PropTypes.arrayOf(PropTypes.number),
+  /** Pressure sensor 1 data */
+  hardpointsPressureSensor1: PropTypes.arrayOf(PropTypes.number),
+  /** Pressure sensor 2 data */
+  hardpointsPressureSensor2: PropTypes.arrayOf(PropTypes.number),
+  /** Pressure sensor 3 data */
+  hardpointsPressureSensor3: PropTypes.arrayOf(PropTypes.number),
+  /** Major fault warning data */
+  hardpointsMajorFault: PropTypes.arrayOf(PropTypes.bool),
+  /** Minor fault warning data */
+  hardpointsMinorFault: PropTypes.arrayOf(PropTypes.bool),
+  /** Minor fault warning data */
+  hardpointsFaultOverride: PropTypes.arrayOf(PropTypes.bool),
+  /** Main calibration error warning data */
+  hardpointsMainCalibrationError: PropTypes.arrayOf(PropTypes.bool),
+  /** Backup calibration error warning data */
+  hardpointsBackupCalibrationError: PropTypes.arrayOf(PropTypes.bool),
+  /** Limit switch 1 operated warning data */
+  hardpointsLimitSwitch1Operated: PropTypes.arrayOf(PropTypes.bool),
+  /** Limit switch 2 operated warning data */
+  hardpointsLimitSwitch2Operated: PropTypes.arrayOf(PropTypes.bool),
+  /** Low proximity warning warning data */
+  hardpointsLowProximityWarning: PropTypes.arrayOf(PropTypes.bool),
+  /** High proximity warning warning data */
+  hardpointsHighProximityWarning: PropTypes.arrayOf(PropTypes.bool),
+  /** Low air pressure fault warning data */
+  hardpointsLowAirPressureFault: PropTypes.arrayOf(PropTypes.bool),
+  /** High air pressure fault warning data */
+  hardpointsHighAirPressureFault: PropTypes.arrayOf(PropTypes.bool),
+  /** Unique ID CRC error warning data */
+  hardpointsUniqueIdCRCError: PropTypes.arrayOf(PropTypes.bool),
+  /** Application type mismatch warning data */
+  hardpointsApplicationTypeMismatch: PropTypes.arrayOf(PropTypes.bool),
+  /** Application missing warning data */
+  hardpointsApplicationMissing: PropTypes.arrayOf(PropTypes.bool),
+  /** Application CRC mismatch warning data */
+  hardpointsApplicationCRCMismatch: PropTypes.arrayOf(PropTypes.bool),
+  /** One wire missing warning data */
+  hardpointsOneWireMissing: PropTypes.arrayOf(PropTypes.bool),
+  /** One wire 1 mismatch warning data */
+  hardpointsOneWire1Mismatch: PropTypes.arrayOf(PropTypes.bool),
+  /** One wire 2 mismatch warning data */
+  hardpointsOneWire2Mismatch: PropTypes.arrayOf(PropTypes.bool),
+  /** Watchdog reset warning data */
+  hardpointsWatchdogReset: PropTypes.arrayOf(PropTypes.bool),
+  /** Brown out warning data */
+  hardpointsBrownOut: PropTypes.arrayOf(PropTypes.bool),
+  /** Event trap reset warning data */
+  hardpointsEventTrapReset: PropTypes.arrayOf(PropTypes.bool),
+  /** Motor driver fault warning data */
+  hardpointsMotorDriverFault: PropTypes.arrayOf(PropTypes.bool),
+  /** SSR power fault warning data */
+  hardpointsSsrPowerFault: PropTypes.arrayOf(PropTypes.bool),
+  /** Aux power fault warning data */
+  hardpointsAuxPowerFault: PropTypes.arrayOf(PropTypes.bool),
+  /** SMC power fault warning data */
+  hardpointsSmcPowerFault: PropTypes.arrayOf(PropTypes.bool),
+  /** ILC fault warning data */
+  hardpointsIlcFault: PropTypes.arrayOf(PropTypes.bool),
+  /** Broadcast counter warning warning data */
+  hardpointsBroadcastCounterWarning: PropTypes.arrayOf(PropTypes.bool),
+  /** Measured force operational warning high limit */
+  hardpointMeasuredForceWarningHigh: PropTypes.number,
+  /** Measured force operational warning low limit */
+  hardpointMeasuredForceWarningLow: PropTypes.number,
+  /** Measured force operational fault high limit */
+  hardpointMeasuredForceFaultHigh: PropTypes.number,
+  /** Measured force operational fault low limit */
+  hardpointMeasuredForceFaultLow: PropTypes.number,
+  /** Measured force FSB warning high limit */
+  hardpointMeasuredForceFSBWarningHigh: PropTypes.number,
+  /** Measured force FSB warning low limit */
+  hardpointMeasuredForceFSBWarningLow: PropTypes.number,
+  /** Breakaway pressure operational fault low limit */
+  hardpointBreakawayFaultLow: PropTypes.number,
+  /** Breakaway pressure operational fault high limit */
+  hardpointBreakawayFaultHigh: PropTypes.number,
+  /** Function to subscribe to streams. */
+  subscribeToStreams: PropTypes.func.isRequired,
+  /** Function to unsubscribe to streams. */
+  unsubscribeToStreams: PropTypes.func.isRequired,
+};
 
 export default M1M3HardpointsDataTable;

--- a/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.jsx
+++ b/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.jsx
@@ -1,0 +1,205 @@
+/** 
+This file is part of LOVE-frontend.
+
+Developed for the LSST Telescope and Site Systems.
+This product includes software developed by the LSST Project
+ (https://www.lsst.org).
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import SimpleTable from 'components//GeneralPurpose/SimpleTable/SimpleTable';
+import { defaultNumberFormatter } from 'Utils';
+import styles from './M1M3HardpointsDataTable.module.css';
+
+function getTableHeaders() {
+  return [
+    {
+      field: 'parameter',
+      title: 'Parameter',
+    },
+    {
+      field: 'hardpoint1',
+      title: '1',
+    },
+    {
+      field: 'hardpoint2',
+      title: '2',
+    },
+    {
+      field: 'hardpoint3',
+      title: '3',
+    },
+    {
+      field: 'hardpoint4',
+      title: '4',
+    },
+    {
+      field: 'hardpoint5',
+      title: '5',
+    },
+    {
+      field: 'hardpoint6',
+      title: '6',
+    },
+  ];
+}
+
+function transposeTelemetries(parameter, telemetryArray, renderFunction, unit = '') {
+  return {
+    parameter: parameter,
+    hardpoint1: (
+      <span>
+        {renderFunction(telemetryArray[0])}
+        {unit ? ` [${unit}]` : ''}
+      </span>
+    ),
+    hardpoint2: (
+      <span>
+        {renderFunction(telemetryArray[1])}
+        {unit ? ` [${unit}]` : ''}
+      </span>
+    ),
+    hardpoint3: (
+      <span>
+        {renderFunction(telemetryArray[2])}
+        {unit ? ` [${unit}]` : ''}
+      </span>
+    ),
+    hardpoint4: (
+      <span>
+        {renderFunction(telemetryArray[3])}
+        {unit ? ` [${unit}]` : ''}
+      </span>
+    ),
+    hardpoint5: (
+      <span>
+        {renderFunction(telemetryArray[4])}
+        {unit ? ` [${unit}]` : ''}
+      </span>
+    ),
+    hardpoint6: (
+      <span>
+        {renderFunction(telemetryArray[5])}
+        {unit ? ` [${unit}]` : ''}
+      </span>
+    ),
+  };
+}
+
+function M1M3HardpointsDataTable({
+  hardpointsStepsQueued,
+  hardpointsStepsCommanded,
+  hardpointsEncoder,
+  hardpointsMeasuredForce,
+  hardpointsDisplacement,
+  hardpointsBreakawayLVDT,
+  hardpointsDisplacementLVDT,
+  hardpointsBreakawayPressure,
+  hardpointsPressureSensor1,
+  hardpointsPressureSensor2,
+  hardpointsPressureSensor3,
+  hardpointsMajorFault,
+  hardpointsMinorFault,
+  hardpointsFaultOverride,
+  hardpointsMainCalibrationError,
+  hardpointsBackupCalibrationError,
+  hardpointsLimitSwitch1Operated,
+  hardpointsLimitSwitch2Operated,
+  hardpointsLowProximityWarning,
+  hardpointsHighProximityWarning,
+  hardpointsLowAirPressureFault,
+  hardpointsHighAirPressureFault,
+  hardpointsUniqueIdCRCError,
+  hardpointsApplicationTypeMismatch,
+  hardpointsApplicationMissing,
+  hardpointsApplicationCRCMismatch,
+  hardpointsOneWireMissing,
+  hardpointsOneWire1Mismatch,
+  hardpointsOneWire2Mismatch,
+  hardpointsWatchdogReset,
+  hardpointsBrownOut,
+  hardpointsEventTrapReset,
+  hardpointsMotorDriverFault,
+  hardpointsSsrPowerFault,
+  hardpointsAuxPowerFault,
+  hardpointsSmcPowerFault,
+  hardpointsIlcFault,
+  hardpointsBroadcastCounterWarning,
+  subscribeToStreams,
+  unsubscribeToStreams,
+  ...props
+}) {
+  useEffect(() => {
+    subscribeToStreams();
+    return () => unsubscribeToStreams();
+  }, []);
+
+  const renderNumbers = (value) => defaultNumberFormatter(value, 2);
+  const renderBooleans = (value) => (
+    <span className={!value ? styles.offWarning : styles.onWarning}>{!value ? 'Off' : 'On'}</span>
+  );
+
+  const data = [
+    transposeTelemetries('Steps queued', hardpointsStepsQueued, renderNumbers),
+    transposeTelemetries('Steps commanded', hardpointsStepsCommanded, renderNumbers),
+    transposeTelemetries('Encoder', hardpointsEncoder, renderNumbers),
+    transposeTelemetries('Measured force', hardpointsMeasuredForce, renderNumbers, 'N'),
+    transposeTelemetries('Displacement', hardpointsDisplacement, renderNumbers, 'mm'),
+    transposeTelemetries('Breakaway LVDT', hardpointsBreakawayLVDT, renderNumbers),
+    transposeTelemetries('Displacement LVDT', hardpointsDisplacementLVDT, renderNumbers),
+    transposeTelemetries('Breakaway pressure', hardpointsBreakawayPressure, renderNumbers),
+    transposeTelemetries('Pressure sensor 1', hardpointsPressureSensor1, renderNumbers),
+    transposeTelemetries('Pressure sensor 2', hardpointsPressureSensor2, renderNumbers),
+    transposeTelemetries('Pressure sensor 3', hardpointsPressureSensor3, renderNumbers),
+    transposeTelemetries('Major fault', hardpointsMajorFault, renderBooleans),
+    transposeTelemetries('Minor fault', hardpointsMinorFault, renderBooleans),
+    transposeTelemetries('Fault override', hardpointsFaultOverride, renderBooleans),
+    transposeTelemetries('Main calibration error', hardpointsMainCalibrationError, renderBooleans),
+    transposeTelemetries('Backup calibration error', hardpointsBackupCalibrationError, renderBooleans),
+    transposeTelemetries('Limit switch 1 operated', hardpointsLimitSwitch1Operated, renderBooleans),
+    transposeTelemetries('Limit switch 2 operated', hardpointsLimitSwitch2Operated, renderBooleans),
+    transposeTelemetries('Low proximity warning', hardpointsLowProximityWarning, renderBooleans),
+    transposeTelemetries('High proximity warning', hardpointsHighProximityWarning, renderBooleans),
+    transposeTelemetries('Low air pressure fault', hardpointsLowAirPressureFault, renderBooleans),
+    transposeTelemetries('High air pressure fault', hardpointsHighAirPressureFault, renderBooleans),
+    transposeTelemetries('Unique ID CRC error', hardpointsUniqueIdCRCError, renderBooleans),
+    transposeTelemetries('Application type mismatch', hardpointsApplicationTypeMismatch, renderBooleans),
+    transposeTelemetries('Application missing', hardpointsApplicationMissing, renderBooleans),
+    transposeTelemetries('Application CRC mismatch', hardpointsApplicationCRCMismatch, renderBooleans),
+    transposeTelemetries('One wire missing', hardpointsOneWireMissing, renderBooleans),
+    transposeTelemetries('One wire 1 mismatch', hardpointsOneWire1Mismatch, renderBooleans),
+    transposeTelemetries('One wire 2 mismatch', hardpointsOneWire2Mismatch, renderBooleans),
+    transposeTelemetries('Watchdog reset', hardpointsWatchdogReset, renderBooleans),
+    transposeTelemetries('Brown out', hardpointsBrownOut, renderBooleans),
+    transposeTelemetries('Event trap reset', hardpointsEventTrapReset, renderBooleans),
+    transposeTelemetries('Motor driver fault', hardpointsMotorDriverFault, renderBooleans),
+    transposeTelemetries('SSR power fault', hardpointsSsrPowerFault, renderBooleans),
+    transposeTelemetries('Aux power fault', hardpointsAuxPowerFault, renderBooleans),
+    transposeTelemetries('SMC power fault', hardpointsSmcPowerFault, renderBooleans),
+    transposeTelemetries('ILC fault', hardpointsIlcFault, renderBooleans),
+    transposeTelemetries('Broadcast counter warning', hardpointsBroadcastCounterWarning, renderBooleans),
+  ];
+
+  // console.log(data);
+  return (
+    <div className={styles.container}>
+      <SimpleTable headers={getTableHeaders()} data={data} />
+    </div>
+  );
+}
+
+M1M3HardpointsDataTable.propTypes = {};
+
+export default M1M3HardpointsDataTable;

--- a/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.module.css
+++ b/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.module.css
@@ -5,3 +5,15 @@
 .onWarning {
   color: var(--status-alert-color);
 }
+
+.notOverThreshold {
+  color: var(--status-ok-color);
+}
+
+.overFaultThreshold {
+  color: var(--status-alert-color);
+}
+
+.overWarningThreshold {
+  color: var(--status-alert-color);
+}

--- a/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.module.css
+++ b/love/src/components/MainTel/M1M3/M1M3HardpointsDataTable.module.css
@@ -1,0 +1,7 @@
+.offWarning {
+  color: var(--status-ok-color);
+}
+
+.onWarning {
+  color: var(--status-alert-color);
+}

--- a/love/src/components/MainTel/M2/M2Compact.jsx
+++ b/love/src/components/MainTel/M2/M2Compact.jsx
@@ -280,50 +280,61 @@ function M2Compact({
 
   return (
     <div className={styles.container}>
-      <svg viewBox={`-20 -20 ${width + 48} ${height + 48}`}>
-        <AxialActuators forceData={forceDataAxial} showActuatorsForces={showActuatorsForces} colorMap={colorMap} />
-        <TangentActuators forceData={forceDataTangent} showActuatorsForces={showActuatorsForces} colorMap={colorMap} />
-      </svg>
-      <div className={styles.forceGradientContainer}>
-        <LinearGradient forceData={forceDataAll} unit={forceParameterValueUnit} />
-      </div>
-      {showForcesSelector && (
-        <div className={[styles.forcesSelector, 'nonDraggable'].join(' ')}>
-          <div>
-            {forceInputs.map((force) => (
-              <div key={force}>
-                <input
-                  type="radio"
-                  id={forceInputId + '-' + force}
-                  name={forceInputId}
-                  value={force}
-                  checked={selectedForce === force}
-                  onChange={() => {
-                    setSelectedForce(force);
-                    setSelectedForceParameter();
-                  }}
-                />
-                <label htmlFor={force}>{M2ActuatorForcesLabels[force]}</label>
-              </div>
-            ))}
-          </div>
-          <div>
-            {forceParameters.map((forceParameter) => (
-              <div key={forceParameter}>
-                <input
-                  type="radio"
-                  id={forceParameterId + '-' + forceParameter}
-                  name={forceParameterId}
-                  value={forceParameter}
-                  checked={selectedForceParameter === forceParameter}
-                  onChange={() => setSelectedForceParameter(forceParameter)}
-                />
-                <label htmlFor={forceParameter}>{forceParameter}</label>
-              </div>
-            ))}
-          </div>
+      {!showForcesSelector && (
+        <div className={styles.selectedForce}>
+          Selected parameters: {selectedForce} - {selectedForceParameter}
         </div>
       )}
+      <div className={styles.diagrams}>
+        <svg viewBox={`-20 -20 ${width + 48} ${height + 48}`}>
+          <AxialActuators forceData={forceDataAxial} showActuatorsForces={showActuatorsForces} colorMap={colorMap} />
+          <TangentActuators
+            forceData={forceDataTangent}
+            showActuatorsForces={showActuatorsForces}
+            colorMap={colorMap}
+          />
+        </svg>
+        <div className={styles.forceGradientContainer}>
+          <LinearGradient forceData={forceDataAll} unit={forceParameterValueUnit} />
+        </div>
+        {showForcesSelector && (
+          <div className={[styles.forcesSelector, 'nonDraggable'].join(' ')}>
+            <div>
+              {forceInputs.map((force) => (
+                <div key={force}>
+                  <input
+                    type="radio"
+                    id={forceInputId + '-' + force}
+                    name={forceInputId}
+                    value={force}
+                    checked={selectedForce === force}
+                    onChange={() => {
+                      setSelectedForce(force);
+                      setSelectedForceParameter();
+                    }}
+                  />
+                  <label htmlFor={force}>{M2ActuatorForcesLabels[force]}</label>
+                </div>
+              ))}
+            </div>
+            <div>
+              {forceParameters.map((forceParameter) => (
+                <div key={forceParameter}>
+                  <input
+                    type="radio"
+                    id={forceParameterId + '-' + forceParameter}
+                    name={forceParameterId}
+                    value={forceParameter}
+                    checked={selectedForceParameter === forceParameter}
+                    onChange={() => setSelectedForceParameter(forceParameter)}
+                  />
+                  <label htmlFor={forceParameter}>{forceParameter}</label>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/love/src/components/MainTel/M2/M2Compact.module.css
+++ b/love/src/components/MainTel/M2/M2Compact.module.css
@@ -19,8 +19,24 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .container {
   padding: var(--content-padding);
-  display: flex;
   height: calc(100% - 30px);
+}
+
+.container:has(.selectedForce) {
+  height: calc(100% - 60px);
+}
+
+.container .diagrams {
+  display: flex;
+  height: 100%;
+}
+
+.selectedForce {
+  margin-bottom: var(--content-padding);
+  color: var(--highlighted-font-color);
+  font-weight: bold;
+  text-align: left;
+  font-size: var(--font-size-large);
 }
 
 .tangentActuators text,

--- a/love/src/components/UIF/ComponentIndex.jsx
+++ b/love/src/components/UIF/ComponentIndex.jsx
@@ -508,6 +508,16 @@ export const mainIndex = {
       },
     },
   },
+  M1M3HardpointsDataTable: {
+    component: require('../MainTel/M1M3/M1M3HardpointsDataTable.container').default,
+    schema: {
+      ...require('../MainTel/M1M3/M1M3HardpointsDataTable.container').schema,
+      props: {
+        ...defaultSchemaProps,
+        ...require('../MainTel/M1M3/M1M3HardpointsDataTable.container').schema.props,
+      },
+    },
+  },
   GlycolLoop: {
     component: require('../MainTel/GlycolLoop/GlycolLoop.container').default,
     schema: {

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -154,6 +154,15 @@ export const getM1M3ActuatorsState = (state) => {
   };
 };
 
+export const getM1M3ForceControllerState = (state) => {
+  const subscriptions = ['event-MTM1M3-0-forceControllerState'];
+  const m1m3Data = getStreamsData(state, subscriptions);
+  return {
+    balanceForcesApplied:
+      m1m3Data['event-MTM1M3-0-forceControllerState']?.[0]?.balanceForcesApplied?.value ?? undefined,
+  };
+};
+
 export const getM1M3ActuatorsData = (state) => {
   const subscriptions = ['telemetry-MTM1M3-0-forceActuatorData'];
   const m1m3Data = getStreamsData(state, subscriptions);
@@ -203,6 +212,29 @@ export const getM1M3HardpointActuatorState = (state) => {
     hardpointReferenceId: [1, 2, 3, 4, 5, 6],
     hardpointMinorRevision: m1m3Data['event-MTM1M3-0-hardpointActuatorInfo']?.[0]?.minorRevision?.value ?? [],
     hardpointMayorRevision: m1m3Data['event-MTM1M3-0-hardpointActuatorInfo']?.[0]?.majorRevision?.value ?? [],
+  };
+};
+
+export const getM1M3HardpointActuatorSettings = (state) => {
+  const subscriptions = ['event-MTM1M3-0-hardpointActuatorSettings'];
+  const m1m3Data = getStreamsData(state, subscriptions);
+  return {
+    hardpointMeasuredForceWarningHigh:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointMeasuredForceWarningHigh?.value ?? 0,
+    hardpointMeasuredForceWarningLow:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointMeasuredForceWarningLow?.value ?? 0,
+    hardpointMeasuredForceFaultHigh:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointMeasuredForceFaultHigh?.value ?? 0,
+    hardpointMeasuredForceFaultLow:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointMeasuredForceFaultLow?.value ?? 0,
+    hardpointMeasuredForceFSBWarningHigh:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointMeasuredForceFSBWarningHigh?.value ?? 0,
+    hardpointMeasuredForceFSBWarningLow:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointMeasuredForceFSBWarningLow?.value ?? 0,
+    hardpointBreakawayFaultLow:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointBreakawayFaultLow?.value ?? 0,
+    hardpointBreakawayFaultHigh:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorSettings']?.[0]?.hardpointBreakawayFaultHigh?.value ?? 0,
   };
 };
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -185,6 +185,11 @@ export const getM1M3HardpointActuatorData = (state) => {
     hardpointsXRotation: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.xRotation?.value ?? 0,
     hardpointsYRotation: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.yRotation?.value ?? 0,
     hardpointsZRotation: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.zRotation?.value ?? 0,
+    hardpointsStepsQueued: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.stepsQueued?.value ?? [],
+    hardpointsStepsCommanded: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.stepsCommanded?.value ?? [],
+    hardpointsEncoder: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.encoder?.value ?? [],
+    hardpointsMeasuredForce: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.measuredForce?.value ?? [],
+    hardpointsDisplacement: m1m3Data['telemetry-MTM1M3-0-hardpointActuatorData']?.displacement?.value ?? [],
   };
 };
 
@@ -208,7 +213,56 @@ export const getM1M3HardpointMonitorData = (state) => {
     hardpointsBreakawayLVDT: m1m3Data['telemetry-MTM1M3-0-hardpointMonitorData']?.breakawayLVDT?.value ?? [],
     hardpointsDisplacementLVDT: m1m3Data['telemetry-MTM1M3-0-hardpointMonitorData']?.displacementLVDT?.value ?? [],
     hardpointsBreakawayPressure: m1m3Data['telemetry-MTM1M3-0-hardpointMonitorData']?.breakawayPressure?.value ?? [],
+    hardpointsPressureSensor1: m1m3Data['telemetry-MTM1M3-0-hardpointMonitorData']?.pressureSensor1?.value ?? [],
+    hardpointsPressureSensor2: m1m3Data['telemetry-MTM1M3-0-hardpointMonitorData']?.pressureSensor2?.value ?? [],
+    hardpointsPressureSensor3: m1m3Data['telemetry-MTM1M3-0-hardpointMonitorData']?.pressureSensor3?.value ?? [],
     referenceHardpointId: [1, 2, 3, 4, 5, 6],
+  };
+};
+
+export const getM1M3HardpointActuatorWarningData = (state) => {
+  const subscriptions = ['event-MTM1M3-0-hardpointActuatorWarning'];
+  const m1m3Data = getStreamsData(state, subscriptions);
+  return {
+    hardpointsMajorFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.majorFault?.value ?? [],
+    hardpointsMinorFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.minorFault?.value ?? [],
+    hardpointsFaultOverride: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.faultOverride?.value ?? [],
+    hardpointsMainCalibrationError:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.mainCalibrationError?.value ?? [],
+    hardpointsBackupCalibrationError:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.backupCalibrationError?.value ?? [],
+    hardpointsLimitSwitch1Operated:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.limitSwitch1Operated?.value ?? [],
+    hardpointsLimitSwitch2Operated:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.limitSwitch2Operated?.value ?? [],
+    hardpointsLowProximityWarning:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.lowProximityWarning?.value ?? [],
+    hardpointsHighProximityWarning:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.highProximityWarning?.value ?? [],
+    hardpointsLowAirPressureFault:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.lowAirPressureFault?.value ?? [],
+    hardpointsHighAirPressureFault:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.highAirPressureFault?.value ?? [],
+    hardpointsUniqueIdCRCError: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.uniqueIdCRCError?.value ?? [],
+    hardpointsApplicationTypeMismatch:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.applicationTypeMismatch?.value ?? [],
+    hardpointsApplicationMissing:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.applicationMissing?.value ?? [],
+    hardpointsApplicationCRCMismatch:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.applicationCRCMismatch?.value ?? [],
+    hardpointsOneWireMissing: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.oneWireMissing?.value ?? [],
+    hardpointsOneWire1Mismatch: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.oneWire1Mismatch?.value ?? [],
+    hardpointsOneWire2Mismatch: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.oneWire2Mismatch?.value ?? [],
+    hardpointsWatchdogReset: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.watchdogReset?.value ?? [],
+    hardpointsBrownOut: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.brownOut?.value ?? [],
+    hardpointsEventTrapReset: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.eventTrapReset?.value ?? [],
+    hardpointsMotorDriverFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.motorDriverFault?.value ?? [],
+    hardpointsSsrPowerFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.ssrPowerFault?.value ?? [],
+    hardpointsAuxPowerFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.auxPowerFault?.value ?? [],
+    hardpointsSmcPowerFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.smcPowerFault?.value ?? [],
+    hardpointsIlcFault: m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.ilcFault?.value ?? [],
+    hardpointsBroadcastCounterWarning:
+      m1m3Data['event-MTM1M3-0-hardpointActuatorWarning']?.[0]?.broadcastCounterWarning?.value ?? [],
   };
 };
 


### PR DESCRIPTION
This PR adds the new `M1M3HardpointsDataTable` which has information about several hardpoints topics. This is a table component which list different parameters and gives visual cues in case thressholds are surpassed.

Also a section for displaying the current selected force parameters on the `M1M3Compact` and `M2Compact` components was added for cases when the forces selector is hidden.