### PR TITLE
Roll back critical alarm loop for Watcher alarm sounds.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.3
 ------
 
+* Roll back critical alarm loop for Watcher alarm sounds. `<https://github.com/lsst-ts/LOVE-frontend/pull/709>`_
 * Fix HVAC Facility Map display after XML 23 changes. `<https://github.com/lsst-ts/LOVE-frontend/pull/707>`_
 * Fix state enumeration mapping for the MTDome_logevent_azEnabled topic. `<https://github.com/lsst-ts/LOVE-frontend/pull/708>`_
 * Fix MTDome shutter display. `<https://github.com/lsst-ts/LOVE-frontend/pull/706>`_

--- a/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
+++ b/love/src/components/Watcher/AlarmAudio/AlarmAudio.jsx
@@ -95,6 +95,9 @@ export default class AlarmAudio extends Component {
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', newCriticalFile);
       },
+      onend: () => {
+        this.createStillCriticalTimeout();
+      },
     });
 
     this.increasedWarningSound = new Howl({
@@ -124,6 +127,9 @@ export default class AlarmAudio extends Component {
       },
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', increasedCriticalFile);
+      },
+      onend: () => {
+        this.createStillCriticalTimeout();
       },
     });
 
@@ -155,6 +161,9 @@ export default class AlarmAudio extends Component {
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', unackedCriticalFile);
       },
+      onend: () => {
+        this.createStillCriticalTimeout();
+      },
     });
 
     this.stillCriticalSound = new Howl({
@@ -164,6 +173,9 @@ export default class AlarmAudio extends Component {
       },
       onloaderror: () => {
         console.error('Error loading sound for critical alarm: ', stillCriticalFile);
+      },
+      onend: () => {
+        this.createStillCriticalTimeout();
       },
     });
   }
@@ -326,7 +338,26 @@ export default class AlarmAudio extends Component {
     }
   };
 
+  stillCriticalTimeout = () => {
+    return setTimeout(() => {
+      this.stillCriticalSound.play();
+    }, ALARM_SOUND_THROTLING_TIME_MS);
+  };
+
+  clearStillCriticalTimeout = () => {
+    if (this.stillCriticalTimeoutRef) {
+      clearTimeout(this.stillCriticalTimeoutRef);
+      this.stillCriticalTimeoutRef = null;
+    }
+  };
+
+  createStillCriticalTimeout = () => {
+    this.clearStillCriticalTimeout();
+    this.stillCriticalTimeoutRef = this.stillCriticalTimeout();
+  };
+
   stopAllSounds = () => {
+    this.clearStillCriticalTimeout();
     this.newWarningSound.stop();
     this.newSeriousSound.stop();
     this.newCriticalSound.stop();


### PR DESCRIPTION
This PR roll back the critical alarm loop feature of the `AlarmAudio` component. This was removed on #705, however that was a mistake because we need the loop in case Watcher alarms are not published often.