### PR TITLE
Add option to duplicate components to the UI framework.

### DIFF
--- a/love/src/components/UIF/CustomView.jsx
+++ b/love/src/components/UIF/CustomView.jsx
@@ -26,6 +26,7 @@ import componentIndex from './ComponentIndex';
 import Button from '../GeneralPurpose/Button/Button';
 import GearIcon from '../icons/GearIcon/GearIcon';
 import DeleteIcon from 'components/icons/DeleteIcon/DeleteIcon.jsx';
+import CopyIcon from 'components/icons/CopyIcon/CopyIcon';
 import ErrorBoundary from '../GeneralPurpose/ErrorBoundary/ErrorBoundary';
 import Panel from '../GeneralPurpose/Panel/Panel';
 import DashedBox from '../GeneralPurpose/DashedBox/DashedBox';
@@ -188,6 +189,15 @@ class CustomView extends Component {
         ].join(' ')}
       >
         <div className={styles.editableComponentActions}>
+          <Button
+            onClick={() => this.props.onComponentDuplicate(component)}
+            title="Duplicate"
+            className={styles.iconButton}
+          >
+            <div className={styles.gearIconWrapper}>
+              <CopyIcon title="Duplicate" className={styles.icon} />
+            </div>
+          </Button>
           <Button
             onClick={() => this.props.onComponentConfig(component)}
             title="Configure"

--- a/love/src/components/UIF/CustomView.module.css
+++ b/love/src/components/UIF/CustomView.module.css
@@ -90,14 +90,11 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 
 .editable:hover .editableComponentActions {
   position: absolute;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-column-gap: 0.2em;
   top: 0.1em;
   right: 0.2em;
-  padding-right: 0.5em;
-  box-sizing: border-box;
-  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: var(--small-padding);
 }
 
 .gearIconWrapper {

--- a/love/src/components/UIF/ViewEditor/ViewEditor.jsx
+++ b/love/src/components/UIF/ViewEditor/ViewEditor.jsx
@@ -387,6 +387,37 @@ class ViewEditor extends Component {
     });
   };
 
+  onComponentDuplicate = (component) => {
+    const parsedLayout = { ...this.getEditedViewLayout() };
+    let startingIndex = 0;
+    Object.keys(parsedLayout.content).forEach((compKey) => {
+      startingIndex = Math.max(parsedLayout.content[compKey].properties.i, startingIndex);
+    });
+    startingIndex += 1;
+
+    const additionalContent = {};
+    additionalContent[`newPanel-${startingIndex}`] = {
+      ...component,
+      config: {
+        ...component.config,
+        title: `${component.config.title} copy`,
+      },
+      properties: {
+        ...component.properties,
+        y: component.properties.y + 10, // Offset to avoid overlapping
+        i: startingIndex,
+      },
+    };
+
+    parsedLayout.content = {
+      ...parsedLayout.content,
+      ...additionalContent,
+    };
+    this.updateEditedViewLayout(parsedLayout);
+    const layoutElement = document.getElementById(LAYOUT_CONTAINER_ID);
+    setTimeout(() => layoutElement.scrollTo({ top: layoutElement?.scrollHeight ?? 0, behavior: 'smooth' }), 0);
+  };
+
   save = () => {
     this.saveBackendView(null);
   };
@@ -641,6 +672,7 @@ class ViewEditor extends Component {
               onLayoutChange={this.confirmLayoutChange}
               onComponentDelete={this.onComponentDelete}
               onComponentConfig={this.onComponentConfig}
+              onComponentDuplicate={this.onComponentDuplicate}
               isEditable={true}
               deviceWidth={this.state.device.value}
               id={this.state.id}


### PR DESCRIPTION
This PR adds a new functionality to the UI Framework so components can be duplicated. This was inspired from Chronograf plot "clone" feature that allows you to duplicate plots and their configurations in case of wanting to reutilize them.