### PR TITLE
Fix TelescopesStates component to properly set the observatoryState from EFD response.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.8.2
+------
+
+* Fix TelescopesStates component to properly set the observatoryState from EFD response. `<https://github.com/lsst-ts/LOVE-frontend/pull/726>`_
+
 v6.8.1
 ------
 


### PR DESCRIPTION
This PR fixes the way the `TelescopesStates` component is parsing the response from the EFD with the latest telemetries. The logic was not considering topics with more than one parameter and that was adjusted.