### PR TITLE
Refactor Watcher AlarmAudio component for a more reliable flow.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.2
 ------
 
+* Refactor Watcher AlarmAudio component for a more reliable flow. `<https://github.com/lsst-ts/LOVE-frontend/pull/700>`_
 * Fix WeatherStation plots for temperature and dewpoint. `<https://github.com/lsst-ts/LOVE-frontend/pull/699>`_
 * Bump vega from 5.25.0 to 5.26.0 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/693>`_
 * Bump nanoid from 3.3.6 to 3.3.8 in /love `<https://github.com/lsst-ts/LOVE-frontend/pull/694>`_

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -165,7 +165,7 @@ export const severityEnum = {
   critical: 4,
 };
 
-export const ALARM_SOUND_THROTLING_TIME_MS = 6000;
+export const ALARM_SOUND_THROTLING_TIME_MS = 30000;
 
 /*****************************************************************************/
 /******************************TCS configurations*****************************/

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -37,8 +37,6 @@ import unackedSeriousFile from '../../../sounds/unacked_serious.mp3';
 import unackedCriticalFile from '../../../sounds/unacked_critical.mp3';
 import stillCriticalFile from '../../../sounds/still_critical.mp3';
 
-const CRITICAL_ALARM_SOUND_TIME_MS = 3000;
-
 export default class AlarmAudio extends Component {
   static propTypes = {
     /** List of all the alarms that are displayed */
@@ -338,7 +336,7 @@ export default class AlarmAudio extends Component {
   stillCriticalTimeout = () => {
     return setTimeout(() => {
       this.stillCriticalSound.play();
-    }, ALARM_SOUND_THROTLING_TIME_MS - CRITICAL_ALARM_SOUND_TIME_MS);
+    }, ALARM_SOUND_THROTLING_TIME_MS);
   };
 
   clearStillCriticalTimeout = () => {

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -203,7 +203,7 @@ export default class AlarmAudio extends Component {
 
     if (this.props.alarms) {
       if (prevProps.alarms?.length === 0 && this.props.alarms?.length > 0) {
-        this.checkAndNotifyAlarms(this.props.alarms, prevProps.alarms);
+        this.throtCheckAndNotifyAlarms(this.props.alarms, prevProps.alarms);
       } else if (
         !isEqual(this.props.alarms, prevProps.alarms) ||
         this.state.minSeveritySound !== prevState.minSeveritySound
@@ -265,6 +265,7 @@ export default class AlarmAudio extends Component {
       this.stopAllSounds();
       this.playSound(newHighestAlarm.severity, newHighestAlarm.type);
     } else if (newHighestAlarm.severity < this.state.minSeveritySound) {
+      this.throtCheckAndNotifyAlarms.cancel();
       this.stopAllSounds();
     }
   };

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -67,9 +67,10 @@ export default class AlarmAudio extends Component {
       minSeveritySound: severityEnum.critical + 1,
     };
 
-    this.soundsStopped = false;
+    this.stillCriticalTimeoutRef = null;
 
     this.numCriticals = 0;
+
     this.newWarningSound = new Howl({
       src: [newWarningFile],
       onplayerror: () => {
@@ -79,6 +80,7 @@ export default class AlarmAudio extends Component {
         console.error('Error loading sound for warning alarm: ', newWarningFile);
       },
     });
+
     this.newSeriousSound = new Howl({
       src: [newSeriousFile],
       onplayerror: () => {
@@ -88,6 +90,7 @@ export default class AlarmAudio extends Component {
         console.error('Error loading sound for serious alarm: ', newSeriousFile);
       },
     });
+
     this.newCriticalSound = new Howl({
       src: [newCriticalFile],
       onplayerror: () => {
@@ -96,17 +99,11 @@ export default class AlarmAudio extends Component {
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', newCriticalFile);
       },
-      onplay: () => {
-        this.soundsStopped = false;
-      },
       onend: () => {
-        setTimeout(() => {
-          if (!this.soundsStopped) {
-            this.newCriticalSound.play();
-          }
-        }, ALARM_SOUND_THROTLING_TIME_MS - CRITICAL_ALARM_SOUND_TIME_MS);
+        this.createStillCriticalTimeout();
       },
     });
+
     this.increasedWarningSound = new Howl({
       src: [increasedWarningFile],
       onplayerror: () => {
@@ -116,6 +113,7 @@ export default class AlarmAudio extends Component {
         console.error('Error loading sound for warning alarm: ', increasedWarningFile);
       },
     });
+
     this.increasedSeriousSound = new Howl({
       src: [increasedSeriousFile],
       onplayerror: () => {
@@ -125,6 +123,7 @@ export default class AlarmAudio extends Component {
         console.error('Error loading sound for serious alarm: ', increasedSeriousFile);
       },
     });
+
     this.increasedCriticalSound = new Howl({
       src: [increasedCriticalFile],
       onplayerror: () => {
@@ -133,17 +132,11 @@ export default class AlarmAudio extends Component {
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', increasedCriticalFile);
       },
-      onplay: () => {
-        this.soundsStopped = false;
-      },
       onend: () => {
-        setTimeout(() => {
-          if (!this.soundsStopped) {
-            this.increasedCriticalSound.play();
-          }
-        }, ALARM_SOUND_THROTLING_TIME_MS - CRITICAL_ALARM_SOUND_TIME_MS);
+        this.createStillCriticalTimeout();
       },
     });
+
     this.unackedWarningSound = new Howl({
       src: [unackedWarningFile],
       onplayerror: () => {
@@ -153,6 +146,7 @@ export default class AlarmAudio extends Component {
         console.error('Error loading sound for warning alarm: ', unackedWarningFile);
       },
     });
+
     this.unackedSeriousSound = new Howl({
       src: [unackedSeriousFile],
       onplayerror: () => {
@@ -162,6 +156,7 @@ export default class AlarmAudio extends Component {
         console.error('Error loading sound for serious alarm: ', unackedSeriousFile);
       },
     });
+
     this.unackedCriticalSound = new Howl({
       src: [unackedCriticalFile],
       onplayerror: () => {
@@ -170,17 +165,11 @@ export default class AlarmAudio extends Component {
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', unackedCriticalFile);
       },
-      onplay: () => {
-        this.soundsStopped = false;
-      },
       onend: () => {
-        setTimeout(() => {
-          if (!this.soundsStopped) {
-            this.unackedCriticalSound.play();
-          }
-        }, ALARM_SOUND_THROTLING_TIME_MS - CRITICAL_ALARM_SOUND_TIME_MS);
+        this.createStillCriticalTimeout();
       },
     });
+
     this.stillCriticalSound = new Howl({
       src: [stillCriticalFile],
       onplayerror: () => {
@@ -189,15 +178,8 @@ export default class AlarmAudio extends Component {
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', stillCriticalFile);
       },
-      onplay: () => {
-        this.soundsStopped = false;
-      },
       onend: () => {
-        setTimeout(() => {
-          if (!this.soundsStopped) {
-            this.stillCriticalSound.play();
-          }
-        }, ALARM_SOUND_THROTLING_TIME_MS - CRITICAL_ALARM_SOUND_TIME_MS);
+        this.createStillCriticalTimeout();
       },
     });
   }
@@ -369,8 +351,25 @@ export default class AlarmAudio extends Component {
     }
   };
 
+  stillCriticalTimeout = () => {
+    return setTimeout(() => {
+      this.stillCriticalSound.play();
+    }, ALARM_SOUND_THROTLING_TIME_MS - CRITICAL_ALARM_SOUND_TIME_MS);
+  };
+
+  clearStillCriticalTimeout = () => {
+    if (this.stillCriticalTimeoutRef) {
+      clearTimeout(this.stillCriticalTimeoutRef);
+      this.stillCriticalTimeoutRef = null;
+    }
+  };
+
+  createStillCriticalTimeout = () => {
+    this.clearStillCriticalTimeout();
+    this.stillCriticalTimeoutRef = this.stillCriticalTimeout();
+  };
+
   stopCriticals = () => {
-    this.soundsStopped = true;
     this.newCriticalSound.stop();
     this.increasedCriticalSound.stop();
     this.unackedCriticalSound.stop();

--- a/love/src/components/Watcher/AlarmUtils.js
+++ b/love/src/components/Watcher/AlarmUtils.js
@@ -21,14 +21,14 @@ import { severityEnum } from '../../Config';
 
 /** Auxiliary function to define wether an alarm is acknowledged or not */
 export const isAcknowledged = (alarm) => {
-  return alarm.acknowledged?.value || (alarm.severity?.value === 1 && alarm.maxSeverity?.value === 1);
+  return alarm.acknowledged?.value;
 };
 
 /**
  * Auxiliary function to define wether an alarm is muted or not.
  * That is, its severity is lower than its mutedSeverity
  */
-export const isMuted = (alarm) => alarm.severity?.value <= alarm.mutedSeverity?.value;
+export const isMuted = (alarm) => alarm.mutedSeverity?.value > severityEnum.ok;
 
 /**
  * Auxiliary function to define wether an alarm has muting configuration or not.
@@ -44,7 +44,8 @@ export const isMaxCritical = (alarm) => alarm.maxSeverity?.value === severityEnu
 export const isCritical = (alarm) => alarm.severity?.value === severityEnum.critical;
 
 /** Auxiliary function to define wether an alarm is active or not */
-export const isActive = (alarm) => alarm.severity?.value > severityEnum.ok;
+export const isActive = (alarm) =>
+  alarm.maxSeverity?.value > severityEnum.ok && alarm.severity?.value > severityEnum.ok;
 
 /** Auxiliary function to define wether an alarm can be unacknowledged or not */
 export const canUnack = (alarm) => alarm.acknowledged?.value && alarm.severity?.value !== 1;

--- a/love/src/components/Watcher/Watcher.jsx
+++ b/love/src/components/Watcher/Watcher.jsx
@@ -23,7 +23,7 @@ import { DateTime } from 'luxon';
 import MuteIcon from '../icons/MuteIcon/MuteIcon';
 import Badge from '../GeneralPurpose/Badge/Badge';
 import AlarmsTable from './AlarmsTable/AlarmsTable';
-import { isAcknowledged, isMuted } from './AlarmUtils';
+import { isAcknowledged, isMuted, isActive } from './AlarmUtils';
 import styles from './Watcher.module.css';
 
 const TIMEOUT = 10;
@@ -105,36 +105,23 @@ export default class Watcher extends Component {
   }
 
   render() {
+    const { alarms } = this.props;
     let alarmsToShow = [];
     let mutedAlarmsCount = 0;
     let unmutedAlarmsCount = 0;
     let inactiveAlarmsCount = 0;
     let unackUnmutedAlarmsCount = 0;
-    const now = DateTime.local().toSeconds() - this.props.taiToUtc;
 
-    this.props.alarms.forEach((alarm) => {
-      if (
-        alarm.severity.value <= 1 &&
-        alarm.maxSeverity.value <= 1 &&
-        alarm.timestampAcknowledged.value !== 0 &&
-        now - alarm.timestampAcknowledged.value >= TIMEOUT
-      ) {
-        return;
-      }
-
-      if (isMuted(alarm)) {
-        if (alarm.severity.value <= 1) {
-          // Inactive alarms
-          inactiveAlarmsCount += 1;
-          if (this.state.selectedTab === 'inactive') {
-            alarmsToShow.push(alarm);
-          }
-        } else {
-          // Muted alarms
-          mutedAlarmsCount += 1;
-          if (this.state.selectedTab === 'muted') {
-            alarmsToShow.push(alarm);
-          }
+    alarms.forEach((alarm) => {
+      if (!isActive(alarm)) {
+        inactiveAlarmsCount += 1;
+        if (this.state.selectedTab === 'inactive') {
+          alarmsToShow.push(alarm);
+        }
+      } else if (isMuted(alarm)) {
+        mutedAlarmsCount += 1;
+        if (this.state.selectedTab === 'muted') {
+          alarmsToShow.push(alarm);
         }
       } else {
         unmutedAlarmsCount += 1;


### PR DESCRIPTION
This PR makes some adjustments to the `AlarmAudio` component in order to improve the evaluation of alarms for triggering the highest severity one:

- Improved the loop sound for critical alarms: now when a critical alarm is triggered, the following sound that triggers on the loop will have the "still critical" alarm sound, instead of repeating the same sound. E.g. Instead of having an "unacknowledged critical alarm" sounding all the time, the following times "still critical alarm" will sound.
- The `checkAndNotifyAlarms` was refactored for better alarms checking, removing unnecesary calculations and adjusting some utility functions to properly define the state of the alarm.
- Increased thotling time to 30 seconds.
- Removed CRITICAL_ALARM_SOUND_TIME_MS and only rely on the throtling time.