### PR TITLE
Move current script configuration to the top in the current script details section.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.7.3
 ------
 
+* Move current script configuration to the top in the current script details section. `<https://github.com/lsst-ts/LOVE-frontend/pull/712>`_
 * Add exitControl for all CSCs and enterControl to XXCamera CSCs in expanded view. `<https://github.com/lsst-ts/LOVE-frontend/pull/711>`_
 * Add Offline detailed stated for big cameras in CSC detailed and expanded views. `<https://github.com/lsst-ts/LOVE-frontend/pull/711>`_
 * Fix MTDomeShutter component interpreting MTDome_apertureShutter value erroneously. `<https://github.com/lsst-ts/LOVE-frontend/pull/710>`_

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -732,8 +732,8 @@ export default class ScriptQueue extends Component {
             ref={this.currentScriptDetailsContainer}
           >
             <div className={styles.currentScriptDescription}>
-              <ScriptDetails {...current} />
               <ScriptConfig {...current} defaultEfdInstance={this.props.efdConfig?.defaultEfdInstance} />
+              <ScriptDetails {...current} />
             </div>
             <div className={styles.currentScriptLogs}>
               <CSCExpandedContainer


### PR DESCRIPTION
This PR swaps the `ScriptDetail` and `ScriptConfig` components in the current script details section in order to have the configurations at the top.