### PR TITLE
Remove custom weather forecast logic from generic plot components.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.8.2
 ------
 
+* Remove custom weather forecast logic from generic plot components. `<https://github.com/lsst-ts/LOVE-frontend/pull/727>`_
 * Fix TelescopesStates component to properly set the observatoryState from EFD response. `<https://github.com/lsst-ts/LOVE-frontend/pull/726>`_
 
 v6.8.1

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -2471,16 +2471,31 @@ export const parsePlotInputsEFD = (inputs) => {
 };
 
 /**
- * Reformat data coming from the commander, from:
+ * Reformat data coming from the commander to a format that the Plot component expects.
+ *
+ * Input format:
  * {
  *   "csc-index-topic": {
- *     "item":[{"ts":"2021-01-26 19:15:00+00:00","value":6.9}]
+ *     "item": [
+ *       {
+ *         "ts": "2021-01-26 19:15:00+00:00",
+ *         "value": 6.9,
+ *         "units": "deg"
+ *       },
+ *     ],
  *   }
  * }
- * to:
+ *
+ * Output format:
  * {
  *   "csc-index-topic": {
- *     "item": [{<tsLabel>:"2021-01-26 19:15:00+00:00",<valueLabel>:6.9}]
+ *     "item": [
+ *       {
+ *         <tsLabel>: "2021-01-26 19:15:00+00:00",
+ *         <valueLabel>: 6.9,
+ *         "units": { y: "deg" }
+ *       }
+ *     ]
  *   }
  * }
  *

--- a/love/src/components/GeneralPurpose/Plot/ForecastPlot/ForecastPlot.module.css
+++ b/love/src/components/GeneralPurpose/Plot/ForecastPlot/ForecastPlot.module.css
@@ -1,0 +1,35 @@
+/** 
+This file is part of LOVE-frontend.
+
+Copyright (c) 2023 Inria Chile.
+
+Developed by Inria Chile.
+
+This program is free software: you can redistribute it and/or modify it under 
+the terms of the GNU General Public License as published by the Free Software 
+Foundation, either version 3 of the License, or at your option) any later version.
+
+This program is distributed in the hope that it will be useful,but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+.containerFlexRow {
+  display: flex;
+  flex-direction: row;
+}
+
+.containerFlexCol {
+  display: flex;
+  flex-direction: column;
+}
+
+.bottomLegend {
+  flex-direction: column;
+}
+
+.marginLegend {
+  margin-left: 4rem;
+}

--- a/love/src/components/GeneralPurpose/Plot/Plot.jsx
+++ b/love/src/components/GeneralPurpose/Plot/Plot.jsx
@@ -22,34 +22,11 @@ import PropTypes from 'prop-types';
 import Moment from 'moment';
 import { ISO_STRING_DATE_TIME_FORMAT, TOPIC_TIMESTAMP_ATTRIBUTE } from 'Config';
 import ManagerInterface, { getEFDInstanceForHost, parseCommanderData, parsePlotInputsEFD, parseTimestamp } from 'Utils';
+import { defaultStyles } from './Plot.container';
 import VegaTimeseriesPlot from './VegaTimeSeriesPlot/VegaTimeSeriesPlot';
 import TimeSeriesControls from './TimeSeriesControls/TimeSeriesControls';
 import VegaLegend from './VegaTimeSeriesPlot/VegaLegend';
 import styles from './Plot.module.css';
-
-const DEFAULT_STYLES = [
-  {
-    color: '#ff7bb5',
-    shape: 'circle',
-    filled: false,
-    orient: 'left',
-    dash: [4, 0],
-  },
-  {
-    color: '#00b7ff',
-    shape: 'square',
-    filled: true,
-    orient: 'left',
-    dash: [4, 0],
-  },
-  {
-    color: '#97e54f',
-    shape: 'diamond',
-    filled: true,
-    orient: 'right',
-    dash: [4, 0],
-  },
-];
 
 const LAYER_TYPES = ['lines', 'bars', 'pointLines', 'arrows', 'areas', 'spreads', 'bigotes', 'rects', 'heatmaps'];
 
@@ -164,7 +141,7 @@ const Plot = ({
     return Object.keys(inputs).map((inputName, index) => {
       return {
         name: inputName,
-        ...DEFAULT_STYLES[index % DEFAULT_STYLES.length],
+        ...defaultStyles[index % defaultStyles.length],
         ...(inputs[inputName].type !== undefined ? { markType: inputs[inputName].type } : {}),
         ...(inputs[inputName].color !== undefined ? { color: inputs[inputName].color } : {}),
         ...(inputs[inputName].dash !== undefined ? { dash: inputs[inputName].dash } : {}),

--- a/love/src/components/GeneralPurpose/Plot/Plot.jsx
+++ b/love/src/components/GeneralPurpose/Plot/Plot.jsx
@@ -253,9 +253,9 @@ const Plot = ({
     setLiveData(newData);
   }, [inputs, streams, sizeLimit]);
 
-  const dataLengthsHash = useMemo(() => {
+  const dataLastTimestampHash = useMemo(() => {
     return Object.entries(liveData)
-      .map(([key, value]) => `${key}:${value.length}`)
+      .map(([key, value]) => `${key}:${value.length > 1 ? value[value.length - 1].x.ts : 0}`)
       .join('|');
   }, [liveData]);
 
@@ -267,12 +267,11 @@ const Plot = ({
       if (!LAYER_TYPES.includes(layerName)) {
         continue;
       }
-
       const inputData = mergeLiveAndHistoricalData(inputName);
       layers[layerName] = [...(layers[layerName] ?? []), ...inputData];
     }
     return layers;
-  }, [dataLengthsHash, inputs]);
+  }, [dataLastTimestampHash, inputs]);
 
   return (
     <>

--- a/love/src/components/UIF/ComponentIndex.jsx
+++ b/love/src/components/UIF/ComponentIndex.jsx
@@ -279,7 +279,7 @@ export const observatoryIndex = {
     },
   },
   WindPlotForecast: {
-    component: require('../WeatherForecast/PlotsContainer/WindPlot.container').default,
+    component: require('../GeneralPurpose/Plot/ForecastPlot/ForecastPlot.container').default,
     schema: {
       ...require('../WeatherForecast/PlotsContainer/WindPlot.container').schema,
       props: {
@@ -289,7 +289,7 @@ export const observatoryIndex = {
     },
   },
   TemperaturePlotForecast: {
-    component: require('../WeatherForecast/PlotsContainer/TemperaturePlot.container').default,
+    component: require('../GeneralPurpose/Plot/ForecastPlot/ForecastPlot.container').default,
     schema: {
       ...require('../WeatherForecast/PlotsContainer/TemperaturePlot.container').schema,
       props: {
@@ -299,7 +299,7 @@ export const observatoryIndex = {
     },
   },
   RainPlotForecast: {
-    component: require('../WeatherForecast/PlotsContainer/RainPlot.container').default,
+    component: require('../GeneralPurpose/Plot/ForecastPlot/ForecastPlot.container').default,
     schema: {
       ...require('../WeatherForecast/PlotsContainer/RainPlot.container').schema,
       props: {
@@ -309,7 +309,7 @@ export const observatoryIndex = {
     },
   },
   CloudPlotForecast: {
-    component: require('../WeatherForecast/PlotsContainer/CloudPlot.container').default,
+    component: require('../GeneralPurpose/Plot/ForecastPlot/ForecastPlot.container').default,
     schema: {
       ...require('../WeatherForecast/PlotsContainer/CloudPlot.container').schema,
       props: {

--- a/love/src/components/WeatherForecast/PlotsContainer/CloudPlot.container.js
+++ b/love/src/components/WeatherForecast/PlotsContainer/CloudPlot.container.js
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -16,13 +18,6 @@ This program is distributed in the hope that it will be useful,but WITHOUT ANY
 You should have received a copy of the GNU General Public License along with 
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
-
-import React from 'react';
-import { connect } from 'react-redux';
-import { addGroup, removeGroup } from 'redux/actions/ws';
-import { getStreamsData, getEfdConfig, getTaiToUtc } from 'redux/selectors';
-import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
-import Plot from 'components/GeneralPurpose/Plot/Plot';
 
 export const schema = {
   description: 'View of Cloud Plot of Weather Forecast ',
@@ -63,13 +58,6 @@ export const schema = {
       type: 'string',
       description: "Format the time, for example the daily use '%Y-%m-%d' and hourly '%d, %H:%M'",
       default: '%Y-%m-%d',
-      isPrivate: false,
-    },
-    isForecast: {
-      type: 'boolean',
-      description:
-        'When is the Weather Forecast, the telemetries receive all data of the interval, and this case, the data its diference process',
-      default: true,
       isPrivate: false,
     },
     scaleIndependent: {
@@ -221,77 +209,3 @@ export const schema = {
     },
   },
 };
-
-const containerRef = React.createRef();
-
-const CloudPlotContainer = ({ subscribeToStreams, unsubscribeToStreams, ...props }) => {
-  const { containerNode } = props;
-  if (props.isRaw) {
-    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
-  }
-  if (!props.containerNode) {
-    return (
-      <div ref={containerRef}>
-        <Plot
-          subscribeToStreams={subscribeToStreams}
-          unsubscribeToStreams={unsubscribeToStreams}
-          {...props}
-          containerNode={containerRef?.current?.parentNode}
-        />
-      </div>
-    );
-  } else {
-    return (
-      <Plot
-        subscribeToStreams={subscribeToStreams}
-        unsubscribeToStreams={unsubscribeToStreams}
-        {...props}
-        containerNode={containerNode}
-      />
-    );
-  }
-};
-
-const getGroupNames = (inputs) => {
-  const inputsMap = Object.values(inputs).map((inputConfig) => {
-    if (inputConfig.values) {
-      const values = Object.values(inputConfig.values).map((value) => {
-        return `${value?.category}-${value?.csc}-${value?.salindex}-${value?.topic}`;
-      });
-      return values;
-    } else {
-      return `${inputConfig?.category}-${inputConfig?.csc}-${inputConfig?.salindex}-${inputConfig?.topic}`;
-    }
-  });
-  return [...new Set(inputsMap.flat())];
-};
-
-const mapStateToProps = (state, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-  const streams = getStreamsData(state, subscriptions);
-  const taiToUtc = getTaiToUtc(state);
-  const efdConfigFile = getEfdConfig(state);
-  return {
-    inputs,
-    streams,
-    taiToUtc,
-    efdConfigFile,
-  };
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-
-  return {
-    subscriptions,
-    subscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(addGroup(s)));
-    },
-    unsubscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(removeGroup(s)));
-    },
-  };
-};
-export default connect(mapStateToProps, mapDispatchToProps)(CloudPlotContainer);

--- a/love/src/components/WeatherForecast/PlotsContainer/RainPlot.container.js
+++ b/love/src/components/WeatherForecast/PlotsContainer/RainPlot.container.js
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -16,13 +18,6 @@ This program is distributed in the hope that it will be useful,but WITHOUT ANY
 You should have received a copy of the GNU General Public License along with 
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
-
-import React from 'react';
-import { connect } from 'react-redux';
-import { addGroup, removeGroup } from 'redux/actions/ws';
-import { getStreamsData, getEfdConfig, getTaiToUtc } from 'redux/selectors';
-import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
-import Plot from 'components/GeneralPurpose/Plot/Plot';
 
 export const schema = {
   description: 'View of Precipitation Plot of Weather Forecast',
@@ -63,13 +58,6 @@ export const schema = {
       type: 'string',
       description: "Format the time, for example the daily use '%Y-%m-%d' and hourly '%d, %H:%M'",
       default: '%Y-%m-%d',
-      isPrivate: false,
-    },
-    isForecast: {
-      type: 'boolean',
-      description:
-        'When is the Weather Forecast, the telemetries receive all data of the interval, and this case, the data its diference process',
-      default: true,
       isPrivate: false,
     },
     scaleIndependent: {
@@ -216,77 +204,3 @@ export const schema = {
     },
   },
 };
-
-const containerRef = React.createRef();
-
-const RainPlotContainer = ({ subscribeToStreams, unsubscribeToStreams, ...props }) => {
-  const { containerNode } = props;
-  if (props.isRaw) {
-    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
-  }
-  if (!props.containerNode) {
-    return (
-      <div ref={containerRef}>
-        <Plot
-          subscribeToStreams={subscribeToStreams}
-          unsubscribeToStreams={unsubscribeToStreams}
-          {...props}
-          containerNode={containerRef?.current?.parentNode}
-        />
-      </div>
-    );
-  } else {
-    return (
-      <Plot
-        subscribeToStreams={subscribeToStreams}
-        unsubscribeToStreams={unsubscribeToStreams}
-        {...props}
-        containerNode={containerNode}
-      />
-    );
-  }
-};
-
-const getGroupNames = (inputs) => {
-  const inputsMap = Object.values(inputs).map((inputConfig) => {
-    if (inputConfig.values) {
-      const values = Object.values(inputConfig.values).map((value) => {
-        return `${value?.category}-${value?.csc}-${value?.salindex}-${value?.topic}`;
-      });
-      return values;
-    } else {
-      return `${inputConfig?.category}-${inputConfig?.csc}-${inputConfig?.salindex}-${inputConfig?.topic}`;
-    }
-  });
-  return [...new Set(inputsMap.flat())];
-};
-
-const mapStateToProps = (state, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-  const streams = getStreamsData(state, subscriptions);
-  const taiToUtc = getTaiToUtc(state);
-  const efdConfigFile = getEfdConfig(state);
-  return {
-    inputs,
-    streams,
-    taiToUtc,
-    efdConfigFile,
-  };
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-
-  return {
-    subscriptions,
-    subscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(addGroup(s)));
-    },
-    unsubscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(removeGroup(s)));
-    },
-  };
-};
-export default connect(mapStateToProps, mapDispatchToProps)(RainPlotContainer);

--- a/love/src/components/WeatherForecast/PlotsContainer/TemperaturePlot.container.js
+++ b/love/src/components/WeatherForecast/PlotsContainer/TemperaturePlot.container.js
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -16,13 +18,6 @@ This program is distributed in the hope that it will be useful,but WITHOUT ANY
 You should have received a copy of the GNU General Public License along with 
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
-
-import React from 'react';
-import { connect } from 'react-redux';
-import { addGroup, removeGroup } from 'redux/actions/ws';
-import { getStreamsData, getEfdConfig, getTaiToUtc } from 'redux/selectors';
-import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
-import Plot from 'components/GeneralPurpose/Plot/Plot';
 
 export const schema = {
   description: 'View of Temperature Plot of Weather Forecast',
@@ -63,13 +58,6 @@ export const schema = {
       type: 'string',
       description: "Format the time, for example the daily use '%Y-%m-%d' and hourly '%d, %H:%M'",
       default: '%Y-%m-%d',
-      isPrivate: false,
-    },
-    isForecast: {
-      type: 'boolean',
-      description:
-        'When is the Weather Forecast, the telemetries receive all data of the interval, and this case, the data its diference process',
-      default: true,
       isPrivate: false,
     },
     scaleIndependent: {
@@ -223,77 +211,3 @@ export const schema = {
     },
   },
 };
-
-const containerRef = React.createRef();
-
-const TemperaturePlotContainer = ({ subscribeToStreams, unsubscribeToStreams, ...props }) => {
-  const { containerNode } = props;
-  if (props.isRaw) {
-    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
-  }
-  if (!props.containerNode) {
-    return (
-      <div ref={containerRef}>
-        <Plot
-          subscribeToStreams={subscribeToStreams}
-          unsubscribeToStreams={unsubscribeToStreams}
-          {...props}
-          containerNode={containerRef?.current?.parentNode}
-        />
-      </div>
-    );
-  } else {
-    return (
-      <Plot
-        subscribeToStreams={subscribeToStreams}
-        unsubscribeToStreams={unsubscribeToStreams}
-        {...props}
-        containerNode={containerNode}
-      />
-    );
-  }
-};
-
-const getGroupNames = (inputs) => {
-  const inputsMap = Object.values(inputs).map((inputConfig) => {
-    if (inputConfig.values) {
-      const values = Object.values(inputConfig.values).map((value) => {
-        return `${value?.category}-${value?.csc}-${value?.salindex}-${value?.topic}`;
-      });
-      return values;
-    } else {
-      return `${inputConfig?.category}-${inputConfig?.csc}-${inputConfig?.salindex}-${inputConfig?.topic}`;
-    }
-  });
-  return [...new Set(inputsMap.flat())];
-};
-
-const mapStateToProps = (state, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-  const streams = getStreamsData(state, subscriptions);
-  const taiToUtc = getTaiToUtc(state);
-  const efdConfigFile = getEfdConfig(state);
-  return {
-    inputs,
-    streams,
-    taiToUtc,
-    efdConfigFile,
-  };
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-
-  return {
-    subscriptions,
-    subscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(addGroup(s)));
-    },
-    unsubscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(removeGroup(s)));
-    },
-  };
-};
-export default connect(mapStateToProps, mapDispatchToProps)(TemperaturePlotContainer);

--- a/love/src/components/WeatherForecast/PlotsContainer/WindPlot.container.js
+++ b/love/src/components/WeatherForecast/PlotsContainer/WindPlot.container.js
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -16,13 +18,6 @@ This program is distributed in the hope that it will be useful,but WITHOUT ANY
 You should have received a copy of the GNU General Public License along with 
 this program. If not, see <http://www.gnu.org/licenses/>.
 */
