### PR TITLE
Add RA and dec information on dome summary table components and a few other improvements.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.4.0
 ------
 
+* Add RA and dec information on dome summary table components and a few other improvements. `<https://github.com/lsst-ts/LOVE-frontend/pull/675>`_
 * Add M1M3HardpointsDataTable component. `<https://github.com/lsst-ts/LOVE-frontend/pull/674>`_
 * Add M1M3Compact and M2Compact components. `<https://github.com/lsst-ts/LOVE-frontend/pull/673>`_
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -121,7 +121,7 @@ export const SCRIPTQUEUE_SCRIPT_LOCATION = {
 
 export const MTMountLimits = {
   elevation: {
-    min: 5,
+    min: 0,
     max: 90,
   },
   azimuth: {

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1575,10 +1575,10 @@ export function degreesToDMS(degrees) {
   const m = Math.floor((degrees % 1) * 4);
   const s = Math.floor(((degrees % 1) * 4 - m) * 60);
   const hourFormat =
-    `${Math.sign(degrees) >= 0 ? '+' : '-'}` +
-    `${d.toString().padStart(2, '0')}` +
-    `:${m.toString().padStart(2, '0')}` +
-    `:${s.toString().padStart(2, '0')}`;
+    `${Math.sign(degrees) >= 0 ? '+' : ''}` +
+    `${d.toString().padStart(2, '0')}°` +
+    ` ${m.toString().padStart(2, '0')}'` +
+    ` ${s.toString().padStart(2, '0')}"`;
   return hourFormat;
 }
 

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -1403,6 +1403,21 @@ export const formatDigitalToSeconds = (time) => {
 };
 
 /**
+ * Convert hours to digital format as '00:00:00'
+ * @param {number} time hours to be converted
+ * @returns {string} hours in digitial format
+ */
+export const formatHoursToDigital = (time) => {
+  const hours = Math.floor(time);
+  const minutes = Math.floor((time - hours) * 60);
+  const seconds = Math.floor(((time - hours) * 60 - minutes) * 60);
+  const hoursString = hours.toString().padStart(2, '0');
+  const minutesString = minutes.toString().padStart(2, '0');
+  const secondsString = seconds.toString().padStart(2, '0');
+  return `${hoursString}:${minutesString}:${secondsString}`;
+};
+
+/**
  * Function to calculate the difference between two dates in hours, using moment.js
  * @param {string} hour1 in format '00:00:00'
  * @param {string} hour2 in format '00:00:00'
@@ -1552,7 +1567,7 @@ export function degrees(radians) {
 }
 
 /**
- * Function to transform degress to Right Ascension hour format
+ * Function to transform degress to Right Ascension hour-minute-seconds format
  * e.g. 180.55 -> 12:02:12
  * @param {number} degrees degrees to be transformed
  * @returns {string} Right Ascension hour format
@@ -1565,17 +1580,18 @@ export function degreesToHMS(degrees) {
 }
 
 /**
- * Function to transform degress to Declination hour format
- * e.g. 180.55 -> +180:02:12
+ * Function to transform degress to Declination degree-minute-seconds format
+ * e.g. 180.55 -> +180° 02' 12"
  * @param {number} degrees degrees to be transformed
  * @returns {string} Declination hour format
  */
 export function degreesToDMS(degrees) {
-  const d = Math.floor(degrees);
-  const m = Math.floor((degrees % 1) * 4);
-  const s = Math.floor(((degrees % 1) * 4 - m) * 60);
+  const degreesAbsolute = Math.abs(degrees);
+  const d = Math.floor(degreesAbsolute);
+  const m = Math.floor((degreesAbsolute % 1) * 4);
+  const s = Math.floor(((degreesAbsolute % 1) * 4 - m) * 60);
   const hourFormat =
-    `${Math.sign(degrees) >= 0 ? '+' : ''}` +
+    `${degrees >= 0 ? '+' : '-'}` +
     `${d.toString().padStart(2, '0')}°` +
     ` ${m.toString().padStart(2, '0')}'` +
     ` ${s.toString().padStart(2, '0')}"`;

--- a/love/src/components/AuxTel/Dome/Dome.container.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.container.jsx
@@ -99,7 +99,6 @@ const DomeContainer = ({
   subscribeToStream,
   unsubscribeToStream,
   controls,
-  atDomeTracking,
   targetName,
   telescopeRA,
   telescopeDec,
@@ -154,7 +153,6 @@ const DomeContainer = ({
       controls={controls}
       atDomeSummaryState={atDomeSummaryState}
       ATMCSSummaryState={ATMCSSummaryState}
-      atDomeTracking={atDomeTracking}
       targetName={targetName}
       telescopeRA={telescopeRA}
       telescopeDec={telescopeDec}

--- a/love/src/components/AuxTel/Dome/Dome.container.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.container.jsx
@@ -100,9 +100,10 @@ const DomeContainer = ({
   unsubscribeToStream,
   controls,
   targetName,
-  telescopeRA,
-  telescopeDec,
-  telescopeRotator,
+  telescopeRAHour,
+  telescopeRADeg,
+  telescopeDecDeg,
+  telescopeRotatorRad,
   raDecHourFormat,
   ...props
 }) => {
@@ -154,9 +155,10 @@ const DomeContainer = ({
       atDomeSummaryState={atDomeSummaryState}
       ATMCSSummaryState={ATMCSSummaryState}
       targetName={targetName}
-      telescopeRA={telescopeRA}
-      telescopeDec={telescopeDec}
-      telescopeRotator={telescopeRotator}
+      telescopeRAHour={telescopeRAHour}
+      telescopeRADeg={telescopeRADeg}
+      telescopeDecDeg={telescopeDecDeg}
+      telescopeRotatorRad={telescopeRotatorRad}
       raDecHourFormat={raDecHourFormat}
     />
   );
@@ -175,6 +177,8 @@ const mapDispatchToProps = (dispatch) => {
     'telemetry-ATMCS-0-mount_AzEl_Encoders',
     'telemetry-ATMCS-0-mount_Nasmyth_Encoders',
     'telemetry-Scheduler-2-observatoryState',
+    'telemetry-ATPtg-0-mountStatus',
+    'telemetry-ATPtg-0-mountPosition',
     'event-ATDome-0-azimuthState',
     'event-ATDome-0-azimuthCommandedState',
     'event-ATDome-0-dropoutDoorState',
@@ -185,10 +189,10 @@ const mapDispatchToProps = (dispatch) => {
     'event-ATMCS-0-allAxesInPosition',
     'event-ATMCS-0-m3State',
     'event-ATMCS-0-positionLimits',
-    'event-ATPtg-1-timesOfLimits',
     'event-ATDome-0-summaryState',
     'event-ATMCS-0-summaryState',
-    `event-ATPtg-1-currentTarget`,
+    'event-ATPtg-0-timesOfLimits',
+    `event-ATPtg-0-currentTarget`,
   ];
   return {
     subscriptions,

--- a/love/src/components/AuxTel/Dome/Dome.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.jsx
@@ -103,12 +103,16 @@ export default class Dome extends Component {
     ATMCSSummaryState: PropTypes.string,
     /** Target name */
     targetName: PropTypes.string,
-    /** Telescope RA */
-    telescopeRA: PropTypes.number,
-    /** Telescope Dec */
-    telescopeDec: PropTypes.number,
-    /** Rotator position */
-    telescopeRotator: PropTypes.number,
+    /** Telescope current RA in hours */
+    telescopeRAHour: PropTypes.number,
+    /** Telescope current RA in degrees */
+    telescopeRADeg: PropTypes.number,
+    /** Telescope current Dec in degrees */
+    telescopeDecDeg: PropTypes.number,
+    /** Telescope rotator position in rad */
+    telescopeRotatorRad: PropTypes.number,
+    /** Whether to display the RA and DEC in hour format */
+    raDecHourFormat: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -299,9 +303,10 @@ export default class Dome extends Component {
       atDomeSummaryState,
       ATMCSSummaryState,
       targetName,
-      telescopeRA,
-      telescopeDec,
-      telescopeRotator,
+      telescopeRAHour,
+      telescopeRADeg,
+      telescopeDecDeg,
+      telescopeRotatorRad,
       raDecHourFormat,
     } = this.props;
 
@@ -328,9 +333,6 @@ export default class Dome extends Component {
       isLive: isLive,
       historicalData: historicalData,
     };
-
-    const parsedTelescopeRA = raDecHourFormat ? degreesToHMS(telescopeRA) : `${telescopeRA}°`;
-    const parsedTelescopeDec = raDecHourFormat ? degreesToDMS(telescopeDec) : `${telescopeDec}°`;
 
     return (
       <div className={styles.domeContainer}>
@@ -400,20 +402,6 @@ export default class Dome extends Component {
             >
               <span>Vignetting distance: </span>
               <span className={styles.value}>{vignettingDistance}°</span>
-              <div
-                title="The following parameters requires the Scheduler:2 CSC to be active"
-                className={styles.telescopeParametersContainer}
-              >
-                <div>
-                  Telescope RA: <span className={styles.value}>{parsedTelescopeRA}</span>
-                </div>
-                <div>
-                  Telescope Dec: <span className={styles.value}>{parsedTelescopeDec}</span>
-                </div>
-                <div>
-                  Rotator position: <span className={styles.value}>{telescopeRotator}°</span>
-                </div>
-              </div>
             </div>
           </div>
           <DomeSummaryTable
@@ -456,6 +444,11 @@ export default class Dome extends Component {
             atDomeSummaryState={atDomeSummaryState}
             ATMCSSummaryState={ATMCSSummaryState}
             targetName={targetName}
+            telescopeRAHour={telescopeRAHour}
+            telescopeRADeg={telescopeRADeg}
+            telescopeDecDeg={telescopeDecDeg}
+            telescopeRotatorRad={telescopeRotatorRad}
+            raDecHourFormat={raDecHourFormat}
           />
         </div>
         {this.props.controls && (

--- a/love/src/components/AuxTel/Dome/Dome.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.jsx
@@ -101,8 +101,6 @@ export default class Dome extends Component {
     atDomeSummaryState: PropTypes.string,
     /** ATMCS summary state */
     ATMCSSummaryState: PropTypes.string,
-    /** AT dome tracking */
-    atDomeTracking: PropTypes.bool,
     /** Target name */
     targetName: PropTypes.string,
     /** Telescope RA */
@@ -300,7 +298,6 @@ export default class Dome extends Component {
       currentPointingNasmyth2,
       atDomeSummaryState,
       ATMCSSummaryState,
-      atDomeTracking,
       targetName,
       telescopeRA,
       telescopeDec,
@@ -458,7 +455,6 @@ export default class Dome extends Component {
             minM3={minM3}
             atDomeSummaryState={atDomeSummaryState}
             ATMCSSummaryState={ATMCSSummaryState}
-            domeTracking={atDomeTracking}
             targetName={targetName}
           />
         </div>

--- a/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
+++ b/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
@@ -18,10 +18,15 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import React, { Component } from 'react';
-import styles from './DomeSummaryTable.module.css';
+import PropTypes from 'prop-types';
 import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
 import CurrentTargetValue from 'components/GeneralPurpose/CurrentTargetValue/CurrentTargetValue';
-import PropTypes from 'prop-types';
+import Limits from 'components/GeneralPurpose/Limits/Limits';
+import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
+import Row from 'components/GeneralPurpose/SummaryPanel/Row';
+import Label from 'components/GeneralPurpose/SummaryPanel/Label';
+import Value from 'components/GeneralPurpose/SummaryPanel/Value';
+import Title from 'components/GeneralPurpose/SummaryPanel/Title';
 import {
   domeAzimuthStateMap,
   dropoutDoorStateMap,
@@ -30,15 +35,11 @@ import {
   stateToStyleDomeAndMount,
   summaryStateToStyle,
   summaryStateMap,
-} from '../../../../Config';
-import Limits from 'components/GeneralPurpose/Limits/Limits';
-import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
-import Row from 'components/GeneralPurpose/SummaryPanel/Row';
-import Label from 'components/GeneralPurpose/SummaryPanel/Label';
-import Value from 'components/GeneralPurpose/SummaryPanel/Value';
-import Title from 'components/GeneralPurpose/SummaryPanel/Title';
-import { stateToStyleDome, stateToStyleMount } from '../../../../Config';
-import { fixedFloat } from 'Utils';
+  stateToStyleDome,
+  stateToStyleMount,
+} from 'Config';
+import { fixedFloat, degrees, degreesToDMS, defaultNumberFormatter, formatHoursToDigital } from 'Utils';
+import styles from './DomeSummaryTable.module.css';
 
 export default class DomeSummaryTable extends Component {
   static propTypes = {
@@ -66,6 +67,12 @@ export default class DomeSummaryTable extends Component {
     minM3: PropTypes.number,
     atDomeSummaryState: PropTypes.number,
     ATMCSSummaryState: PropTypes.number,
+    targetName: PropTypes.string,
+    telescopeRAHour: PropTypes.number,
+    telescopeRADeg: PropTypes.number,
+    telescopeDecDeg: PropTypes.number,
+    telescopeRotatorRad: PropTypes.number,
+    raDecHourFormat: PropTypes.bool,
   };
 
   static defaultProps = {};
@@ -102,8 +109,12 @@ export default class DomeSummaryTable extends Component {
       minNas2,
       atDomeSummaryState,
       ATMCSSummaryState,
-      domeTracking,
       targetName,
+      telescopeRAHour,
+      telescopeRADeg,
+      telescopeDecDeg,
+      telescopeRotatorRad,
+      raDecHourFormat,
     } = this.props;
 
     const azimuthStateValue = domeAzimuthStateMap[this.props.azimuthState];
@@ -144,12 +155,26 @@ export default class DomeSummaryTable extends Component {
     let mountInPositionLabel = 'UNKNOWN';
     if (mountInPositionValue !== 0) mountInPositionLabel = mountInPositionValue ? 'IN POSITION' : 'NOT IN POSITION';
 
+    const parsedTelescopeRAHour = formatHoursToDigital(telescopeRAHour);
+    const parsedTelescopeDecHour = degreesToDMS(telescopeDecDeg);
+    const parsedTelescopeRADeg = defaultNumberFormatter(telescopeRADeg, 2) + '°';
+    const parsedTelescopeDecDeg = defaultNumberFormatter(telescopeDecDeg, 2) + '°';
+    const parsedTelescopeRotatorDeg = defaultNumberFormatter(degrees(telescopeRotatorRad), 2) + '°';
+    const telescopeRAText = raDecHourFormat ? parsedTelescopeRAHour : parsedTelescopeRADeg;
+    const telescopeDecText = raDecHourFormat ? parsedTelescopeDecHour : parsedTelescopeDecDeg;
+
     return (
       <SummaryPanel className={styles.summaryTable}>
         <Title>Track ID</Title>
         <Value>{this.props.trackID?.toString()}</Value>
         <Label>Target Name</Label>
         <Value>{targetName}</Value>
+        <Label>Telescope RA</Label>
+        <Value>{telescopeRAText}</Value>
+        <Label>Telescope Dec</Label>
+        <Value>{telescopeDecText}</Value>
+        <Label>Rotator</Label>
+        <Value>{parsedTelescopeRotatorDeg}</Value>
         {/* Dome */}
         <Title>ATDome CSC</Title>
         <Value>

--- a/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
+++ b/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
@@ -30,8 +30,6 @@ import {
   stateToStyleDomeAndMount,
   summaryStateToStyle,
   summaryStateMap,
-  atDomeTrackingStateMap,
-  atDomeTrackingStatetoStyle,
 } from '../../../../Config';
 import Limits from 'components/GeneralPurpose/Limits/Limits';
 import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
@@ -141,9 +139,6 @@ export default class DomeSummaryTable extends Component {
     const atDomeSummaryStateValue = summaryStateMap[atDomeSummaryState];
     const ATMCSSummaryStateValue = summaryStateMap[ATMCSSummaryState];
 
-    const domeTrackingName = atDomeTrackingStateMap[domeTracking];
-    const domeTrackingStyle = atDomeTrackingStatetoStyle[domeTrackingName];
-
     let domeInPositionLabel = 'UNKNOWN';
     if (domeInPositionValue !== 0) domeInPositionLabel = domeInPositionValue ? 'IN POSITION' : 'NOT IN POSITION';
     let mountInPositionLabel = 'UNKNOWN';
@@ -167,10 +162,6 @@ export default class DomeSummaryTable extends Component {
           <StatusText title={domeInPositionValue} status={stateToStyleDome[domeInPositionLabel]} small>
             {domeInPositionLabel}
           </StatusText>
-        </Value>
-        <Label>Tracking</Label>
-        <Value>
-          <StatusText status={domeTrackingStyle}>{domeTrackingName}</StatusText>
         </Value>
         <Label>Azimuth</Label>
         <Value>

--- a/love/src/components/MainTel/MTDome/MTDome.container.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.container.jsx
@@ -27,6 +27,7 @@ import {
   getDomeAzimuth,
   getLightWindScreen,
   getPointingStatus,
+  getMainTelescopeState,
 } from '../../../redux/selectors';
 import { addGroup, removeGroup } from '../../../redux/actions/ws';
 import SubscriptionTableContainer from '../../GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
@@ -46,6 +47,12 @@ export const schema = {
       description: "Whether to display controls to configure periods of time'",
       default: true,
       isPrivate: false,
+    },
+    raDecHourFormat: {
+      type: 'boolean',
+      description: 'Whether to display the RA and DEC in hour format',
+      isPrivate: false,
+      default: false,
     },
   },
 };
@@ -72,6 +79,11 @@ const MTDomeContainer = ({
   targetPointingAz,
   currentPointingEl,
   targetPointingEl,
+  telescopeRAHour,
+  telescopeRADeg,
+  telescopeDecDeg,
+  telescopeRotatorRad,
+  raDecHourFormat,
   ...props
 }) => {
   if (props.isRaw) {
@@ -100,6 +112,11 @@ const MTDomeContainer = ({
       targetPointingAz={targetPointingAz}
       currentPointingEl={currentPointingEl}
       targetPointingEl={targetPointingEl}
+      telescopeRAHour={telescopeRAHour}
+      telescopeRADeg={telescopeRADeg}
+      telescopeDecDeg={telescopeDecDeg}
+      telescopeRotatorRad={telescopeRotatorRad}
+      raDecHourFormat={raDecHourFormat}
     />
   );
 };
@@ -111,6 +128,7 @@ const mapStateToProps = (state) => {
   const lightWindScreenState = getLightWindScreen(state);
   const domeAzimuthState = getDomeAzimuth(state);
   const pointingState = getPointingStatus(state);
+  const telescopeState = getMainTelescopeState(state);
   return {
     ...domeState,
     ...louversState,
@@ -118,6 +136,7 @@ const mapStateToProps = (state) => {
     ...lightWindScreenState,
     ...domeAzimuthState,
     ...pointingState,
+    ...telescopeState,
   };
 };
 
@@ -129,6 +148,8 @@ const mapDispatchToProps = (dispatch) => {
     'telemetry-MTDome-0-louvers',
     'telemetry-MTMount-0-azimuth',
     'telemetry-MTMount-0-elevation',
+    'telemetry-MTPtg-0-mountStatus',
+    'telemetry-MTPtg-0-mountPosition',
     'event-MTDome-0-azEnabled',
     'event-MTDome-0-azMotion',
     'event-MTDome-0-azTarget',
@@ -136,6 +157,8 @@ const mapDispatchToProps = (dispatch) => {
     'event-MTMount-0-target',
     'event-MTDome-0-summaryState',
     'event-MTMount-0-summaryState',
+    'event-MTPtg-0-currentTarget',
+
   ];
   return {
     subscriptions,

--- a/love/src/components/MainTel/MTDome/MTDome.container.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.container.jsx
@@ -79,6 +79,7 @@ const MTDomeContainer = ({
   targetPointingAz,
   currentPointingEl,
   targetPointingEl,
+  targetName,
   telescopeRAHour,
   telescopeRADeg,
   telescopeDecDeg,
@@ -112,6 +113,7 @@ const MTDomeContainer = ({
       targetPointingAz={targetPointingAz}
       currentPointingEl={currentPointingEl}
       targetPointingEl={targetPointingEl}
+      targetName={targetName}
       telescopeRAHour={telescopeRAHour}
       telescopeRADeg={telescopeRADeg}
       telescopeDecDeg={telescopeDecDeg}
@@ -158,7 +160,6 @@ const mapDispatchToProps = (dispatch) => {
     'event-MTDome-0-summaryState',
     'event-MTMount-0-summaryState',
     'event-MTPtg-0-currentTarget',
-
   ];
   return {
     subscriptions,

--- a/love/src/components/MainTel/MTDome/MTDome.container.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.container.jsx
@@ -72,7 +72,6 @@ const MTDomeContainer = ({
   targetPointingAz,
   currentPointingEl,
   targetPointingEl,
-  mtDomeTracking,
   ...props
 }) => {
   if (props.isRaw) {
@@ -101,7 +100,6 @@ const MTDomeContainer = ({
       targetPointingAz={targetPointingAz}
       currentPointingEl={currentPointingEl}
       targetPointingEl={targetPointingEl}
-      mtDomeTracking={mtDomeTracking}
     />
   );
 };

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -28,9 +28,8 @@ import Azimuth from 'components/GeneralPurpose/Azimuth/Azimuth';
 import Elevation from 'components/GeneralPurpose/Elevation/Elevation';
 import WindRose from '../../icons/WindRose/WindRose';
 import MTDomeSummaryTable from './MTDomeSummaryTable/MTDomeSummaryTable';
-import styles from './MTDome.module.css';
-
 import { MTDomeLouversMapAF, MTDomeLouversMapGN } from 'Config';
+import styles from './MTDome.module.css';
 
 const defaultValuesAF = {
   A1: '0',
@@ -218,6 +217,16 @@ export default class MTDome extends Component {
     targetPointingEl: PropTypes.number,
     /** High level state machine state identifier of the MTMount. */
     mtMountSummaryState: PropTypes.number,
+    /** Telescope current RA in hours */
+    telescopeRAHour: PropTypes.number,
+    /** Telescope current RA in degrees */
+    telescopeRADeg: PropTypes.number,
+    /** Telescope current Dec in degrees */
+    telescopeDecDeg: PropTypes.number,
+    /** Telescope rotator position in rad */
+    telescopeRotatorRad: PropTypes.number,
+    /** Whether to display the RA and DEC in hour format */
+    raDecHourFormat: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -559,6 +568,11 @@ export default class MTDome extends Component {
       currentPointingEl,
       targetPointingAz,
       targetPointingEl,
+      telescopeRAHour,
+      telescopeRADeg,
+      telescopeDecDeg,
+      telescopeRotatorRad,
+      raDecHourFormat,
     } = this.props;
 
     const currentPointing = {
@@ -642,6 +656,11 @@ export default class MTDome extends Component {
                 positionCommandedShutter={positionCommandedShutter}
                 currentPointing={currentPointing}
                 targetPointing={targetPointing}
+                telescopeRAHour={telescopeRAHour}
+                telescopeRADeg={telescopeRADeg}
+                telescopeDecDeg={telescopeDecDeg}
+                telescopeRotatorRad={telescopeRotatorRad}
+                raDecHourFormat={raDecHourFormat}
               />
             </div>
           </div>

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -568,6 +568,7 @@ export default class MTDome extends Component {
       currentPointingEl,
       targetPointingAz,
       targetPointingEl,
+      targetName,
       telescopeRAHour,
       telescopeRADeg,
       telescopeDecDeg,
@@ -656,6 +657,7 @@ export default class MTDome extends Component {
                 positionCommandedShutter={positionCommandedShutter}
                 currentPointing={currentPointing}
                 targetPointing={targetPointing}
+                targetName={targetName}
                 telescopeRAHour={telescopeRAHour}
                 telescopeRADeg={telescopeRADeg}
                 telescopeDecDeg={telescopeDecDeg}

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -536,44 +536,39 @@ export default class MTDome extends Component {
   ];
 
   render() {
-    const isProjected = this.props.isProjected;
-    const width = this.props.width;
-    const height = this.props.height;
+    const {
+      isProjected,
+      width,
+      height,
+      trackId,
+      mtDomeSummaryState,
+      modeDomeStatus,
+      azimuthDomeState,
+      azimuthDomeTarget,
+      azimuthDomeMotion,
+      mtMountSummaryState,
+      positionActualDomeAz,
+      positionCommandedDomeAz,
+      positionActualLightWindScreen,
+      positionCommandedLightWindScreen,
+      positionActualShutter,
+      positionCommandedShutter,
+      actualPositionLouvers,
+      commandedPositionLouvers,
+      currentPointingAz,
+      currentPointingEl,
+      targetPointingAz,
+      targetPointingEl,
+    } = this.props;
 
-    //SummaryPanel
-    const trackID = this.props.trackId;
-    const mtDomeSummaryState = this.props.mtDomeSummaryState;
-    const modeDomeStatus = this.props.modeDomeStatus;
-    const azimuthDomeState = this.props.azimuthDomeState;
-    const azimuthDomeTarget = this.props.azimuthDomeTarget;
-    const azimuthDomeMotion = this.props.azimuthDomeMotion;
-    const mtMountSummaryState = this.props.mtMountSummaryState;
-
-    //domeAzimuth
-    const positionActualDomeAz = this.props.positionActualDomeAz;
-    const positionCommandedDomeAz = this.props.positionCommandedDomeAz;
-
-    //lightWindScreen
-    const positionActualLightWindScreen = this.props.positionActualLightWindScreen;
-    const positionCommandedLightWindScreen = this.props.positionCommandedLightWindScreen;
-
-    //apertureShutters
-    const positionActualShutter = this.props.positionActualShutter;
-    const positionCommandedShutter = this.props.positionCommandedShutter;
-
-    // Louvers
-    const actualPositionLouvers = this.props?.actualPositionLouvers;
-    const commandedPositionLouvers = this.props?.commandedPositionLouvers;
-
-    // pointing
     const currentPointing = {
-      az: this.props.currentPointingAz,
-      el: this.props.currentPointingEl,
+      az: currentPointingAz,
+      el: currentPointingEl,
     };
 
     const targetPointing = {
-      az: this.props.targetPointingAz,
-      el: this.props.targetPointingEl,
+      az: targetPointingAz,
+      el: targetPointingEl,
     };
 
     return (
@@ -632,7 +627,7 @@ export default class MTDome extends Component {
             </div>
             <div className={styles.divSummaryTable}>
               <MTDomeSummaryTable
-                trackID={trackID}
+                trackId={trackId}
                 mtDomeSummaryState={mtDomeSummaryState}
                 mtMountSummaryState={mtMountSummaryState}
                 modeDomeStatus={modeDomeStatus}

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -548,7 +548,6 @@ export default class MTDome extends Component {
     const azimuthDomeTarget = this.props.azimuthDomeTarget;
     const azimuthDomeMotion = this.props.azimuthDomeMotion;
     const mtMountSummaryState = this.props.mtMountSummaryState;
-    const mtDomeTracking = this.props.mtDomeTracking;
 
     //domeAzimuth
     const positionActualDomeAz = this.props.positionActualDomeAz;
@@ -648,7 +647,6 @@ export default class MTDome extends Component {
                 positionCommandedShutter={positionCommandedShutter}
                 currentPointing={currentPointing}
                 targetPointing={targetPointing}
-                domeTracking={mtDomeTracking}
               />
             </div>
           </div>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -39,7 +39,7 @@ import {
   mtdomeMotionStateMap,
   mtdomeMotionStatetoStyle,
   MTMountLimits,
-} from '../../../../Config';
+} from 'Config';
 
 export default class MTDomeSummaryTable extends Component {
   static propTypes = {
@@ -108,6 +108,11 @@ export default class MTDomeSummaryTable extends Component {
 
     const { az: mountActualAz, el: mountActualEl } = currentPointing;
     const { az: mountCommandedAz, el: mountCommandedEl } = targetPointing;
+
+    const shutterPositionActual1 = Math.round(positionActualShutter[0] ?? 0);
+    const shutterPositionCommanded1 = Math.round(positionCommandedShutter[0] ?? 0);
+    const shutterPositionActual2 = Math.round(positionActualShutter[1] ?? 0);
+    const shutterPositionCommanded2 = Math.round(positionCommandedShutter[1] ?? 0);
 
     return (
       <div className={styles.divSummary}>
@@ -181,8 +186,8 @@ export default class MTDomeSummaryTable extends Component {
             <Label>Shutters</Label>
           </SummaryPanel>
           <div className={styles.divProgressBars}>
-            <ProgressBar targetValue={positionCommandedShutter} completed={positionActualShutter} />
-            <ProgressBar targetValue={positionCommandedShutter} completed={positionActualShutter} />
+            <ProgressBar targetValue={shutterPositionCommanded1} completed={shutterPositionActual1} />
+            <ProgressBar targetValue={shutterPositionCommanded2} completed={shutterPositionActual2} />
           </div>
         </SummaryPanel>
       </div>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -215,9 +215,7 @@ export default class MTDomeSummaryTable extends Component {
           </Row>
         </SummaryPanel>
         <SummaryPanel className={styles.shutters}>
-          <SummaryPanel>
-            <Label>Shutters</Label>
-          </SummaryPanel>
+          <Title>Shutters</Title>
           <div className={styles.divProgressBars}>
             <ProgressBar targetValue={shutterPositionCommanded1} completed={shutterPositionActual1} />
             <ProgressBar targetValue={shutterPositionCommanded2} completed={shutterPositionActual2} />

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -39,8 +39,6 @@ import {
   mtdomeMotionStateMap,
   mtdomeMotionStatetoStyle,
   MTMountLimits,
-  mtDomeTrackingStateMap,
-  mtDomeTrackingStatetoStyle,
 } from '../../../../Config';
 
 export default class MTDomeSummaryTable extends Component {
@@ -91,14 +89,11 @@ export default class MTDomeSummaryTable extends Component {
     const azimuthDomeState = mtDomeAzimuthEnabledStateMap[this.props.azimuthDomeState];
     const azimuthDomeMotion = mtdomeMotionStateMap[this.props.azimuthDomeMotion];
     const mtMountStatus = summaryStateMap[this.props.mtMountSummaryState];
-    const mtDomeTrackingName = mtDomeTrackingStateMap[this.props.domeTracking];
-    const mtDomeTrackingStyle = mtDomeTrackingStatetoStyle[mtDomeTrackingName];
-
     const domeActualAz = this.props.positionActualDomeAz;
     const domeCommandedAz = this.props.positionCommandedDomeAz;
 
-    const { az: mountActualAz, el: mountActualEl } = this.props.currentPointing;
-    const { az: mountCommandedAz, el: mountCommandedEl } = this.props.targetPointing;
+    const { az: mountActualAz, el: mountActualEl } = currentPointing;
+    const { az: mountCommandedAz, el: mountCommandedEl } = targetPointing;
 
     return (
       <div className={styles.divSummary}>
@@ -112,10 +107,6 @@ export default class MTDomeSummaryTable extends Component {
           <Label>Mode</Label>
           <Value>
             <StatusText status={mtDomeModeStatetoStyle[modeDomeStatus]}>{modeDomeStatus}</StatusText>
-          </Value>
-          <Label>Tracking</Label>
-          <Value>
-            <StatusText status={mtDomeTrackingStyle}>{mtDomeTrackingName}</StatusText>
           </Value>
           <Label>Az State</Label>
           <Value>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -109,6 +109,7 @@ export default class MTDomeSummaryTable extends Component {
       targetPointing,
       positionActualShutter,
       positionCommandedShutter,
+      targetName,
       telescopeRAHour,
       telescopeRADeg,
       telescopeDecDeg,
@@ -129,7 +130,7 @@ export default class MTDomeSummaryTable extends Component {
     const shutterPositionCommanded1 = Math.round(positionCommandedShutter[0] ?? 0);
     const shutterPositionActual2 = Math.round(positionActualShutter[1] ?? 0);
     const shutterPositionCommanded2 = Math.round(positionCommandedShutter[1] ?? 0);
-    
+
     const parsedTelescopeRAHour = formatHoursToDigital(telescopeRAHour);
     const parsedTelescopeDecHour = degreesToDMS(telescopeDecDeg);
     const parsedTelescopeRADeg = defaultNumberFormatter(telescopeRADeg, 2) + '°';
@@ -143,6 +144,8 @@ export default class MTDomeSummaryTable extends Component {
         <SummaryPanel className={styles.summaryTable}>
           <Title>Track ID</Title>
           <Value>{trackId?.toString()}</Value>
+          <Label>Target Name</Label>
+          <Value>{targetName}</Value>
           <Label>Telescope RA</Label>
           <Value>{telescopeRAText}</Value>
           <Label>Telescope Dec</Label>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -18,17 +18,16 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import React, { Component } from 'react';
-import styles from './MTDomeSummaryTable.module.css';
-import StatusText from '../../../GeneralPurpose/StatusText/StatusText';
-import CurrentTargetValue from '../../../GeneralPurpose/CurrentTargetValue/CurrentTargetValue';
 import PropTypes from 'prop-types';
-import Limits from '../../../GeneralPurpose/Limits/Limits';
-import SummaryPanel from '../../../GeneralPurpose/SummaryPanel/SummaryPanel';
-import Row from '../../../GeneralPurpose/SummaryPanel/Row';
-import Label from '../../../GeneralPurpose/SummaryPanel/Label';
-import Value from '../../../GeneralPurpose/SummaryPanel/Value';
-import Title from '../../../GeneralPurpose/SummaryPanel/Title';
-import ProgressBar from '../../../GeneralPurpose/ProgressBar/ProgressBar';
+import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
+import CurrentTargetValue from 'components/GeneralPurpose/CurrentTargetValue/CurrentTargetValue';
+import Limits from 'components/GeneralPurpose/Limits/Limits';
+import SummaryPanel from 'components/GeneralPurpose/SummaryPanel/SummaryPanel';
+import Row from 'components/GeneralPurpose/SummaryPanel/Row';
+import Label from 'components/GeneralPurpose/SummaryPanel/Label';
+import Value from 'components/GeneralPurpose/SummaryPanel/Value';
+import Title from 'components/GeneralPurpose/SummaryPanel/Title';
+import ProgressBar from 'components/GeneralPurpose/ProgressBar/ProgressBar';
 import {
   summaryStateMap,
   summaryStateToStyle,
@@ -40,6 +39,8 @@ import {
   mtdomeMotionStatetoStyle,
   MTMountLimits,
 } from 'Config';
+import { formatHoursToDigital, degreesToDMS, degrees, defaultNumberFormatter } from 'Utils';
+import styles from './MTDomeSummaryTable.module.css';
 
 export default class MTDomeSummaryTable extends Component {
   static propTypes = {
@@ -67,6 +68,16 @@ export default class MTDomeSummaryTable extends Component {
     positionActualShutter: PropTypes.array,
     /** Commanded shutter position */
     positionCommandedShutter: PropTypes.array,
+    /** Telescope current RA in hours */
+    telescopeRAHour: PropTypes.number,
+    /** Telescope current RA in degrees */
+    telescopeRADeg: PropTypes.number,
+    /** Telescope current Dec in degrees */
+    telescopeDecDeg: PropTypes.number,
+    /** Telescope rotator position in rad */
+    telescopeRotatorRad: PropTypes.number,
+    /** Whether to display the RA and DEC in hour format */
+    raDecHourFormat: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -98,6 +109,11 @@ export default class MTDomeSummaryTable extends Component {
       targetPointing,
       positionActualShutter,
       positionCommandedShutter,
+      telescopeRAHour,
+      telescopeRADeg,
+      telescopeDecDeg,
+      telescopeRotatorRad,
+      raDecHourFormat,
     } = this.props;
 
     const mtDomeStatusText = summaryStateMap[mtDomeSummaryState];
@@ -113,12 +129,26 @@ export default class MTDomeSummaryTable extends Component {
     const shutterPositionCommanded1 = Math.round(positionCommandedShutter[0] ?? 0);
     const shutterPositionActual2 = Math.round(positionActualShutter[1] ?? 0);
     const shutterPositionCommanded2 = Math.round(positionCommandedShutter[1] ?? 0);
+    
+    const parsedTelescopeRAHour = formatHoursToDigital(telescopeRAHour);
+    const parsedTelescopeDecHour = degreesToDMS(telescopeDecDeg);
+    const parsedTelescopeRADeg = defaultNumberFormatter(telescopeRADeg, 2) + '°';
+    const parsedTelescopeDecDeg = defaultNumberFormatter(telescopeDecDeg, 2) + '°';
+    const parsedTelescopeRotatorDeg = defaultNumberFormatter(degrees(telescopeRotatorRad), 2) + '°';
+    const telescopeRAText = raDecHourFormat ? parsedTelescopeRAHour : parsedTelescopeRADeg;
+    const telescopeDecText = raDecHourFormat ? parsedTelescopeDecHour : parsedTelescopeDecDeg;
 
     return (
       <div className={styles.divSummary}>
         <SummaryPanel className={styles.summaryTable}>
           <Title>Track ID</Title>
           <Value>{trackId?.toString()}</Value>
+          <Label>Telescope RA</Label>
+          <Value>{telescopeRAText}</Value>
+          <Label>Telescope Dec</Label>
+          <Value>{telescopeDecText}</Value>
+          <Label>Rotator</Label>
+          <Value>{parsedTelescopeRotatorDeg}</Value>
           <Title>MTDome CSC</Title>
           <Value>
             <StatusText status={summaryStateToStyle[mtDomeStatusText]}>{mtDomeStatusText}</StatusText>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -45,26 +45,28 @@ export default class MTDomeSummaryTable extends Component {
   static propTypes = {
     /** Unique target identifier. Echoed from the trackTarget command */
     trackId: PropTypes.number,
-    /** High level state machine state identifier */
+    /** Summary state of the MTDome CSC */
     mtDomeSummaryState: PropTypes.number,
-    /** High level state machine state identifier */
+    /** Summary state of the MTMount CSC */
     mtMountSummaryState: PropTypes.number,
-    /** Enabled state; an EnabledState enum */
+    /** Azimuth dome state */
     azimuthDomeState: PropTypes.number,
-    /** The motion state; a MotionState enum */
+    /** Azimuth dome motion */
     azimuthDomeMotion: PropTypes.number,
-    /** Target position; nan for the crawlAz command */
-    azimuthDomeTarget: PropTypes.number,
-    /** Operational mode; an OperationalMode enum */
+    /** Operational dome mode */
     modeDomeStatus: PropTypes.number,
-    /** Position measured by the encoders */
-    currentPointingAz: PropTypes.number,
-    /** Position computed by the path generator */
-    targetPointingAz: PropTypes.number,
-    /** Position measured by the encoders */
-    currentPointingEl: PropTypes.number,
-    /** Position computed by the path generator */
-    targetPointingEl: PropTypes.number,
+    /** Actual dome azimuth position */
+    positionActualDomeAz: PropTypes.number,
+    /** Commanded dome azimuth position */
+    positionCommandedDomeAz: PropTypes.number,
+    /** Telescope current pointing */
+    currentPointing: PropTypes.object,
+    /** Telescope target pointing */
+    targetPointing: PropTypes.object,
+    /** Actual shutter position */
+    positionActualShutter: PropTypes.array,
+    /** Commanded shutter position */
+    positionCommandedShutter: PropTypes.array,
   };
 
   static defaultProps = {
@@ -73,13 +75,13 @@ export default class MTDomeSummaryTable extends Component {
     mtMountSummaryState: 0,
     azimuthDomeState: 0,
     azimuthDomeMotion: 0,
-    azimuthDomeTarget: 0,
-    elevationDomeTarget: 0,
     modeDomeStatus: 0,
-    currentPointingAz: 0,
-    targetPointingAz: 0,
-    currentPointingEl: 0,
-    targetPointingEl: 0,
+    positionActualDomeAz: 0,
+    positionCommandedDomeAz: 0,
+    currentPointing: { az: 0, el: 0 },
+    targetPointing: { az: 0, el: 0 },
+    positionActualShutter: [],
+    positionCommandedShutter: [],
   };
 
   render() {

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -83,14 +83,26 @@ export default class MTDomeSummaryTable extends Component {
   };
 
   render() {
-    const trackID = this.props.trackID;
-    const mtDomeStatus = summaryStateMap[this.props.mtDomeSummaryState];
-    const modeDomeStatus = mtDomeModeStateMap[this.props.modeDomeStatus];
-    const azimuthDomeState = mtDomeAzimuthEnabledStateMap[this.props.azimuthDomeState];
-    const azimuthDomeMotion = mtdomeMotionStateMap[this.props.azimuthDomeMotion];
-    const mtMountStatus = summaryStateMap[this.props.mtMountSummaryState];
-    const domeActualAz = this.props.positionActualDomeAz;
-    const domeCommandedAz = this.props.positionCommandedDomeAz;
+    const {
+      trackId,
+      mtDomeSummaryState,
+      mtMountSummaryState,
+      azimuthDomeState,
+      azimuthDomeMotion,
+      modeDomeStatus,
+      positionActualDomeAz,
+      positionCommandedDomeAz,
+      currentPointing,
+      targetPointing,
+      positionActualShutter,
+      positionCommandedShutter,
+    } = this.props;
+
+    const mtDomeStatusText = summaryStateMap[mtDomeSummaryState];
+    const modeDomeStatusText = mtDomeModeStateMap[modeDomeStatus];
+    const azimuthDomeStateText = mtDomeAzimuthEnabledStateMap[azimuthDomeState];
+    const azimuthDomeMotionText = mtdomeMotionStateMap[azimuthDomeMotion];
+    const mtMountStatusText = summaryStateMap[mtMountSummaryState];
 
     const { az: mountActualAz, el: mountActualEl } = currentPointing;
     const { az: mountCommandedAz, el: mountCommandedEl } = targetPointing;
@@ -99,31 +111,37 @@ export default class MTDomeSummaryTable extends Component {
       <div className={styles.divSummary}>
         <SummaryPanel className={styles.summaryTable}>
           <Title>Track ID</Title>
-          <Value>{trackID?.toString()}</Value>
+          <Value>{trackId?.toString()}</Value>
           <Title>MTDome CSC</Title>
           <Value>
-            <StatusText status={summaryStateToStyle[mtDomeStatus]}>{mtDomeStatus}</StatusText>
+            <StatusText status={summaryStateToStyle[mtDomeStatusText]}>{mtDomeStatusText}</StatusText>
           </Value>
           <Label>Mode</Label>
           <Value>
-            <StatusText status={mtDomeModeStatetoStyle[modeDomeStatus]}>{modeDomeStatus}</StatusText>
+            <StatusText status={mtDomeModeStatetoStyle[modeDomeStatusText]}>{modeDomeStatusText}</StatusText>
           </Value>
           <Label>Az State</Label>
           <Value>
-            <StatusText status={mtDomeAzimuthEnabledStatetoStyle[azimuthDomeState]}>{azimuthDomeState}</StatusText>
+            <StatusText status={mtDomeAzimuthEnabledStatetoStyle[azimuthDomeStateText]}>
+              {azimuthDomeStateText}
+            </StatusText>
           </Value>
           <Label>Az Motion</Label>
           <Value>
-            <StatusText status={mtdomeMotionStatetoStyle[azimuthDomeMotion]}>{azimuthDomeMotion}</StatusText>
+            <StatusText status={mtdomeMotionStatetoStyle[azimuthDomeMotionText]}>{azimuthDomeMotionText}</StatusText>
           </Value>
           <Label>Az</Label>
           <Value>
-            <CurrentTargetValue currentValue={domeActualAz} targetValue={domeCommandedAz} isChanging={true} />
+            <CurrentTargetValue
+              currentValue={positionActualDomeAz}
+              targetValue={positionCommandedDomeAz}
+              isChanging={true}
+            />
           </Value>
 
           <Title>MTMount CSC</Title>
           <Value>
-            <StatusText status={summaryStateToStyle[mtMountStatus]}>{mtMountStatus}</StatusText>
+            <StatusText status={summaryStateToStyle[mtMountStatusText]}>{mtMountStatusText}</StatusText>
           </Value>
           <Label>Elevation</Label>
           <Value>
@@ -161,14 +179,8 @@ export default class MTDomeSummaryTable extends Component {
             <Label>Shutters</Label>
           </SummaryPanel>
           <div className={styles.divProgressBars}>
-            <ProgressBar
-              targetValue={this.props.positionCommandedShutter}
-              completed={this.props.positionActualShutter}
-            />
-            <ProgressBar
-              targetValue={this.props.positionCommandedShutter}
-              completed={this.props.positionActualShutter}
-            />
+            <ProgressBar targetValue={positionCommandedShutter} completed={positionActualShutter} />
+            <ProgressBar targetValue={positionCommandedShutter} completed={positionActualShutter} />
           </div>
         </SummaryPanel>
       </div>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.module.css
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.module.css
@@ -25,22 +25,9 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   background-color: var(--second-quaternary-background-dimmed-color);
 }
 
-/* .summaryTable {
-  align-self: center;
-  grid-template-columns: 0.5fr 0.5fr;
-  padding: 20px;
-}
-
-.summaryState {
-  border-radius: 1rem;
-  font-weight: 550;
-  text-align: center;
-  display: inline-block;
-  width: 10em;
-} */
-
 .shutters {
   display: block;
+  padding: 0;
 }
 
 .divProgressBars {

--- a/love/src/components/MainTel/TMA/Summary/Summary.jsx
+++ b/love/src/components/MainTel/TMA/Summary/Summary.jsx
@@ -158,8 +158,8 @@ export default class Summary extends Component {
           </Value>
           <Label>
             <CurrentTargetValue
-              currentValue={azimuthActualPosition.toFixed(2)}
-              targetValue={azimuthDemandPosition.toFixed(2)}
+              currentValue={azimuthActualPosition}
+              targetValue={azimuthDemandPosition}
               isChanging={true}
             />
           </Label>
@@ -201,8 +201,8 @@ export default class Summary extends Component {
           </Value>
           <Label>
             <CurrentTargetValue
-              currentValue={elevationActualPosition.toFixed(2)}
-              targetValue={elevationDemandPosition.toFixed(2)}
+              currentValue={elevationActualPosition}
+              targetValue={elevationDemandPosition}
               isChanging={true}
             />
           </Label>

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -721,9 +721,9 @@ export const getATMCSState = (state) => {
     'event-ATMCS-0-allAxesInPosition',
     'event-ATMCS-0-m3State',
     'event-ATMCS-0-positionLimits',
-    'event-ATPtg-1-timesOfLimits',
     'event-ATMCS-0-summaryState',
-    `event-ATPtg-1-currentTarget`,
+    'event-ATPtg-0-timesOfLimits',
+    `event-ATPtg-0-currentTarget`,
   ];
   const data = getStreamsData(state, subscriptions);
   const [minEl, minAz, minNas1, minNas2, minM3] = data['event-ATMCS-0-positionLimits']?.[0].minimum?.value ?? [
@@ -753,25 +753,29 @@ export const getATMCSState = (state) => {
     maxNas1,
     maxNas2,
     maxM3,
-    timeAzLim: data['event-ATPtg-1-timesOfLimits']?.[0].timeAzLim?.value ?? 0,
-    timeRotLim: data['event-ATPtg-1-timesOfLimits']?.[0].timeRotLim?.value ?? 0,
-    timeUnobservable: data['event-ATPtg-1-timesOfLimits']?.[0].timeUnobservable?.value ?? 0,
-    timeElHighLimit: data['event-ATPtg-1-timesOfLimits']?.[0].timeElHighLimit?.value ?? 0,
     currentPointingAz: data['telemetry-ATMCS-0-mount_AzEl_Encoders']?.azimuthCalculatedAngle?.value?.[0],
     currentPointingEl: data['telemetry-ATMCS-0-mount_AzEl_Encoders']?.elevationCalculatedAngle?.value?.[0],
     currentPointingNasmyth1: data['telemetry-ATMCS-0-mount_Nasmyth_Encoders']?.nasmyth1CalculatedAngle?.value?.[0],
     currentPointingNasmyth2: data['telemetry-ATMCS-0-mount_Nasmyth_Encoders']?.nasmyth2CalculatedAngle?.value?.[0],
-    targetName: data[`event-ATPtg-1-currentTarget`]?.[0].targetName?.value ?? 'Unknown',
+    timeAzLim: data['event-ATPtg-0-timesOfLimits']?.[0].timeAzLim?.value ?? 0,
+    timeRotLim: data['event-ATPtg-0-timesOfLimits']?.[0].timeRotLim?.value ?? 0,
+    timeUnobservable: data['event-ATPtg-0-timesOfLimits']?.[0].timeUnobservable?.value ?? 0,
+    timeElHighLimit: data['event-ATPtg-0-timesOfLimits']?.[0].timeElHighLimit?.value ?? 0,
+    targetName: data[`event-ATPtg-0-currentTarget`]?.[0].targetName?.value ?? 'Unknown',
   };
 };
 
 export const getAuxiliaryTelescopeState = (state) => {
-  const subscriptions = ['telemetry-Scheduler-2-observatoryState'];
+  const subscriptions = [
+    'telemetry-ATPtg-0-mountStatus',
+    'telemetry-ATPtg-0-mountPosition',
+  ];
   const data = getStreamsData(state, subscriptions);
   return {
-    telescopeRA: data['telemetry-Scheduler-2-observatoryState']?.ra?.value ?? 0,
-    telescopeDec: data['telemetry-Scheduler-2-observatoryState']?.declination?.value ?? 0,
-    telescopeRotator: data['telemetry-Scheduler-2-observatoryState']?.telescopeRotator?.value ?? 0,
+    telescopeRAHour: data['telemetry-ATPtg-0-mountStatus']?.mountRA?.value ?? 0,
+    telescopeRADeg: data['telemetry-ATPtg-0-mountPosition']?.ra?.value ?? 0,
+    telescopeDecDeg: data['telemetry-ATPtg-0-mountStatus']?.mountDec?.value ?? 0,
+    telescopeRotatorRad: data['telemetry-ATPtg-0-mountStatus']?.mountRot?.value ?? 0,
   };
 };
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -709,8 +709,6 @@ export const getDomeState = (state) => {
     dropoutDoorState: domeData['event-ATDome-0-dropoutDoorState']?.[0].state?.value ?? 0,
     mainDoorState: domeData['event-ATDome-0-mainDoorState']?.[0].state?.value ?? 0,
     atDomeSummaryState: domeData['event-ATDome-0-summaryState']?.[0].summaryState?.value ?? 0,
-    // TODO: The following parameter is missing a CSC, add it when it becomes available//
-    atDomeTracking: 0,
   };
 };
 
@@ -1302,8 +1300,6 @@ export const getDomeStatus = (state) => {
     azimuthDomeTarget: domeStatus['event-MTDome-0-azTarget']?.[0]?.position?.value ?? 0,
     modeDomeStatus: domeStatus['event-MTDome-0-operationalMode']?.[0]?.operationalMode?.value ?? 0,
     mtMountSummaryState: domeStatus['event-MTMount-0-summaryState']?.[0]?.summaryState?.value ?? 0,
-    // TODO: The following parameter is missing a CSC, add it when it becomes available//
-    mtDomeTracking: 0,
   };
 };
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -1307,6 +1307,20 @@ export const getDomeStatus = (state) => {
   };
 };
 
+export const getMainTelescopeState = (state) => {
+  const subscriptions = [
+    'telemetry-MTPtg-0-mountStatus',
+    'telemetry-MTPtg-0-mountPosition'
+  ];
+  const data = getStreamsData(state, subscriptions);
+  return {
+    telescopeRAHour: data[`telemetry-MTPtg-0-mountStatus`]?.mountRA?.value ?? 0,
+    telescopeRADeg: data[`telemetry-MTPtg-0-mountPosition`]?.ra?.value ?? 0,
+    telescopeDecDeg: data[`telemetry-MTPtg-0-mountStatus`]?.mountDec?.value ?? 0,
+    telescopeRotatorRad: data[`telemetry-MTPtg-0-mountStatus`]?.mountRot?.value ?? 0,
+  };
+};
+
 // MTDome Power Draw
 export const getMtDomePowerDraw = (state) => {
   const subscriptions = [

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -723,7 +723,6 @@ export const getATMCSState = (state) => {
     'event-ATMCS-0-positionLimits',
     'event-ATMCS-0-summaryState',
     'event-ATPtg-0-timesOfLimits',
-    `event-ATPtg-0-currentTarget`,
   ];
   const data = getStreamsData(state, subscriptions);
   const [minEl, minAz, minNas1, minNas2, minM3] = data['event-ATMCS-0-positionLimits']?.[0].minimum?.value ?? [
@@ -761,7 +760,6 @@ export const getATMCSState = (state) => {
     timeRotLim: data['event-ATPtg-0-timesOfLimits']?.[0].timeRotLim?.value ?? 0,
     timeUnobservable: data['event-ATPtg-0-timesOfLimits']?.[0].timeUnobservable?.value ?? 0,
     timeElHighLimit: data['event-ATPtg-0-timesOfLimits']?.[0].timeElHighLimit?.value ?? 0,
-    targetName: data[`event-ATPtg-0-currentTarget`]?.[0].targetName?.value ?? 'Unknown',
   };
 };
 
@@ -769,6 +767,7 @@ export const getAuxiliaryTelescopeState = (state) => {
   const subscriptions = [
     'telemetry-ATPtg-0-mountStatus',
     'telemetry-ATPtg-0-mountPosition',
+    'event-ATPtg-0-currentTarget',
   ];
   const data = getStreamsData(state, subscriptions);
   return {
@@ -776,6 +775,7 @@ export const getAuxiliaryTelescopeState = (state) => {
     telescopeRADeg: data['telemetry-ATPtg-0-mountPosition']?.ra?.value ?? 0,
     telescopeDecDeg: data['telemetry-ATPtg-0-mountStatus']?.mountDec?.value ?? 0,
     telescopeRotatorRad: data['telemetry-ATPtg-0-mountStatus']?.mountRot?.value ?? 0,
+    targetName: data['event-ATPtg-0-currentTarget']?.[0].targetName?.value ?? 'Unknown',
   };
 };
 
@@ -1310,14 +1310,16 @@ export const getDomeStatus = (state) => {
 export const getMainTelescopeState = (state) => {
   const subscriptions = [
     'telemetry-MTPtg-0-mountStatus',
-    'telemetry-MTPtg-0-mountPosition'
+    'telemetry-MTPtg-0-mountPosition',
+    'event-MTPtg-0-currentTarget',
   ];
   const data = getStreamsData(state, subscriptions);
   return {
-    telescopeRAHour: data[`telemetry-MTPtg-0-mountStatus`]?.mountRA?.value ?? 0,
-    telescopeRADeg: data[`telemetry-MTPtg-0-mountPosition`]?.ra?.value ?? 0,
-    telescopeDecDeg: data[`telemetry-MTPtg-0-mountStatus`]?.mountDec?.value ?? 0,
-    telescopeRotatorRad: data[`telemetry-MTPtg-0-mountStatus`]?.mountRot?.value ?? 0,
+    telescopeRAHour: data['telemetry-MTPtg-0-mountStatus']?.mountRA?.value ?? 0,
+    telescopeRADeg: data['telemetry-MTPtg-0-mountPosition']?.ra?.value ?? 0,
+    telescopeDecDeg: data['telemetry-MTPtg-0-mountStatus']?.mountDec?.value ?? 0,
+    telescopeRotatorRad: data['telemetry-MTPtg-0-mountStatus']?.mountRot?.value ?? 0,
+    targetName: data['event-MTPtg-0-currentTarget']?.[0].targetName?.value ?? 'Unknown',
   };
 };
 


### PR DESCRIPTION
This PR is a continuation of #656 as an effort to include RA, dec and rotator angles information on the current dome displays, specifically on the `MTDomeSummaryTable` and `AuxTel/Dome/DomeSummaryTable/DomeSummaryTable` components.

A couple extra things where done along this work:
- Deprecated dome tracking displays were removed as there is not telemetry for them.
- Adjustments on utility functions to convert RA and Dec degrees to `hour:minute:second` and `degree° minute' seconds"` format.
- Added a new utility function for converting hours into digital format: `formatHoursToDigital`.
- Fixed some wrongly set saldindices for ATPtg topics.
- Code cleaning in components.
- Fixed aperture shutter positions display and layout for `MTDomeSummaryTable` component.