### PR TITLE
Remove deprecated XML user menu.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.8.2
 ------
 
+* Remove deprecated XML user menu. `<https://github.com/lsst-ts/LOVE-frontend/pull/729>`_
 * Remove deprecated openSplice version from CSCExpanded. `<https://github.com/lsst-ts/LOVE-frontend/pull/730>`_
 * Include bump test status result on BumpTests component. `<https://github.com/lsst-ts/LOVE-frontend/pull/728>`_
 * Remove custom weather forecast logic from generic plot components. `<https://github.com/lsst-ts/LOVE-frontend/pull/727>`_

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -58,7 +58,6 @@ import AlarmAudioContainer from '../Watcher/AlarmAudio/AlarmAudio.container';
 import AlarmsList from '../Watcher/AlarmsList/AlarmsList';
 import { isAcknowledged, isMuted, isActive } from '../Watcher/AlarmUtils';
 import Modal from '../GeneralPurpose/Modal/Modal';
-import XMLTable from './XMLTable/XMLTable';
 import ConfigPanel from './ConfigPanel/ConfigPanel';
 import EmergencyContactsPanel from './EmergencyContactsPanel/EmergencyContactsPanel';
 import AboutPanel from './AboutPanel/AboutPanel';
@@ -137,7 +136,6 @@ class Layout extends Component {
       heartbeatStatus: {},
       heartbeatInfo: {},
       hovered: false, // true if leftTopbar is being hovered
-      isXMLModalOpen: false,
       isConfigModalOpen: false,
       isEmergencyContactsModalOpen: false,
       isAboutModalOpen: false,
@@ -648,7 +646,6 @@ class Layout extends Component {
                 this.setState({ tokenSwapRequested: true });
                 this.props.requireUserSwap(true);
               }}
-              onXMLClick={() => this.setState({ isXMLModalOpen: true })}
               onConfigClick={() => this.setState({ isConfigModalOpen: true })}
               onEmergencyContactsClick={() => this.setState({ isEmergencyContactsModalOpen: true })}
               onAboutClick={() => this.setState({ isAboutModalOpen: true })}
@@ -726,7 +723,6 @@ class Layout extends Component {
                 this.setState({ tokenSwapRequested: true });
                 this.props.requireUserSwap(true);
               }}
-              onXMLClick={() => this.setState({ isXMLModalOpen: true })}
               onConfigClick={() => this.setState({ isConfigModalOpen: true })}
               onEmergencyContactsClick={() => this.setState({ isEmergencyContactsModalOpen: true })}
               onAboutClick={() => this.setState({ isAboutModalOpen: true })}
@@ -872,13 +868,6 @@ class Layout extends Component {
           <InriaLogo className={styles.logoInria} title="Love" />
         </div>
 
-        <Modal
-          isOpen={this.state.isXMLModalOpen}
-          onRequestClose={() => this.setState({ isXMLModalOpen: false })}
-          contentLabel="XML versions modal"
-        >
-          <XMLTable />
-        </Modal>
         <Modal
           isOpen={this.state.isConfigModalOpen}
           onRequestClose={() => this.setState({ isConfigModalOpen: false })}

--- a/love/src/components/Layout/UserDetails/UserDetails.jsx
+++ b/love/src/components/Layout/UserDetails/UserDetails.jsx
@@ -34,8 +34,6 @@ UserDetails.propTypes = {
   menuElementClassName: PropTypes.string,
   /** Classname to add ot the diveiders */
   dividerClassName: PropTypes.string,
-  /** Callback to execute when clicking on the XML menu element */
-  onXMLClick: PropTypes.func,
   /** Callback to execute when clicking on the Config file menu element */
   onConfigClick: PropTypes.func,
   /** Callback to execute when clicking on the Emergency contact menu element */
@@ -56,7 +54,6 @@ export default function UserDetails({
   execPermission,
   menuElementClassName,
   dividerClassName,
-  onXMLClick,
   onConfigClick,
   onEmergencyContactsClick,
   logout,
@@ -93,12 +90,6 @@ export default function UserDetails({
         <div className={styles.smallIconRow}>
           <EmergencyContactIcon active={false} className={styles.paddedIcon} />
           <span>Emergency contacts </span>
-        </div>
-      </div>
-      <div className={[menuElementClassName, styles.menuElement].join(' ')} onClick={onXMLClick}>
-        <div className={styles.smallIconRow}>
-          <ScriptIcon active={false} className={styles.paddedIcon} />
-          <span>XML versions </span>
         </div>
       </div>
       <div className={[menuElementClassName, styles.menuElement].join(' ')} onClick={onConfigClick}>


### PR DESCRIPTION
This PR removes the `XML Versions` display as that feature was deprecated after the move to Kafka (https://github.com/lsst-ts/LOVE-commander/pull/76). The new `salobj` versions don't have the necessary methods to retrieve al XML versions in one call as it could before, for this reason we decided to remove the feature in favor of having the `CSCSummary` to display this instead for each CSC (coming from each CSC LOVE-producer).