-
-import React from 'react';
-import { connect } from 'react-redux';
-import { addGroup, removeGroup } from 'redux/actions/ws';
-import { getStreamsData, getEfdConfig, getTaiToUtc } from 'redux/selectors';
-import SubscriptionTableContainer from 'components/GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
-import Plot from 'components/GeneralPurpose/Plot/Plot';
 
 export const schema = {
   description: 'View of Wind Plot of Weather Forecast',
@@ -63,13 +58,6 @@ export const schema = {
       type: 'string',
       description: "Format the time, for example the daily use '%Y-%m-%d' and hourly '%d, %H:%M'",
       default: '%Y-%m-%d',
-      isPrivate: false,
-    },
-    isForecast: {
-      type: 'boolean',
-      description:
-        'When is the Weather Forecast, the telemetries receive all data of the interval, and this case, the data its diference process',
-      default: true,
       isPrivate: false,
     },
     scaleIndependent: {
@@ -233,78 +221,3 @@ export const schema = {
     },
   },
 };
-
-const containerRef = React.createRef();
-
-const WindPlotContainer = ({ subscribeToStreams, unsubscribeToStreams, ...props }) => {
-  const { containerNode } = props;
-
-  if (props.isRaw) {
-    return <SubscriptionTableContainer subscriptions={props.subscriptions}></SubscriptionTableContainer>;
-  }
-  if (!props.containerNode) {
-    return (
-      <div ref={containerRef}>
-        <Plot
-          subscribeToStreams={subscribeToStreams}
-          unsubscribeToStreams={unsubscribeToStreams}
-          {...props}
-          containerNode={containerRef?.current?.parentNode}
-        />
-      </div>
-    );
-  } else {
-    return (
-      <Plot
-        subscribeToStreams={subscribeToStreams}
-        unsubscribeToStreams={unsubscribeToStreams}
-        {...props}
-        containerNode={containerNode}
-      />
-    );
-  }
-};
-
-const getGroupNames = (inputs) => {
-  const inputsMap = Object.values(inputs).map((inputConfig) => {
-    if (inputConfig.values) {
-      const values = Object.values(inputConfig.values).map((value) => {
-        return `${value?.category}-${value?.csc}-${value?.salindex}-${value?.topic}`;
-      });
-      return values;
-    } else {
-      return `${inputConfig?.category}-${inputConfig?.csc}-${inputConfig?.salindex}-${inputConfig?.topic}`;
-    }
-  });
-  return [...new Set(inputsMap.flat())];
-};
-
-const mapStateToProps = (state, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-  const streams = getStreamsData(state, subscriptions);
-  const taiToUtc = getTaiToUtc(state);
-  const efdConfigFile = getEfdConfig(state);
-  return {
-    inputs,
-    streams,
-    taiToUtc,
-    efdConfigFile,
-  };
-};
-
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const inputs = ownProps.inputs || schema.props.inputs.default;
-  const subscriptions = getGroupNames(inputs);
-
-  return {
-    subscriptions,
-    subscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(addGroup(s)));
-    },
-    unsubscribeToStreams: () => {
-      subscriptions.forEach((s) => dispatch(removeGroup(s)));
-    },
-  };
-};
-export default connect(mapStateToProps, mapDispatchToProps)(WindPlotContainer);

