### PR TITLE
Temporary disable control location feature.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.11.3
+-------
+
+* Temporary disable control location feature. `<https://github.com/lsst-ts/LOVE-frontend/pull/780>`_
+
 v6.11.2
 -------
 

--- a/love/src/components/Layout/Layout.container.jsx
+++ b/love/src/components/Layout/Layout.container.jsx
@@ -37,12 +37,16 @@ import {
   getEfdConfig,
   getSALConfig,
   getObservatoryState,
-  getControlLocation,
+  // TODO: roll back this feature if/when required.
+  // See: OSW-1998.
+  // getControlLocation,
 } from '../../redux/selectors';
 import { logout, receiveConfig, requireSwapToken, cancelSwapToken } from '../../redux/actions/auth';
 import { logAlarm, ackAlarm } from '../../redux/actions/alarms';
-import { addGroup, removeGroup, requestSALCommand, resetSubscriptions } from '../../redux/actions/ws';
-import { fetchControlLocationLoopStart, fetchControlLocationLoopStop } from '../../redux/actions/observatoryState';
+import { addGroup, removeGroup, resetSubscriptions } from '../../redux/actions/ws';
+// TODO: roll back this feature if/when required.
+// See: OSW-1998.
+// import { fetchControlLocationLoopStart, fetchControlLocationLoopStop } from '../../redux/actions/observatoryState';
 import { queryTopicsFieldsInfo } from '../../redux/actions/salinfo';
 import { clearViewToEdit } from '../../redux/actions/uif';
 import Layout from './Layout';
@@ -70,7 +74,9 @@ const mapStateToProps = (state) => {
   const efdConfigFile = getEfdConfig(state);
   const salConfigFile = getSALConfig(state);
   const observatorySummary = getObservatoryState(state);
-  const controlLocation = getControlLocation(state);
+  // TODO: roll back this feature if/when required.
+  // See: OSW-1998.
+  // const controlLocation = getControlLocation(state);
   return {
     user,
     config,
@@ -90,7 +96,7 @@ const mapStateToProps = (state) => {
     efdConfigFile,
     salConfigFile,
     observatorySummary,
-    controlLocation,
+    // controlLocation,
   };
 };
 
@@ -129,12 +135,14 @@ const mapDispatchToProps = (dispatch) => {
       else dispatch(cancelSwapToken);
     },
     setConfig: (config) => dispatch(receiveConfig(config)),
-    startControlLocationLoop: () => {
-      dispatch(fetchControlLocationLoopStart());
-    },
-    stopControlLocationLoop: () => {
-      dispatch(fetchControlLocationLoopStop());
-    },
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
+    // startControlLocationLoop: () => {
+    //   dispatch(fetchControlLocationLoopStart());
+    // },
+    // stopControlLocationLoop: () => {
+    //   dispatch(fetchControlLocationLoopStop());
+    // },
     queryTopicsFieldsInfo: () => dispatch(queryTopicsFieldsInfo()),
   };
 };

--- a/love/src/components/Layout/Layout.jsx
+++ b/love/src/components/Layout/Layout.jsx
@@ -28,7 +28,6 @@ import OLEMenu from 'components/OLE/Menu/OLEMenu';
 import ExposureAdd from 'components/OLE/Exposure/ExposureAdd';
 import NonExposureEdit from 'components/OLE/NonExposure/NonExposureEdit';
 import TeknikerAdd from 'components/OLE/Tekniker/TeknikerAdd';
