### PR TITLE
Fix MTDomeShutter component interpreting MTDome_apertureShutter value erroneously.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.3
 ------
 
+* Fix MTDomeShutter component interpreting MTDome_apertureShutter value erroneously. `<https://github.com/lsst-ts/LOVE-frontend/pull/710>`_
 * Roll back critical alarm loop for Watcher alarm sounds. `<https://github.com/lsst-ts/LOVE-frontend/pull/709>`_
 * Fix HVAC Facility Map display after XML 23 changes. `<https://github.com/lsst-ts/LOVE-frontend/pull/707>`_
 * Fix state enumeration mapping for the MTDome_logevent_azEnabled topic. `<https://github.com/lsst-ts/LOVE-frontend/pull/708>`_

--- a/love/src/components/MainTel/MTDome/MTDomeShutter.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeShutter.jsx
@@ -91,14 +91,16 @@ export default class MTDomeShutter extends Component {
     // The display considers left and right shutters as seen from above the dome.
     const leftShutterPositionActual = Math.abs(positionActualShutter[1]);
     const rightShutterPositionActual = Math.abs(positionActualShutter[0]);
-    const leftShutterPositionActualPixels = Math.floor(leftShutterPositionActual * widthShutterInPixels);
-    const rightShutterPositionActualPixels = Math.floor(rightShutterPositionActual * widthShutterInPixels);
+    const leftShutterPositionActualPixels = Math.floor((leftShutterPositionActual * widthShutterInPixels) / 100);
+    const rightShutterPositionActualPixels = Math.floor((rightShutterPositionActual * widthShutterInPixels) / 100);
 
     // The display considers left and right shutters as seen from above the dome.
     const leftShutterPositionCommanded = Math.abs(positionCommandedShutter[1]);
     const rightShutterPositionCommanded = Math.abs(positionCommandedShutter[0]);
-    const leftShutterPositionCommandedPixels = Math.floor(leftShutterPositionCommanded * widthShutterInPixels);
-    const rightShutterPositionCommandedPixels = Math.floor(rightShutterPositionCommanded * widthShutterInPixels);
+    const leftShutterPositionCommandedPixels = Math.floor((leftShutterPositionCommanded * widthShutterInPixels) / 100);
+    const rightShutterPositionCommandedPixels = Math.floor(
+      (rightShutterPositionCommanded * widthShutterInPixels) / 100,
+    );
 
     return (
       <svg className={styles.svgOverlay} height={height} width={width} viewBox="0 0 235 235">


### PR DESCRIPTION
This PR adds a scale conversion for the `MTDome_apertureShutter` topic display as values were being interpreted from 0 to 1 instead of from 0 to 100 as it should.