--- a/love/src/components/WeatherForecast/WeatherForecast.container.jsx
+++ b/love/src/components/WeatherForecast/WeatherForecast.container.jsx
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -36,7 +38,7 @@ export const schema = {
     },
     controls: {
       type: 'boolean',
-      description: "Whether to display controls to configure periods of time'",
+      description: 'Whether to display controls to configure periods of time',
       default: true,
       isPrivate: false,
     },
@@ -48,31 +50,31 @@ export const schema = {
     },
     infoHeader: {
       type: 'boolean',
-      description: "Whether to display info header'",
+      description: 'Whether to display info header',
       default: true,
       isPrivate: false,
     },
     cloud: {
       type: 'boolean',
-      description: "Whether to display plot of cloud'",
+      description: 'Whether to display plot of cloud',
       default: true,
       isPrivate: false,
     },
     wind: {
       type: 'boolean',
-      description: "Whether to display plot of wind'",
+      description: 'Whether to display plot of wind',
       default: true,
       isPrivate: false,
     },
     temperature: {
       type: 'boolean',
-      description: "Whether to display plot of temperature'",
+      description: 'Whether to display plot of temperature',
       default: true,
       isPrivate: false,
     },
     rain: {
       type: 'boolean',
-      description: "Whether to display  plot of precipitation'",
+      description: 'Whether to display  plot of precipitation',
       default: true,
       isPrivate: false,
     },

