### PR TITLE
Show error details for requests to the LOVE-manager.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.4.1
+------
+
+* Show error details for requests to the LOVE-manager. `<https://github.com/lsst-ts/LOVE-frontend/pull/678>`_
+
 v6.4.0
 ------
 

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -2105,7 +2105,8 @@ export function checkJSONResponse(response, onSuccess) {
   }
   if (response.status === 400) {
     return response.json().then((resp) => {
-      toast.error(resp.ack);
+      const errorMsg = resp.error ? `${resp.ack}: ${resp.error}` : resp.ack;
+      toast.error(errorMsg);
       return false;
     });
   }


### PR DESCRIPTION
This PR makes a small change to the `checkJSONResponse` utility function to give more details to the user in case of existent of errors details sent from the LOVE-manager.
This PR is related to: https://github.com/lsst-ts/LOVE-manager/pull/294.