### PR TITLE
Refactor AvailableScript to avoid using isCompact property by relaying just in CSS styles for script name triming.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.8.0
 ------
 
+* Refactor AvailableScript to avoid using isCompact property by relaying just in CSS styles for script name triming. `<https://github.com/lsst-ts/LOVE-frontend/pull/716>`_
 * Add option to duplicate components to the UI framework. `<https://github.com/lsst-ts/LOVE-frontend/pull/717>`_
 * Refactor and improve EFD interface for different components. `<https://github.com/lsst-ts/LOVE-frontend/pull/713>`_
 

--- a/love/src/components/ScriptQueue/RecursiveScriptsTree/RecursiveScriptsTree.jsx
+++ b/love/src/components/ScriptQueue/RecursiveScriptsTree/RecursiveScriptsTree.jsx
@@ -82,7 +82,6 @@ const RecursiveScriptsTree = ({
                   launchScriptConfig={launchScriptConfig}
                   script={scriptObject}
                   commandExecutePermission={scriptsBlocked}
-                  isCompact={true}
                   {...scriptObject}
                 />
               )

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -587,7 +587,6 @@ export default class ScriptQueue extends Component {
           script={script}
           commandExecutePermission={this.props.commandExecutePermission}
           {...script}
-          isCompact={this.state.isAvailableScriptListVisible && this.state.isFinishedScriptListListVisible}
         />
       </DraggableScript>
     );

--- a/love/src/components/ScriptQueue/Scripts/AvailableScript/AvailableScript.jsx
+++ b/love/src/components/ScriptQueue/Scripts/AvailableScript/AvailableScript.jsx
@@ -37,8 +37,6 @@ export default class AvailableScript extends PureComponent {
     state: PropTypes.string,
     /** Function called when launching the script configuration panel */
     launchScriptConfig: PropTypes.func,
-    /** True if the script is displayed in compact view */
-    isCompact: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -48,7 +46,6 @@ export default class AvailableScript extends PureComponent {
     estimatedTime: 0,
     state: 'Unknown',
     onLaunch: () => 0,
-    isCompact: false,
   };
 
   constructor(props) {
@@ -70,15 +67,7 @@ export default class AvailableScript extends PureComponent {
       <div className={scriptStyles.scriptContainer}>
         <div className={styles.availableScriptContainer}>
           <div className={scriptStyles.pathTextContainer} title={path}>
-            {(() => {
-              if (!this.props.isCompact) {
-                return <span className={scriptStyles.pathText}>{fileFolder}</span>;
-              }
-              if (fileFolder !== '') {
-                return <span className={scriptStyles.pathText}>.../</span>;
-              }
-              return null;
-            })()}
+            <span className={scriptStyles.pathText}>{fileFolder}</span>
             <span className={[scriptStyles.pathText, scriptStyles.highlighted].join(' ')}>{fileName}</span>
             <span className={scriptStyles.pathText}>{fileExtension}</span>
           </div>

--- a/love/src/components/ScriptQueue/Scripts/AvailableScript/AvailableScript.module.css
+++ b/love/src/components/ScriptQueue/Scripts/AvailableScript/AvailableScript.module.css
@@ -24,7 +24,10 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   align-items: flex-end;
 }
 
-.estimatedTimeLabel {
+.availableScriptContainer > div {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  direction: rtl;
 }
 
 .estimatedTimeValue {


### PR DESCRIPTION
This PR refactors the `AvailableScript` component to avoid using the `isCompact` boolean property (which was defined by the FinishedScripts component being collapsed or not). Now the name triming is handled with CSS text overflow instead, improving the UX.