--- a/love/src/components/WeatherForecast/WeatherForecast.jsx
+++ b/love/src/components/WeatherForecast/WeatherForecast.jsx
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -21,27 +23,36 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Toggle from 'components/GeneralPurpose/Toggle/Toggle';
 import styles from './WeatherForecast.module.css';
-import PlotContainer from 'components/GeneralPurpose/Plot/Plot.container';
+import ForecastPlotContainer from 'components/GeneralPurpose/Plot/ForecastPlot/ForecastPlot.container';
 import InfoHeaderContainer from './InfoHeader/InfoHeader.container';
 import CSCDetail from 'components/CSCSummary/CSCDetail/CSCDetail';
 import WEATHER from './WeatherForecastInputs.json';
 
 export default class WeatherForecast extends Component {
   static propTypes = {
-    subscribeToStreams: PropTypes.func,
-    unsubscribeToStreams: PropTypes.func,
     /* Weather stream data */
     weather: PropTypes.object,
+    /* Whether to display info header */
     infoHeader: PropTypes.bool,
+    /* Whether to display plot of cloud */
     cloud: PropTypes.bool,
+    /* Whether to display plot of wind */
     wind: PropTypes.bool,
+    /* Whether to display plot of temperature */
     temperature: PropTypes.bool,
+    /* Whether to display plot of precipitation */
+    cloudComplement: PropTypes.bool,
+    /* Whether to display plot of precipitation */
     rain: PropTypes.bool,
+    /* Function to subscribe to streams */
+    subscribeToStreams: PropTypes.func,
+    /* Function to unsubscribe from streams */
+    unsubscribeToStreams: PropTypes.func,
   };
 
   static defaultProps = {
-    subscribeToStreams: () => undefined,
-    unsubscribeToStreams: () => undefined,
+    subscribeToStreams: () => {},
+    unsubscribeToStreams: () => {},
     weather: WEATHER,
   };
 
@@ -152,7 +163,7 @@ export default class WeatherForecast extends Component {
           <div className={styles.fullSectionPlot}>
             <div className={styles.sectionTitle}>Clouds</div>
             <div ref={this.cloudPlotRef} className={styles.plot}>
-              <PlotContainer
+              <ForecastPlotContainer
                 containerNode={this.cloudPlotRef}
                 xAxisTitle="Time"
                 yAxisTitle=""
@@ -162,7 +173,6 @@ export default class WeatherForecast extends Component {
                 sliceInvert={this.state.sliceInvert}
                 sizeLimit={this.state.sizeLimit}
                 temporalXAxisFormat={this.state.temporalXAxisFormat}
-                isForecast={true}
                 scaleDomain={{ domainMin: 0, domainMax: 100 }}
                 maxHeight={130}
               />
@@ -174,7 +184,7 @@ export default class WeatherForecast extends Component {
           <div className={styles.fullSectionPlot}>
             <div></div>
             <div ref={this.cloudComplementPlotRef} className={styles.plot}>
-              <PlotContainer
+              <ForecastPlotContainer
                 containerNode={this.cloudComplementPlotRef}
                 xAxisTitle="Time"
                 yAxisTitle="Cloud"
@@ -184,7 +194,6 @@ export default class WeatherForecast extends Component {
                 sliceInvert={this.state.sliceInvert}
                 sizeLimit={this.state.sizeLimit}
                 temporalXAxisFormat={this.state.temporalXAxisFormat}
-                isForecast={true}
                 scaleDomain={{ domainMin: 0, domainMax: 100 }}
                 scaleIndependent={true}
               />
@@ -196,7 +205,7 @@ export default class WeatherForecast extends Component {
           <div className={styles.fullSectionPlot}>
             <div className={styles.sectionTitle}>Wind</div>
             <div ref={this.windPlotRef} className={styles.plot}>
-              <PlotContainer
+              <ForecastPlotContainer
                 containerNode={this.windPlotRef}
                 xAxisTitle="Time"
                 yAxisTitle=""
@@ -206,7 +215,6 @@ export default class WeatherForecast extends Component {
                 sliceInvert={this.state.sliceInvert}
                 sizeLimit={this.state.sizeLimit}
                 temporalXAxisFormat={this.state.temporalXAxisFormat}
-                isForecast={true}
               />
             </div>
           </div>
@@ -216,7 +224,7 @@ export default class WeatherForecast extends Component {
           <div className={styles.fullSectionPlot}>
             <div className={styles.sectionTitle}>Temperature</div>
             <div ref={this.temperaturePlotRef} className={styles.plot}>
-              <PlotContainer
+              <ForecastPlotContainer
                 containerNode={this.temperaturePlotRef}
                 xAxisTitle="Time"
                 yAxisTitle="Temperature"
@@ -226,7 +234,6 @@ export default class WeatherForecast extends Component {
                 sliceInvert={this.state.sliceInvert}
                 sizeLimit={this.state.sizeLimit}
                 temporalXAxisFormat={this.state.temporalXAxisFormat}
-                isForecast={true}
               />
             </div>
           </div>
@@ -236,7 +243,7 @@ export default class WeatherForecast extends Component {
           <div className={styles.fullSectionPlot}>
             <div className={styles.sectionTitle}>Rain</div>
             <div ref={this.rainPlotRef} className={styles.plot}>
-              <PlotContainer
+              <ForecastPlotContainer
                 containerNode={this.rainPlotRef}
                 xAxisTitle="Time"
                 yAxisTitle=""
@@ -246,7 +253,6 @@ export default class WeatherForecast extends Component {
                 sliceInvert={this.state.sliceInvert}
                 sizeLimit={this.state.sizeLimit}
                 temporalXAxisFormat={this.state.temporalXAxisFormat}
-                isForecast={true}
                 scaleIndependent={true}
                 scaleDomain={{ domainMin: 0, domainMax: 100 }}
               />

--- a/love/src/components/WeatherStation/WeatherStation.container.jsx
+++ b/love/src/components/WeatherStation/WeatherStation.container.jsx
@@ -3,7 +3,9 @@ This file is part of LOVE-frontend.
 
 Copyright (c) 2023 Inria Chile.
 
-Developed by Inria Chile.
+Developed by Inria Chile and the Telescope and Site Software team.
+
+Developed for the Vera C. Rubin Observatory Telescope and Site Systems.
 
 This program is free software: you can redistribute it and/or modify it under 
 the terms of the GNU General Public License as published by the Free Software 
@@ -39,12 +41,6 @@ export const schema = {
       description: 'Whether the component has a raw mode version',
       isPrivate: true,
       default: true,
-    },
-    controls: {
-      type: 'boolean',
-      description: "Whether to display controls to configure periods of time'",
-      default: true,
-      isPrivate: false,
     },
     salindex: {
       type: 'number',


### PR DESCRIPTION
This PR brings several improvements to the Plot components logic by separating concerns. The weather forecast plots logic was inserted inside the generic Plot component which in turn presented maintenance problems, this was refactored by moving the weather forecast plots logic into its own component: `WeatherForecastPlot`, similar to having the `PolarPlot` and `VegaCustomPlot` logic independent.

Also controls for plots historical data on `WeatherStation` and `Auxtel/Dome` component was removed as now that is handled directly by the `Plot` component.