### PR TITLE
Fix CSCDetail & CSCExpanded containers to subscribe to offlineDetailedState event only for big cameras: ATCamera, MTCamera and CCCamera.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ Version History
 v6.11.1
 -------
 
+* Fix CSCDetail & CSCExpanded containers to subscribe to offlineDetailedState event only for big cameras: ATCamera, MTCamera and CCCamera. `<https://github.com/lsst-ts/LOVE-frontend/pull/773>`_
 * Improvements for the observatory status feature. `<https://github.com/lsst-ts/LOVE-frontend/pull/772>`_
-
 
 v6.11.0
 -------

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -110,6 +110,9 @@ export const DATE_TIME_FORMAT = 'YYYY/MM/DD, HH:mm:ss';
 export const URL_REGEX =
   /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/;
 
+// List of big camera CSC names
+export const CAMERA_CSC_NAMES = ['ATCamera', 'CCCamera', 'MTCamera'];
+
 /*****************************************************************************/
 /*********************Observatory state configurations************************/
 /*****************************************************************************/

--- a/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
+++ b/love/src/components/CSCSummary/CSCDetail/CSCDetail.container.jsx
@@ -23,6 +23,7 @@ import { addGroup, removeGroup } from 'redux/actions/ws';
 import { getStreamData, getCSCHeartbeat, getCSCWithWarning, getServerTime } from 'redux/selectors';
 import CSCDetail from './CSCDetail';
 import SubscriptionTableContainer from '../../GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
+import { CAMERA_CSC_NAMES } from 'Config';
 
 export const schema = {
   description: 'Displays heartbeat and Summary State for a single CSC',
@@ -127,8 +128,11 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     `event-${ownProps.name}-${ownProps.salindex}-errorCode`,
     `event-${ownProps.name}-${ownProps.salindex}-simulationMode`,
     `event-Heartbeat-0-stream`,
-    `event-${ownProps.name}-${ownProps.salindex}-offlineDetailedState`,
   ];
+
+  if (CAMERA_CSC_NAMES.includes(ownProps.name)) {
+    subscriptions.push(`event-${ownProps.name}-${ownProps.salindex}-offlineDetailedState`);
+  }
   return {
     subscriptions,
     subscribeToStreams: () => {

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -118,30 +118,25 @@ const CSCExpandedContainer = ({
 };
 
 const mapDispatchToProps = (dispatch) => {
+  const topics = [
+    'summaryState',
+    'logMessage',
+    'logLevel',
+    'errorCode',
+    'softwareVersions',
+    'configurationsAvailable',
+    'configurationApplied',
+    'simulationMode',
+    'offlineDetailedState',
+  ];
   return {
     subscribeToStreams: (cscName, index) => {
       dispatch(addGroup('event-Heartbeat-0-stream'));
-      dispatch(addGroup(`event-${cscName}-${index}-summaryState`));
-      dispatch(addGroup(`event-${cscName}-${index}-logMessage`));
-      dispatch(addGroup(`event-${cscName}-${index}-logLevel`));
-      dispatch(addGroup(`event-${cscName}-${index}-errorCode`));
-      dispatch(addGroup(`event-${cscName}-${index}-softwareVersions`));
-      dispatch(addGroup(`event-${cscName}-${index}-configurationsAvailable`));
-      dispatch(addGroup(`event-${cscName}-${index}-configurationApplied`));
-      dispatch(addGroup(`event-${cscName}-${index}-simulationMode`));
-      dispatch(addGroup(`event-${cscName}-${index}-offlineDetailedState`));
+      topics.forEach((topic) => dispatch(addGroup(`event-${cscName}-${index}-${topic}`)));
     },
     unsubscribeToStreams: (cscName, index) => {
       dispatch(removeGroup('event-Heartbeat-0-stream'));
-      dispatch(removeGroup(`event-${cscName}-${index}-summaryState`));
-      dispatch(removeGroup(`event-${cscName}-${index}-logMessage`));
-      dispatch(removeGroup(`event-${cscName}-${index}-logLevel`));
-      dispatch(removeGroup(`event-${cscName}-${index}-errorCode`));
-      dispatch(removeGroup(`event-${cscName}-${index}-softwareVersions`));
-      dispatch(removeGroup(`event-${cscName}-${index}-configurationsAvailable`));
-      dispatch(removeGroup(`event-${cscName}-${index}-configurationApplied`));
-      dispatch(removeGroup(`event-${cscName}-${index}-simulationMode`));
-      dispatch(removeGroup(`event-${cscName}-${index}-offlineDetailedState`));
+      topics.forEach((topic) => dispatch(removeGroup(`event-${cscName}-${index}-${topic}`)));
     },
     clearCSCLogMessages: (csc, salindex) => {
       dispatch(removeCSCLogMessages(csc, salindex));

--- a/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
+++ b/love/src/components/CSCSummary/CSCExpanded/CSCExpanded.container.jsx
@@ -23,6 +23,7 @@ import CSCExpanded from './CSCExpanded';
 import { addGroup, removeGroup, requestSALCommand } from '../../../redux/actions/ws';
 import { removeCSCLogMessages, removeCSCErrorCodeData } from '../../../redux/actions/summaryData';
 import { getStreamData, getCSCHeartbeat, getCSCLogMessages, getCSCErrorCodeData } from '../../../redux/selectors';
+import { CAMERA_CSC_NAMES } from 'Config';
 
 export const schema = {
   description: 'Displays the error code and message logs for a single CSC',
@@ -127,16 +128,22 @@ const mapDispatchToProps = (dispatch) => {
     'configurationsAvailable',
     'configurationApplied',
     'simulationMode',
-    'offlineDetailedState',
   ];
+
   return {
     subscribeToStreams: (cscName, index) => {
       dispatch(addGroup('event-Heartbeat-0-stream'));
       topics.forEach((topic) => dispatch(addGroup(`event-${cscName}-${index}-${topic}`)));
+      if (CAMERA_CSC_NAMES.includes(cscName)) {
+        dispatch(addGroup(`event-${cscName}-${index}-offlineDetailedState`));
+      }
     },
     unsubscribeToStreams: (cscName, index) => {
       dispatch(removeGroup('event-Heartbeat-0-stream'));
       topics.forEach((topic) => dispatch(removeGroup(`event-${cscName}-${index}-${topic}`)));
+      if (CAMERA_CSC_NAMES.includes(cscName)) {
+        dispatch(removeGroup(`event-${cscName}-${index}-offlineDetailedState`));
+      }
     },
     clearCSCLogMessages: (csc, salindex) => {
       dispatch(removeCSCLogMessages(csc, salindex));


### PR DESCRIPTION
This PR extends the `CSCDetail` and `CSCExpanded` containers to constraint subscriptions of the `offlineDetailedState` event only for the big cameras, i.e: ATCamera, MTCamera and CCCamera.