### PR TITLE
Fix payload arrangement for nightreport CSC states EFD query.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.9.2
+------
+
+* Fix payload arrangement for nightreport CSC states EFD query. `<https://github.com/lsst-ts/LOVE-frontend/pull/737>`_
+
 v6.9.1
 ------
 

--- a/love/src/components/NightReport/CSCStates.jsx
+++ b/love/src/components/NightReport/CSCStates.jsx
@@ -18,7 +18,7 @@ function CSCStates({ report, cscs: cscsProp }) {
     const cutDate = getCutDateFromNightReport(report);
     const timeCutdate = cutDate.utc().format(ISO_STRING_DATE_TIME_FORMAT);
     const cscsPayload = {};
-    Object.keys(cscs).forEach((cscName) => {
+    NIGHTREPORT_CSCS_TO_REPORT.forEach((cscName) => {
       const [csc, index] = cscName.split(':');
       cscsPayload[csc] = {
         [index]: {


### PR DESCRIPTION
Hotfix PR for fixing the `CSCStates` EFD query payload arrangement.