### PR TITLE
Fix state enumeration mapping for the MTDome_logevent_azEnabled topic.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.3
 ------
 
+* Fix state enumeration mapping for the MTDome_logevent_azEnabled topic. `<https://github.com/lsst-ts/LOVE-frontend/pull/708>`_
 * Fix MTDome shutter display. `<https://github.com/lsst-ts/LOVE-frontend/pull/706>`_
 * Improve AlarmAudio sound handling even more. `<https://github.com/lsst-ts/LOVE-frontend/pull/705>`_
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -3362,9 +3362,9 @@ export const mtDomeModeStateMap = {
 };
 
 export const mtDomeAzimuthEnabledStateMap = {
-  0: 'DISABLED',
-  1: 'ENABLED',
-  2: 'FAULT',
+  1: 'DISABLED',
+  2: 'ENABLED',
+  3: 'FAULT',
 };
 
 export const mtdomeMotionStateMap = {


### PR DESCRIPTION
This PR adjusts the `mtDomeAzimuthEnabledStateMap` configuration to properly display states from the `MTDome_logevent_azEnabled` topic.