### PR TITLE
Refactor LOVE components to use private_sndStamp instead of deprecated private_rcvStamp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.7.1
+------
+
+* Refactor LOVE components to use private_sndStamp instead of deprecated private_rcvStamp `<https://github.com/lsst-ts/LOVE-frontend/pull/687>`_
+
 v6.7.0
 ------
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -21,6 +21,9 @@ import InfoIcon from 'components/icons/CSCExpanded/InfoIcon/InfoIcon';
 import WarningIcon from 'components/icons/CSCExpanded/WarningIcon/WarningIcon';
 import { VALUE_TYPES } from 'Constants';
 
+// SAL parameters
+export const TOPIC_TIMESTAMP_ATTRIBUTE = 'private_sndStamp';
+
 // Subpath
 export const SUBPATH = process.env.PUBLIC_URL ?? '';
 

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -25,6 +25,7 @@ import Button from 'components/GeneralPurpose/Button/Button';
 import LogMessageDisplay from 'components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay';
 import Select from 'components/GeneralPurpose/Select/Select';
 import WarningIcon from 'components/icons/WarningIcon/WarningIcon';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import { cscText, formatTimestamp } from 'Utils';
 import styles from './CSCExpanded.module.css';
 
@@ -467,13 +468,13 @@ export default class CSCExpanded extends PureComponent {
               <div className={[styles.log, styles.messageLogContent].join(' ')}>
                 {errorCodeData.map((msg, index) => {
                   return (
-                    <div key={`${msg.private_rcvStamp.value}-${index}`} className={styles.logMessage}>
+                    <div key={`${msg[TOPIC_TIMESTAMP_ATTRIBUTE].value}-${index}`} className={styles.logMessage}>
                       <div className={styles.errorCode} title={`Error code ${msg.errorCode.value}`}>
                         {msg.errorCode.value}
                       </div>
                       <div className={styles.messageTextContainer}>
-                        <div className={styles.timestamp} title="private_rcvStamp">
-                          {formatTimestamp(msg.private_rcvStamp.value * 1000)}
+                        <div className={styles.timestamp} title={TOPIC_TIMESTAMP_ATTRIBUTE}>
+                          {formatTimestamp(msg[TOPIC_TIMESTAMP_ATTRIBUTE].value * 1000)}
                         </div>
                         <pre className={styles.preText}>{msg.errorReport.value}</pre>
                         <pre className={styles.preText}>{msg.traceback.value}</pre>

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.jsx
@@ -19,14 +19,14 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import HeartbeatIcon from 'components/icons/HeartbeatIcon/HeartbeatIcon';
+import BackArrowIcon from 'components/icons/BackArrowIcon/BackArrowIcon';
+import Button from 'components/GeneralPurpose/Button/Button';
+import LogMessageDisplay from 'components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay';
+import Select from 'components/GeneralPurpose/Select/Select';
+import WarningIcon from 'components/icons/WarningIcon/WarningIcon';
+import { cscText, formatTimestamp } from 'Utils';
 import styles from './CSCExpanded.module.css';
-import HeartbeatIcon from '../../icons/HeartbeatIcon/HeartbeatIcon';
-import BackArrowIcon from '../../icons/BackArrowIcon/BackArrowIcon';
-import Button from '../../GeneralPurpose/Button/Button';
-import LogMessageDisplay from '../../GeneralPurpose/LogMessageDisplay/LogMessageDisplay';
-import Select from '../../GeneralPurpose/Select/Select';
-import WarningIcon from '../../icons/WarningIcon/WarningIcon';
-import { cscText, formatTimestamp } from '../../../Utils';
 
 export default class CSCExpanded extends PureComponent {
   constructor(props) {

--- a/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.jsx
+++ b/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.jsx
@@ -19,11 +19,11 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import styles from './CSCGroupLog.module.css';
-import BackArrowIcon from '../../icons/BackArrowIcon/BackArrowIcon';
+import BackArrowIcon from 'components/icons/BackArrowIcon/BackArrowIcon';
+import Button from 'components/GeneralPurpose/Button/Button';
+import { formatTimestamp } from 'Utils';
 import CSCDetailContainer from '../CSCDetail/CSCDetail.container';
-import Button from '../../GeneralPurpose/Button/Button';
-import { formatTimestamp } from '../../../Utils';
+import styles from './CSCGroupLog.module.css';
 
 export default class CSCGroupLog extends Component {
   static propTypes = {

--- a/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.jsx
+++ b/love/src/components/CSCSummary/CSCGroupLog/CSCGroupLog.jsx
@@ -21,6 +21,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import BackArrowIcon from 'components/icons/BackArrowIcon/BackArrowIcon';
 import Button from 'components/GeneralPurpose/Button/Button';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import { formatTimestamp } from 'Utils';
 import CSCDetailContainer from '../CSCDetail/CSCDetail.container';
 import styles from './CSCGroupLog.module.css';
@@ -103,7 +104,7 @@ export default class CSCGroupLog extends Component {
             <div className={[styles.log, styles.messageLogContent].join(' ')}>
               {this.props.errorCodeData.map((msg, index) => {
                 return (
-                  <div key={`${msg.private_rcvStamp.value}-${index}`} className={styles.logMessage}>
+                  <div key={`${msg[TOPIC_TIMESTAMP_ATTRIBUTE].value}-${index}`} className={styles.logMessage}>
                     <div className={styles.errorCode} title={`Error code ${msg.errorCode.value}`}>
                       {msg.errorCode.value}
                     </div>
@@ -117,8 +118,8 @@ export default class CSCGroupLog extends Component {
                           onCSCClick={this.props.onCSCClick}
                           embedded={true}
                         />
-                        <div className={styles.timestamp} title="private_rcvStamp">
-                          {formatTimestamp(msg.private_rcvStamp.value * 1000)}
+                        <div className={styles.timestamp} title={TOPIC_TIMESTAMP_ATTRIBUTE}>
+                          {formatTimestamp(msg[TOPIC_TIMESTAMP_ATTRIBUTE].value * 1000)}
                         </div>
                       </div>
                       <div className={styles.messageText}>{msg.errorReport.value}</div>

--- a/love/src/components/EventLog/EventLog.jsx
+++ b/love/src/components/EventLog/EventLog.jsx
@@ -19,16 +19,15 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ManagerInterface, { formatTimestamp, getStringRegExp } from 'Utils';
 import EFDQuery from 'components/GeneralPurpose/EFDQuery/EFDQuery';
 import Toggle from 'components/GeneralPurpose/Toggle/Toggle';
 import { CardList, Card, Title, Separator } from 'components/GeneralPurpose/CardList/CardList';
+import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
+import WarningIcon from 'components/icons/WarningIcon/WarningIcon';
+import ErrorIcon from 'components/icons/ErrorIcon/ErrorIcon';
+import TextField from 'components/TextField/TextField';
+import ManagerInterface, { formatTimestamp, getStringRegExp } from 'Utils';
 import styles from './EventLog.module.css';
-import InfoIcon from '../icons/InfoIcon/InfoIcon';
-import WarningIcon from '../icons/WarningIcon/WarningIcon';
-import ErrorIcon from '../icons/ErrorIcon/ErrorIcon';
-
-import TextField from '../TextField/TextField';
 
 export default class EventLog extends PureComponent {
   static propTypes = {

--- a/love/src/components/EventLog/EventLog.jsx
+++ b/love/src/components/EventLog/EventLog.jsx
@@ -26,6 +26,7 @@ import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
 import WarningIcon from 'components/icons/WarningIcon/WarningIcon';
 import ErrorIcon from 'components/icons/ErrorIcon/ErrorIcon';
 import TextField from 'components/TextField/TextField';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import ManagerInterface, { formatTimestamp, getStringRegExp } from 'Utils';
 import styles from './EventLog.module.css';
 
@@ -95,8 +96,8 @@ export default class EventLog extends PureComponent {
     });
     cscList.forEach((obj) => {
       cscTopicDict[obj.name][obj.salindex] = {
-        logevent_logMessage: ['private_rcvStamp', 'level', 'message', 'traceback'],
-        logevent_errorCode: ['private_rcvStamp', 'errorCode', 'errorReport', 'traceback'],
+        logevent_logMessage: [TOPIC_TIMESTAMP_ATTRIBUTE, 'level', 'message', 'traceback'],
+        logevent_errorCode: [TOPIC_TIMESTAMP_ATTRIBUTE, 'errorCode', 'errorReport', 'traceback'],
       };
     });
     return cscTopicDict;
@@ -119,7 +120,7 @@ export default class EventLog extends PureComponent {
           errorReport: log.errorReport !== undefined ? { value: log.errorReport } : undefined,
           // shared parameters
           traceback: { value: log.traceback },
-          private_rcvStamp: { value: log.private_rcvStamp },
+          [TOPIC_TIMESTAMP_ATTRIBUTE]: { value: log[TOPIC_TIMESTAMP_ATTRIBUTE] },
         }),
       );
     });
@@ -156,7 +157,9 @@ export default class EventLog extends PureComponent {
       JSON.stringify(this.props.errorCodeData) !== JSON.stringify(prevProps.errorCodeData)
     ) {
       const eventData = [...this.props.logMessageData.slice(0, 100), ...this.props.errorCodeData.slice(0, 50)];
-      eventData.sort((a, b) => (a?.private_rcvStamp?.value > b?.private_rcvStamp?.value ? -1 : 1));
+      eventData.sort((a, b) =>
+        a?.[TOPIC_TIMESTAMP_ATTRIBUTE]?.value > b?.[TOPIC_TIMESTAMP_ATTRIBUTE]?.value ? -1 : 1,
+      );
       if (eventData.length !== 0) {
         this.setState({
           eventData,
@@ -170,7 +173,7 @@ export default class EventLog extends PureComponent {
     const filterResult = this.state.cscFilter === '' || this.state.cscRegExp.test(cscKey);
     return (
       filterResult && (
-        <Card key={`${msg.private_rcvStamp.value}-${index}`} className={styles.card}>
+        <Card key={`${msg[TOPIC_TIMESTAMP_ATTRIBUTE].value}-${index}`} className={styles.card}>
           <div className={styles.messageTextContainer}>
             <div className={styles.messageTopSection}>
               <div className={styles.cardTitleContainer}>
@@ -181,8 +184,8 @@ export default class EventLog extends PureComponent {
                 </span>
               </div>
 
-              <div className={styles.timestamp} title="private_rcvStamp">
-                {formatTimestamp(msg.private_rcvStamp.value * 1000)}
+              <div className={styles.timestamp} title={TOPIC_TIMESTAMP_ATTRIBUTE}>
+                {formatTimestamp(msg[TOPIC_TIMESTAMP_ATTRIBUTE].value * 1000)}
               </div>
             </div>
 
@@ -207,7 +210,7 @@ export default class EventLog extends PureComponent {
     return (
       filterResult &&
       this.state.messageFilters[value]?.value && (
-        <Card key={`${msg.private_rcvStamp.value}-${msg.level.value}-${index}`} className={styles.card}>
+        <Card key={`${msg[TOPIC_TIMESTAMP_ATTRIBUTE].value}-${msg.level.value}-${index}`} className={styles.card}>
           <div className={styles.messageTextContainer}>
             <div className={styles.messageTopSection}>
               <div className={styles.cardTitleContainer}>
@@ -219,8 +222,8 @@ export default class EventLog extends PureComponent {
                 </span>
               </div>
 
-              <div className={styles.timestamp} title="private_rcvStamp">
-                {formatTimestamp(msg.private_rcvStamp.value * 1000)}
+              <div className={styles.timestamp} title={TOPIC_TIMESTAMP_ATTRIBUTE}>
+                {formatTimestamp(msg[TOPIC_TIMESTAMP_ATTRIBUTE].value * 1000)}
               </div>
             </div>
             <Separator className={styles.innerSeparator} />

--- a/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
+++ b/love/src/components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay.jsx
@@ -25,8 +25,9 @@ import InfoIcon from 'components/icons/CSCExpanded/InfoIcon/InfoIcon';
 import WarningIcon from 'components/icons/CSCExpanded/WarningIcon/WarningIcon';
 import ErrorIcon from 'components/icons/CSCExpanded/ErrorIcon/ErrorIcon';
 import CopyIcon from 'components/icons/CopyIcon/CopyIcon';
-import styles from './LogMessageDisplay.module.css';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import { formatTimestamp, copyToClipboard } from 'Utils';
+import styles from './LogMessageDisplay.module.css';
 
 function CopyToClipboard({ text }) {
   const [copied, setCopied] = useState(false);
@@ -109,11 +110,14 @@ function LogMessageDisplay({ logMessageData, clearCSCLogMessages }) {
               const copyToClipboardText =
                 msg.message?.value + (msg.traceback?.value ? '\n\n' + msg.traceback?.value : '');
               return (
-                <div key={`${msg.private_rcvStamp.value}-${msg.level.value}-${index}`} className={styles.logMessage}>
+                <div
+                  key={`${msg[TOPIC_TIMESTAMP_ATTRIBUTE].value}-${msg.level.value}-${index}`}
+                  className={styles.logMessage}
+                >
                   <div className={styles.messageIcon}>{icon}</div>
                   <div className={styles.messageTextContainer}>
-                    <div className={styles.timestamp} title="private_rcvStamp">
-                      {formatTimestamp(msg.private_rcvStamp.value * 1000)}
+                    <div className={styles.timestamp} title={TOPIC_TIMESTAMP_ATTRIBUTE}>
+                      {formatTimestamp(msg[TOPIC_TIMESTAMP_ATTRIBUTE].value * 1000)}
                     </div>
                     <div className={styles.messageText}>
                       {msg.ScriptID && <div className={styles.scriptID}>Script {msg.ScriptID?.value}</div>}

--- a/love/src/components/GeneralPurpose/Plot/Plot.jsx
+++ b/love/src/components/GeneralPurpose/Plot/Plot.jsx
@@ -19,11 +19,12 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import Moment from 'moment';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
+import ManagerInterface, { parseTimestamp, parsePlotInputsEFD, parseCommanderData } from 'Utils';
 import VegaTimeseriesPlot from './VegaTimeSeriesPlot/VegaTimeSeriesPlot';
 import TimeSeriesControls from './TimeSeriesControls/TimeSeriesControls';
 import VegaLegend from './VegaTimeSeriesPlot/VegaLegend';
-import Moment from 'moment';
-import ManagerInterface, { parseTimestamp, parsePlotInputsEFD, parseCommanderData } from 'Utils';
 import styles from './Plot.module.css';
 
 const DEFAULT_STYLES = [
@@ -197,7 +198,7 @@ const Plot = ({
 
       const newValue = {
         name: inputName,
-        x: parseTimestamp(streamValue.private_rcvStamp?.value * 1000),
+        x: parseTimestamp(streamValue[TOPIC_TIMESTAMP_ATTRIBUTE]?.value * 1000),
         y: accessorFunc(streamValue[item]?.value),
       };
 
@@ -242,7 +243,7 @@ const Plot = ({
         }
 
         const streamValue = Array.isArray(streams[streamName]) ? streams[streamName][0] : streams[streamName];
-        newValue['x'] = parseTimestamp(streamValue.private_rcvStamp?.value * 1000);
+        newValue['x'] = parseTimestamp(streamValue[TOPIC_TIMESTAMP_ATTRIBUTE]?.value * 1000);
 
         const val = accessorFunc(streamValue[item]?.value);
         const units = streamValue[item]?.units;

--- a/love/src/components/GeneralPurpose/Plot/PolarPlot/PolarPlot.container.jsx
+++ b/love/src/components/GeneralPurpose/Plot/PolarPlot/PolarPlot.container.jsx
@@ -19,11 +19,12 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 import React from 'react';
 import { connect } from 'react-redux';
+import _ from 'lodash';
 import { addGroup, removeGroup } from 'redux/actions/ws';
 import { getStreamsData, getTaiToUtc } from 'redux/selectors/selectors';
-import _ from 'lodash';
-import PolarPlot from './PolarPlot';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import ManagerInterface, { parseTimestamp, parsePlotInputsEFD, parseCommanderData } from 'Utils';
+import PolarPlot from './PolarPlot';
 
 const DATA_WINDOW = 10;
 
@@ -218,7 +219,7 @@ class PolarPlotContainer extends React.Component {
         const streamValue = Array.isArray(streams[streamName]) ? streams[streamName][0] : streams[streamName];
         const newValue = {
           name: inputName,
-          time: parseTimestamp(streamValue.private_rcvStamp?.value * 1000),
+          time: parseTimestamp(streamValue[TOPIC_TIMESTAMP_ATTRIBUTE]?.value * 1000),
           value: accessorFunc(streamValue[item]?.value),
         };
 

--- a/love/src/components/ScriptQueue/Scripts/FinishedScript/FinishedScript.jsx
+++ b/love/src/components/ScriptQueue/Scripts/FinishedScript/FinishedScript.jsx
@@ -21,15 +21,15 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import LogMessageDisplay from 'components/GeneralPurpose/LogMessageDisplay/LogMessageDisplay';
 import Button from 'components/GeneralPurpose/Button/Button';
+import RequeueIcon from 'components/icons/ScriptQueue/RequeueIcon/RequeueIcon';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import ManagerInterface, { parseToSALFormat } from 'Utils';
-
-import styles from './FinishedScript.module.css';
-import scriptStyles from '../Scripts.module.css';
-import ScriptStatus from '../../ScriptStatus/ScriptStatus';
 import { getStatusStyle } from '../Scripts';
-import RequeueIcon from '../../../icons/ScriptQueue/RequeueIcon/RequeueIcon';
+import ScriptStatus from '../../ScriptStatus/ScriptStatus';
 import ScriptDetails from '../ScriptDetails';
 import ScriptConfig from '../ScriptConfig/ScriptConfig';
+import styles from './FinishedScript.module.css';
+import scriptStyles from '../Scripts.module.css';
 
 class FinishedScript extends React.Component {
   static propTypes = {
@@ -102,7 +102,7 @@ class FinishedScript extends React.Component {
     const cscs = {
       Script: {
         [scriptIndex]: {
-          logevent_logMessage: ['private_rcvStamp', 'level', 'message', 'traceback'],
+          logevent_logMessage: [TOPIC_TIMESTAMP_ATTRIBUTE, 'level', 'message', 'traceback'],
         },
       },
     };

--- a/love/src/components/ScriptQueue/Scripts/ScriptConfig/ScriptConfig.jsx
+++ b/love/src/components/ScriptQueue/Scripts/ScriptConfig/ScriptConfig.jsx
@@ -2,6 +2,7 @@ import React, { memo, useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
 import CopyIcon from 'components/icons/CopyIcon/CopyIcon';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import ManagerInterface, { copyToClipboard } from 'Utils';
 import styles from './ScriptConfig.module.css';
 
@@ -22,7 +23,7 @@ function ScriptConfig({ index, timestampProcessStart, timestampConfigureEnd, def
     const cscs = {
       Script: {
         [scriptIndex]: {
-          command_configure: ['private_rcvStamp', 'config'],
+          command_configure: [TOPIC_TIMESTAMP_ATTRIBUTE, 'config'],
         },
       },
     };

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -18,7 +18,8 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { createCachedSelector } from 're-reselect';
-import { flatMap, arrayRandomBoolean } from '../../Utils';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
+import { flatMap, arrayRandomBoolean } from 'Utils';
 
 export const getToken = (state) => state.auth.token;
 
@@ -2795,7 +2796,7 @@ export const getGroupSortedErrorCodeData = (state, group) => {
   });
 
   const sorted = flatMapped.sort((msg1, msg2) => {
-    return msg1.private_rcvStamp.value > msg2.private_rcvStamp.value ? -1 : 1;
+    return msg1[TOPIC_TIMESTAMP_ATTRIBUTE].value > msg2[TOPIC_TIMESTAMP_ATTRIBUTE].value ? -1 : 1;
   });
 
   return sorted;
@@ -2822,7 +2823,7 @@ export const getGroupSortedLogMessageData = (state, group) => {
   });
 
   const sorted = flatMapped.sort((msg1, msg2) => {
-    return msg1.private_rcvStamp.value > msg2.private_rcvStamp.value ? -1 : 1;
+    return msg1[TOPIC_TIMESTAMP_ATTRIBUTE].value > msg2[TOPIC_TIMESTAMP_ATTRIBUTE].value ? -1 : 1;
   });
 
   return sorted;

--- a/love/src/redux/tests/summaryData.test.js
+++ b/love/src/redux/tests/summaryData.test.js
@@ -30,6 +30,7 @@ import {
   getAllStreamsAsDictionary,
   getGroupSortedErrorCodeData,
 } from 'redux/selectors';
+import { TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import { flatMap } from 'Utils';
 import * as mockData from './mock';
 
@@ -312,7 +313,7 @@ it('Should extract a sorted list of a subset of errorCode event data ', async ()
   });
 
   const sortedMessages = [...flat1, ...flat2].sort((msg1, msg2) => {
-    return msg1.private_rcvStamp.value > msg2.private_rcvStamp.value ? -1 : 1;
+    return msg1[TOPIC_TIMESTAMP_ATTRIBUTE].value > msg2[TOPIC_TIMESTAMP_ATTRIBUTE].value ? -1 : 1;
   });
 
   // Act

--- a/love/src/redux/tests/summaryData.test.js
+++ b/love/src/redux/tests/summaryData.test.js
@@ -20,18 +20,18 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 import { createStore, applyMiddleware } from 'redux';
 import WS from 'jest-websocket-mock';
 import thunkMiddleware from 'redux-thunk';
-import rootReducer from '../reducers';
-import { addGroup } from '../actions/ws';
-import { doReceiveToken } from '../actions/auth';
-import { removeCSCLogMessages, removeCSCErrorCodeData } from '../actions/summaryData';
+import rootReducer from 'redux/reducers';
+import { addGroup } from 'redux/actions/ws';
+import { doReceiveToken } from 'redux/actions/auth';
+import { removeCSCLogMessages, removeCSCErrorCodeData } from 'redux/actions/summaryData';
 import {
   getCSCLogMessages,
   getCSCErrorCodeData,
   getAllStreamsAsDictionary,
   getGroupSortedErrorCodeData,
-} from '../selectors';
+} from 'redux/selectors';
+import { flatMap } from 'Utils';
 import * as mockData from './mock';
-import { flatMap } from '../../Utils';
 
 let store;
 let server;


### PR DESCRIPTION
This PR refactors several LOVE components in order to standardize the use of the `private_sndStamp` which will be now used in favor of the old `private_rcvStamp` which won't be used anymore on CSC's topics.