### PR TITLE
Fix telescope RA and Rotator display on DomeSummaryTable components.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.0
 ------
 
+* Fix telescope RA and Rotator display on DomeSummaryTable components. `<https://github.com/lsst-ts/LOVE-frontend/pull/685>`_
 * Add a button to log alarms from the AlarmsList and AlarmsTable components. `<https://github.com/lsst-ts/LOVE-frontend/pull/684>`_
 
 v6.6.0

--- a/love/src/components/AuxTel/Dome/Dome.container.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.container.jsx
@@ -103,7 +103,7 @@ const DomeContainer = ({
   telescopeRAHour,
   telescopeRADeg,
   telescopeDecDeg,
-  telescopeRotatorRad,
+  telescopeRotatorDeg,
   raDecHourFormat,
   ...props
 }) => {
@@ -158,7 +158,7 @@ const DomeContainer = ({
       telescopeRAHour={telescopeRAHour}
       telescopeRADeg={telescopeRADeg}
       telescopeDecDeg={telescopeDecDeg}
-      telescopeRotatorRad={telescopeRotatorRad}
+      telescopeRotatorDeg={telescopeRotatorDeg}
       raDecHourFormat={raDecHourFormat}
     />
   );

--- a/love/src/components/AuxTel/Dome/Dome.container.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.container.jsx
@@ -178,7 +178,7 @@ const mapDispatchToProps = (dispatch) => {
     'telemetry-ATMCS-0-mount_Nasmyth_Encoders',
     'telemetry-Scheduler-2-observatoryState',
     'telemetry-ATPtg-0-mountStatus',
-    'telemetry-ATPtg-0-mountPosition',
+    'telemetry-ATPtg-0-mountPositions',
     'event-ATDome-0-azimuthState',
     'event-ATDome-0-azimuthCommandedState',
     'event-ATDome-0-dropoutDoorState',

--- a/love/src/components/AuxTel/Dome/Dome.jsx
+++ b/love/src/components/AuxTel/Dome/Dome.jsx
@@ -109,8 +109,8 @@ export default class Dome extends Component {
     telescopeRADeg: PropTypes.number,
     /** Telescope current Dec in degrees */
     telescopeDecDeg: PropTypes.number,
-    /** Telescope rotator position in rad */
-    telescopeRotatorRad: PropTypes.number,
+    /** Telescope rotator position in degrees */
+    telescopeRotatorDeg: PropTypes.number,
     /** Whether to display the RA and DEC in hour format */
     raDecHourFormat: PropTypes.bool,
   };
@@ -306,7 +306,7 @@ export default class Dome extends Component {
       telescopeRAHour,
       telescopeRADeg,
       telescopeDecDeg,
-      telescopeRotatorRad,
+      telescopeRotatorDeg,
       raDecHourFormat,
     } = this.props;
 
@@ -447,7 +447,7 @@ export default class Dome extends Component {
             telescopeRAHour={telescopeRAHour}
             telescopeRADeg={telescopeRADeg}
             telescopeDecDeg={telescopeDecDeg}
-            telescopeRotatorRad={telescopeRotatorRad}
+            telescopeRotatorDeg={telescopeRotatorDeg}
             raDecHourFormat={raDecHourFormat}
           />
         </div>

--- a/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
+++ b/love/src/components/AuxTel/Dome/DomeSummaryTable/DomeSummaryTable.jsx
@@ -71,7 +71,7 @@ export default class DomeSummaryTable extends Component {
     telescopeRAHour: PropTypes.number,
     telescopeRADeg: PropTypes.number,
     telescopeDecDeg: PropTypes.number,
-    telescopeRotatorRad: PropTypes.number,
+    telescopeRotatorDeg: PropTypes.number,
     raDecHourFormat: PropTypes.bool,
   };
 
@@ -113,7 +113,7 @@ export default class DomeSummaryTable extends Component {
       telescopeRAHour,
       telescopeRADeg,
       telescopeDecDeg,
-      telescopeRotatorRad,
+      telescopeRotatorDeg,
       raDecHourFormat,
     } = this.props;
 
@@ -159,7 +159,7 @@ export default class DomeSummaryTable extends Component {
     const parsedTelescopeDecHour = degreesToDMS(telescopeDecDeg);
     const parsedTelescopeRADeg = defaultNumberFormatter(telescopeRADeg, 2) + '°';
     const parsedTelescopeDecDeg = defaultNumberFormatter(telescopeDecDeg, 2) + '°';
-    const parsedTelescopeRotatorDeg = defaultNumberFormatter(degrees(telescopeRotatorRad), 2) + '°';
+    const parsedTelescopeRotatorDeg = defaultNumberFormatter(telescopeRotatorDeg, 2) + '°';
     const telescopeRAText = raDecHourFormat ? parsedTelescopeRAHour : parsedTelescopeRADeg;
     const telescopeDecText = raDecHourFormat ? parsedTelescopeDecHour : parsedTelescopeDecDeg;
 

--- a/love/src/components/MainTel/MTDome/MTDome.container.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.container.jsx
@@ -83,7 +83,7 @@ const MTDomeContainer = ({
   telescopeRAHour,
   telescopeRADeg,
   telescopeDecDeg,
-  telescopeRotatorRad,
+  telescopeRotatorDeg,
   raDecHourFormat,
   ...props
 }) => {
@@ -117,7 +117,7 @@ const MTDomeContainer = ({
       telescopeRAHour={telescopeRAHour}
       telescopeRADeg={telescopeRADeg}
       telescopeDecDeg={telescopeDecDeg}
-      telescopeRotatorRad={telescopeRotatorRad}
+      telescopeRotatorDeg={telescopeRotatorDeg}
       raDecHourFormat={raDecHourFormat}
     />
   );

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -223,8 +223,8 @@ export default class MTDome extends Component {
     telescopeRADeg: PropTypes.number,
     /** Telescope current Dec in degrees */
     telescopeDecDeg: PropTypes.number,
-    /** Telescope rotator position in rad */
-    telescopeRotatorRad: PropTypes.number,
+    /** Telescope rotator position in degrees */
+    telescopeRotatorDeg: PropTypes.number,
     /** Whether to display the RA and DEC in hour format */
     raDecHourFormat: PropTypes.bool,
   };
@@ -572,7 +572,7 @@ export default class MTDome extends Component {
       telescopeRAHour,
       telescopeRADeg,
       telescopeDecDeg,
-      telescopeRotatorRad,
+      telescopeRotatorDeg,
       raDecHourFormat,
     } = this.props;
 
@@ -661,7 +661,7 @@ export default class MTDome extends Component {
                 telescopeRAHour={telescopeRAHour}
                 telescopeRADeg={telescopeRADeg}
                 telescopeDecDeg={telescopeDecDeg}
-                telescopeRotatorRad={telescopeRotatorRad}
+                telescopeRotatorDeg={telescopeRotatorDeg}
                 raDecHourFormat={raDecHourFormat}
               />
             </div>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -74,8 +74,8 @@ export default class MTDomeSummaryTable extends Component {
     telescopeRADeg: PropTypes.number,
     /** Telescope current Dec in degrees */
     telescopeDecDeg: PropTypes.number,
-    /** Telescope rotator position in rad */
-    telescopeRotatorRad: PropTypes.number,
+    /** Telescope rotator position in degrees */
+    telescopeRotatorDeg: PropTypes.number,
     /** Whether to display the RA and DEC in hour format */
     raDecHourFormat: PropTypes.bool,
   };
@@ -113,7 +113,7 @@ export default class MTDomeSummaryTable extends Component {
       telescopeRAHour,
       telescopeRADeg,
       telescopeDecDeg,
-      telescopeRotatorRad,
+      telescopeRotatorDeg,
       raDecHourFormat,
     } = this.props;
 
@@ -135,7 +135,7 @@ export default class MTDomeSummaryTable extends Component {
     const parsedTelescopeDecHour = degreesToDMS(telescopeDecDeg);
     const parsedTelescopeRADeg = defaultNumberFormatter(telescopeRADeg, 2) + '°';
     const parsedTelescopeDecDeg = defaultNumberFormatter(telescopeDecDeg, 2) + '°';
-    const parsedTelescopeRotatorDeg = defaultNumberFormatter(degrees(telescopeRotatorRad), 2) + '°';
+    const parsedTelescopeRotatorDeg = defaultNumberFormatter(telescopeRotatorDeg, 2) + '°';
     const telescopeRAText = raDecHourFormat ? parsedTelescopeRAHour : parsedTelescopeRADeg;
     const telescopeDecText = raDecHourFormat ? parsedTelescopeDecHour : parsedTelescopeDecDeg;
 

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -774,7 +774,7 @@ export const getAuxiliaryTelescopeState = (state) => {
     telescopeRAHour: data['telemetry-ATPtg-0-mountStatus']?.mountRA?.value ?? 0,
     telescopeRADeg: data['telemetry-ATPtg-0-mountPositions']?.ra?.value[0] ?? 0,
     telescopeDecDeg: data['telemetry-ATPtg-0-mountStatus']?.mountDec?.value ?? 0,
-    telescopeRotatorRad: data['telemetry-ATPtg-0-mountStatus']?.mountRot?.value ?? 0,
+    telescopeRotatorDeg: data['telemetry-ATPtg-0-mountStatus']?.mountRot?.value ?? 0,
     targetName: data['event-ATPtg-0-currentTarget']?.[0].targetName?.value ?? 'Unknown',
   };
 };
@@ -1318,7 +1318,7 @@ export const getMainTelescopeState = (state) => {
     telescopeRAHour: data['telemetry-MTPtg-0-mountStatus']?.mountRA?.value ?? 0,
     telescopeRADeg: data['telemetry-MTPtg-0-mountPosition']?.ra?.value ?? 0,
     telescopeDecDeg: data['telemetry-MTPtg-0-mountStatus']?.mountDec?.value ?? 0,
-    telescopeRotatorRad: data['telemetry-MTPtg-0-mountStatus']?.mountRot?.value ?? 0,
+    telescopeRotatorDeg: data['telemetry-MTPtg-0-mountStatus']?.mountRot?.value ?? 0,
     targetName: data['event-MTPtg-0-currentTarget']?.[0].targetName?.value ?? 'Unknown',
   };
 };

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -766,13 +766,13 @@ export const getATMCSState = (state) => {
 export const getAuxiliaryTelescopeState = (state) => {
   const subscriptions = [
     'telemetry-ATPtg-0-mountStatus',
-    'telemetry-ATPtg-0-mountPosition',
+    'telemetry-ATPtg-0-mountPositions',
     'event-ATPtg-0-currentTarget',
   ];
   const data = getStreamsData(state, subscriptions);
   return {
     telescopeRAHour: data['telemetry-ATPtg-0-mountStatus']?.mountRA?.value ?? 0,
-    telescopeRADeg: data['telemetry-ATPtg-0-mountPosition']?.ra?.value ?? 0,
+    telescopeRADeg: data['telemetry-ATPtg-0-mountPositions']?.ra?.value[0] ?? 0,
     telescopeDecDeg: data['telemetry-ATPtg-0-mountStatus']?.mountDec?.value ?? 0,
     telescopeRotatorRad: data['telemetry-ATPtg-0-mountStatus']?.mountRot?.value ?? 0,
     targetName: data['event-ATPtg-0-currentTarget']?.[0].targetName?.value ?? 'Unknown',


### PR DESCRIPTION
This PR makes two fixes to properly ready telemetries from the `ATPtg` and `MTPtg` CSCs:
- Fix a typo whereas the code was calling `ATPtg.mountPositions` whereas it should be `ATPtg.mountPosition`.
- Fix a bad conversion from rad to degrees whereas it is not necessary as the value already comes in degree scale.