### PR TITLE
Improve how scripts with empty schemas are handled.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.1
 ------
 
+* Improve how scripts with empty schemas are handled. `<https://github.com/lsst-ts/LOVE-frontend/pull/689>`_
 * Improve error handling for queries to get services status for SAL and EFD. `<https://github.com/lsst-ts/LOVE-frontend/pull/688>`_
 * Refactor LOVE components to use private_sndStamp instead of deprecated private_rcvStamp `<https://github.com/lsst-ts/LOVE-frontend/pull/687>`_
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -21,6 +21,10 @@ import InfoIcon from 'components/icons/CSCExpanded/InfoIcon/InfoIcon';
 import WarningIcon from 'components/icons/CSCExpanded/WarningIcon/WarningIcon';
 import { VALUE_TYPES } from 'Constants';
 
+// Scripts empty schema value
+// When SAL scripts doesn't have a schema the following value is published instead
+export const EMPTY_SCHEMA = '# empty schema';
+
 // SAL parameters
 export const TOPIC_TIMESTAMP_ATTRIBUTE = 'private_sndStamp';
 


### PR DESCRIPTION
This PR refactors the `ScriptQueue/ConfigPanel` component for better UX. Before this change user would see an "error icon" for scripts that don't have an schema associated, however those scripts can be run without doing nothing extra. Showing the error icon was missleading so that's better handled now.