-import ObservatorySummaryMenu from 'components/ObservatorySummary/Menu/ObservatorySummaryMenu';
 import ManagerInterface, {
   getNotificationMessage,
   relativeTime,
@@ -45,6 +44,7 @@ import Button from '../GeneralPurpose/Button/Button';
 import DropdownMenu from '../GeneralPurpose/DropdownMenu/DropdownMenu';
 import NotificationIcon from '../icons/NotificationIcon/NotificationIcon';
 import UserIcon from '../icons/UserIcon/UserIcon';
+import ObservatorySummaryMenu from 'components/ObservatorySummary/Menu/ObservatorySummaryMenu';
 import LogoIcon from '../icons/LogoIcon/LogoIcon';
 import MenuIcon from '../icons/MenuIcon/MenuIcon';
 import InriaLogo from '../icons/InriaLogo/InriaLogo';
@@ -64,10 +64,12 @@ import AboutPanel from './AboutPanel/AboutPanel';
 import UserDetails from './UserDetails/UserDetails';
 import UserSwapContainer from '../Login/UserSwap.container';
 import styles from './Layout.module.css';
-import CactusIcon from '../icons/CactusIcon/CactusIcon';
 import UnknownLocationIcon from '../icons/UnknownLocationIcon/UnknownLocationIcon';
-import BeachIcon from '../icons/BeachIcon/BeachIcon';
-import MountainIcon from '../icons/MountainIcon/MountainIcon';
+// TODO: roll back this feature if/when required.
+// See: OSW-1998.
+// import CactusIcon from '../icons/CactusIcon/CactusIcon';
+// import BeachIcon from '../icons/BeachIcon/BeachIcon';
+// import MountainIcon from '../icons/MountainIcon/MountainIcon';
 
 export const LAYOUT_CONTAINER_ID = 'layoutContainer';
 const BREAK_1 = 865;
@@ -159,7 +161,9 @@ class Layout extends Component {
   componentDidMount = () => {
     this.moveCustomTopbar();
     this.props.subscribeToStreams();
-    this.props.startControlLocationLoop();
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
+    // this.props.startControlLocationLoop();
 
     this.heartbeatInterval = setInterval(() => {
       this.checkHeartbeat();
@@ -179,7 +183,9 @@ class Layout extends Component {
     window.clearInterval(this.heartbeatInterval);
     window.clearInterval(this.externalServicesInterval);
     this.props.unsubscribeToStreams();
-    this.props.stopControlLocationLoop();
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
+    // this.props.stopControlLocationLoop();
   };
 
   componentDidUpdate = (prevProps, prevState) => {
@@ -329,22 +335,24 @@ class Layout extends Component {
   };
 
   /** Returns the corresponding svg based on Observatory Control Location * */
-  getObsLocationIcon = (style) => {
-    const { controlLocation } = this.props.controlLocation;
+  // TODO: roll back this feature if/when required.
+  // See: OSW-1998.
+  // getObsLocationIcon = (style) => {
+  //   const { controlLocation } = this.props.controlLocation;
 
-    switch (controlLocation ? controlLocation.name : 'unknown') {
-      case 'unknown':
-        return <UnknownLocationIcon className={style} />;
-      case 'tucson':
-        return <CactusIcon className={style} />;
-      case 'base':
-        return <BeachIcon className={style} />;
-      case 'summit':
-        return <MountainIcon className={style} />;
-      default:
-        return <UnknownLocationIcon className={style} />;
-    }
-  };
+  //   switch (controlLocation ? controlLocation.name : 'unknown') {
+  //     case 'unknown':
+  //       return <UnknownLocationIcon className={style} />;
+  //     case 'tucson':
+  //       return <CactusIcon className={style} />;
+  //     case 'base':
+  //       return <BeachIcon className={style} />;
+  //     case 'summit':
+  //       return <MountainIcon className={style} />;
+  //     default:
+  //       return <UnknownLocationIcon className={style} />;
+  //   }
+  // };
 
   handleClick = (event) => {
     if (
@@ -474,16 +482,17 @@ class Layout extends Component {
   };
 
   renderRightSideMenu = () => {
-    const { controlLocation, lastUpdated } = this.props.controlLocation;
     const filteredAlarms = this.props.alarms.filter((a) => {
       return (
         isActive(a) && !isAcknowledged(a) && !isMuted(a) && a.severity?.value >= this.state.minSeverityNotification
       );
     });
 
-    const controlLocationName = controlLocation
-      ? controlLocation.name.charAt(0).toUpperCase() + controlLocation.name.slice(1)
-      : 'Unknown';
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
+    // const controlLocationName = controlLocation
+    //   ? controlLocation.name.charAt(0).toUpperCase() + controlLocation.name.slice(1)
+    //   : 'Unknown';
 
     return (
       <div className={styles.rightTopbar}>
@@ -583,15 +592,24 @@ class Layout extends Component {
 
         {/** Observatory Summary  * */}
         <DropdownMenu className={styles.settingsDropdown}>
-          <Button className={styles.iconBtn} title="Settings" status="transparent">
-            {this.getObsLocationIcon(`${styles.icon} ${styles.locationIcon}`)}
+          <Button className={styles.iconBtn} title="Observatory Summary" status="transparent">
+            {/* TODO: roll back this feature if/when required.
+            * Remove the UnknownLocationIcon and uncomment the getObsLocationIcon function to show
+            * the actual control location icon when the feature is re-enabled.
+            * /}
+            {/* See: OSW-1998. */}
+            {/* {this.getObsLocationIcon(`${styles.icon} ${styles.locationIcon}`)} */}
+            <UnknownLocationIcon className={`${styles.icon} ${styles.locationIcon}`} />
           </Button>
+
           <div className={styles.observatorySummaryMenu}>
             <ObservatorySummaryMenu
               dividerClassName={styles.divider}
-              locationIcon={this.getObsLocationIcon()}
-              location={controlLocationName}
-              locationLastUpdate={lastUpdated}
+              // TODO: roll back this feature if/when required.
+              // See: OSW-1998.
+              // locationIcon={this.getObsLocationIcon()}
+              // location={controlLocationName}
+              // locationLastUpdate={lastUpdated}
               simonyiOperationMode={'UNKNOWN'}
               simonyiTrackingState={this.props.observatorySummary?.simonyiTrackingState}
               simonyiTrackingMode={this.props.observatorySummary?.simonyiTrackingMode}
@@ -604,7 +622,7 @@ class Layout extends Component {
               degradation={this.props.observatorySummary?.degradation}
               auxtelPower={'UNKNOWN'}
               atmosphericTrans={this.props.observatorySummary?.atmosphericTrans}
-            ></ObservatorySummaryMenu>
+            />
           </div>
         </DropdownMenu>
 
@@ -657,26 +675,35 @@ class Layout extends Component {
   };
 
   renderMobileRightSideMenu = () => {
-    const { controlLocation, lastUpdated } = this.props.controlLocation;
-
-    const controlLocationName = controlLocation
-      ? controlLocation.name.charAt(0).toUpperCase() + controlLocation.name.slice(1)
-      : 'Unknown';
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
+    // const controlLocationName = controlLocation
+    //   ? controlLocation.name.charAt(0).toUpperCase() + controlLocation.name.slice(1)
+    //   : 'Unknown';
 
     return (
       <div className={styles.rightTopbarMobile}>
         {this.renderHeartbeatsMenu()}
         <DropdownMenu className={styles.settingsDropdown} disabledToggle={true}>
-          <Button className={styles.iconBtn} title="Settings" status="transparent">
-            {this.getObsLocationIcon(`${styles.icon} ${styles.locationIcon}`)}
+          {/** Observatory Summary  * */}
+          <Button className={styles.iconBtn} title="Observatory Summary" status="transparent">
+            {/* TODO: roll back this feature if/when required.
+            * Remove the UnknownLocationIcon and uncomment the getObsLocationIcon function to show
+            * the actual control location icon when the feature is re-enabled.
+            * /}
+            {/* See: OSW-1998. */}
+            {/* {this.getObsLocationIcon(`${styles.icon} ${styles.locationIcon}`)} */}
+            <UnknownLocationIcon className={`${styles.icon} ${styles.locationIcon}`} />
           </Button>
 
           <div className={styles.observatorySummaryMenu}>
             <ObservatorySummaryMenu
               dividerClassName={styles.divider}
-              locationIcon={this.getObsLocationIcon()}
-              location={controlLocationName}
-              locationLastUpdate={lastUpdated}
+              // TODO: roll back this feature if/when required.
+              // See: OSW-1998.
+              // locationIcon={this.getObsLocationIcon()}
+              // location={controlLocationName}
+              // locationLastUpdate={lastUpdated}
               simonyiOperationMode={'UNKNOWN'}
               simonyiTrackingState={this.props.observatorySummary?.simonyiTrackingState}
               simonyiTrackingMode={this.props.observatorySummary?.simonyiTrackingMode}
@@ -686,8 +713,10 @@ class Layout extends Component {
               auxtelTrackingState={this.props.observatorySummary?.auxtelTrackingState}
               auxtelTrackingMode={this.props.observatorySummary?.auxtelTrackingMode}
               auxtelObsMode={this.props.observatorySummary?.auxtelObservingMode}
+              degradation={this.props.observatorySummary?.degradation}
               auxtelPower={'UNKNOWN'}
-            ></ObservatorySummaryMenu>
+              atmosphericTrans={this.props.observatorySummary?.atmosphericTrans}
+            />
           </div>
           <div className={styles.userMenu}>
             <UserDetails

--- a/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.jsx
+++ b/love/src/components/ObservatorySummary/Menu/ObservatorySummaryMenu.jsx
@@ -20,19 +20,16 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 import React from 'react';
 import PropTypes from 'prop-types';
 import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
-import {
-  telescopeTrackingStateMap,
-  telescopeTrackingModeStateMap,
-  telescopeTrackingStateToStyle,
-  telescopeTrackingModeStateToStyle,
-} from 'Config';
+import { telescopeTrackingStateMap, telescopeTrackingModeStateMap, telescopeTrackingStateToStyle } from 'Config';
 import styles from './ObservatorySummaryMenu.module.css';
 
 /** Contents of the ObservatorySummary details Dropdown Menu */
 export default function ObservatorySummaryMenu({
-  location,
-  locationLastUpdate,
-  locationIcon,
+  // TODO: roll back this feature if/when required.
+  // See: OSW-1998.
+  // location,
+  // locationLastUpdate,
+  // locationIcon,
   menuElementClassName,
   dividerClassName,
   simonyiOperationMode,
@@ -55,7 +52,9 @@ export default function ObservatorySummaryMenu({
   return (
     <>
       <div className={[menuElementClassName, styles.menuElement, styles.section].join(' ')}>
-        <div className={styles.bigIconRow}>
+        {/* TODO: roll back this feature if/when required. */}
+        {/* See: OSW-1998. */}
+        {/* <div className={styles.bigIconRow}>
           <div className={styles.iconContainer}>{locationIcon}</div>
           <div className={styles.contentContainer}>
             <span>Observatory control </span>
@@ -65,7 +64,7 @@ export default function ObservatorySummaryMenu({
               </span>
             </div>
           </div>
-        </div>
+        </div> */}
         <span className={styles.label}>Env. Degradation</span>
         <span>{degradation}</span>
       </div>
@@ -149,11 +148,11 @@ export default function ObservatorySummaryMenu({
 
 ObservatorySummaryMenu.propTypes = {
   /** Location from where LOVE is being controlled from */
-  location: PropTypes.string,
+  // location: PropTypes.string,
   /** Location last update */
-  locationLastUpdate: PropTypes.instanceOf(Date),
+  // locationLastUpdate: PropTypes.instanceOf(Date),
   /** An svg representing the location generated on Layout.jsx */
-  locationIcon: PropTypes.object,
+  // locationIcon: PropTypes.object,
   /** Classname to add ot the menu elements */
   menuElementClassName: PropTypes.string,
   /** Classname to add ot the diveiders */

--- a/love/src/components/ObservatorySummary/ObservatorySummary.container.jsx
+++ b/love/src/components/ObservatorySummary/ObservatorySummary.container.jsx
@@ -20,7 +20,7 @@ this program. If not, see <http://www.gnu.org/licenses/>.
 import React from 'react';
 import { connect } from 'react-redux';
 import ObservatorySummary from './ObservatorySummary';
-import { getControlLocation, getObservatoryState, getObservatorySubscriptions } from '../../redux/selectors';
+import { getObservatoryState, getObservatorySubscriptions } from '../../redux/selectors';
 import { addGroup, removeGroup } from '../../redux/actions/ws';
 import SubscriptionTableContainer from '../GeneralPurpose/SubscriptionTable/SubscriptionTable.container';
 
@@ -47,8 +47,10 @@ const ObservatorySummaryContainer = ({ ...props }) => {
 
 const mapStateToProps = (state) => {
   const observatorySummary = getObservatoryState(state);
-  const controlLocation = getControlLocation(state);
-  return { ...observatorySummary, ...controlLocation };
+  // TODO: roll back this feature if/when required.
+  // See: OSW-1998.
+  // const controlLocation = getControlLocation(state);
+  return { ...observatorySummary };
 };
 
 const mapDispatchToProps = (dispatch) => {

--- a/love/src/components/ObservatorySummary/ObservatorySummary.jsx
+++ b/love/src/components/ObservatorySummary/ObservatorySummary.jsx
@@ -24,14 +24,11 @@ import Label from 'components/GeneralPurpose/SummaryPanel/Label';
 import Value from 'components/GeneralPurpose/SummaryPanel/Value';
 import Title from 'components/GeneralPurpose/SummaryPanel/Title';
 import StatusText from 'components/GeneralPurpose/StatusText/StatusText';
-import {
-  telescopeTrackingStateMap,
-  telescopeTrackingModeStateMap,
-  telescopeTrackingStateToStyle,
-  telescopeTrackingModeStateToStyle,
-} from 'Config';
+import { telescopeTrackingStateMap, telescopeTrackingModeStateMap, telescopeTrackingStateToStyle } from 'Config';
 import styles from './ObservatorySummary.module.css';
 
+// TODO: roll back this feature if/when required.
+// See: OSW-1998.
 const POOLING_TIME = 3000;
 
 export default class ObservatorySummary extends Component {
@@ -48,10 +45,12 @@ export default class ObservatorySummary extends Component {
     auxtelTrackingState: PropTypes.string,
     /** Auxiliary Telescope Tracking Mode */
     auxtelTrackingMode: PropTypes.string,
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
     /** Control Location */
-    controlLocation: PropTypes.object,
+    // controlLocation: PropTypes.object,
     /** Last Updated Control Location info */
-    lastUpdated: PropTypes.instanceOf(Date),
+    // lastUpdated: PropTypes.instanceOf(Date),
     /** Atmospheric Transmission */
     atmosphericTrans: PropTypes.string,
   };
@@ -63,8 +62,10 @@ export default class ObservatorySummary extends Component {
     auxtelObservingMode: 'UNKNOWN',
     auxtelTrackingState: 'UNKNOWN',
     auxtelTrackingMode: 'UNKNOWN',
-    controlLocation: null,
-    lastUpdated: null,
+    // TODO: roll back this feature if/when required.
+    // See: OSW-1998.
+    // controlLocation: null,
+    // lastUpdated: null,
     atmosphericTrans: 'UNKNOWN',
   };
 
@@ -84,15 +85,17 @@ export default class ObservatorySummary extends Component {
       auxtelObservingMode,
       auxtelTrackingState,
       auxtelTrackingMode,
-      controlLocation,
-      lastUpdated,
+      // TODO: roll back this feature if/when required.
+      // See: OSW-1998.
+      // controlLocation,
+      // lastUpdated,
       degradation,
       atmosphericTrans,
     } = this.props;
 
-    const controlLocationName = controlLocation
-      ? controlLocation.name.charAt(0).toUpperCase() + controlLocation.name.slice(1)
-      : 'UNKNOWN';
+    // const controlLocationName = controlLocation
+    //   ? controlLocation.name.charAt(0).toUpperCase() + controlLocation.name.slice(1)
+    //   : 'UNKNOWN';
 
     const simonyiTrackingStateText = telescopeTrackingStateMap[simonyiTrackingState];
     const simonyiTrackingModeText = telescopeTrackingModeStateMap[simonyiTrackingMode];
@@ -121,10 +124,12 @@ export default class ObservatorySummary extends Component {
 
         <SummaryPanel>
           <Title wide>Vera C. Rubin Observatory</Title>
-          <Label>Control</Label>
+          {/* TODO: roll back this feature if/when required. */}
+          {/* See: OSW-1998. */}
+          {/* <Label>Control</Label>
           <Value>
             <span title={`Last updated: ${lastUpdated?.toUTCString()}`}>{controlLocationName}</span>
-          </Value>
+          </Value> */}
           <Label>Power Source</Label>
           <Value>UNKNOWN</Value>
           <Label>Env. Degradation</Label>


### PR DESCRIPTION
This PR temporary removes the control location feature. This was a implementation that has never been used and in favor of reducing load from the system we are removing it. This feature was polling a manager endpoint every 3 seconds per each open LOVE tab, leading to excesive unused requests.