### PR TITLE
Add visual cue to ScriptQueue observatory state to indicate the Scheduler CSC is pending to be enabled.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.11.4
+-------
+
+* Add visual cue to ScriptQueue observatory state to indicate the Scheduler CSC is pending to be enabled `<https://github.com/lsst-ts/LOVE-frontend/pull/788>`_
+
 v6.11.3
 -------
 

--- a/love/src/components/ScriptQueue/GlobalState/GlobalState.jsx
+++ b/love/src/components/ScriptQueue/GlobalState/GlobalState.jsx
@@ -27,6 +27,7 @@ import ResumeIcon from 'components/icons/ScriptQueue/ResumeIcon/ResumeIcon';
 import PauseIcon from 'components/icons/ScriptQueue/PauseIcon/PauseIcon';
 import GearIcon from 'components/icons/ScriptQueue/GearIcon/GearIcon.jsx';
 import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
+import WarningIcon from 'components/icons/WarningIcon/WarningIcon';
 import MessageIcon from 'components/icons/MessageIcon/MessageIcon';
 import CSCDetail from 'components/CSCSummary/CSCDetail/CSCDetail.jsx';
 import { OBSERVATORY_STATES } from 'Config';
@@ -217,6 +218,11 @@ const GlobalState = ({
                       <div className={styles.pauseIconWrapper} title="Change observatoryState">
                         <GearIcon className={styles.gearIcon} />
                       </div>
+                    </div>
+                  )}
+                  {schedulerSummaryState.name !== 'ENABLED' && (
+                    <div className={styles.observatoryStateWarningIconWrapper}>
+                      <WarningIcon title="Observatory state controls are disabled because the Scheduler CSC is not enabled." />
                     </div>
                   )}
                 </div>

--- a/love/src/components/ScriptQueue/GlobalState/GlobalState.module.css
+++ b/love/src/components/ScriptQueue/GlobalState/GlobalState.module.css
@@ -174,3 +174,7 @@ input:checked + .sliderActiveState {
   width: 1em;
   height: 1em;
 }
+
+.observatoryStateWarningIconWrapper {
+  width: 2em;
+}


### PR DESCRIPTION
This PR adds a `WarningIcon` to the `GlobalState` component in the ScriptQueue display to provide an extra visual cue respecting the state of the Scheduler CSC. In order to control the observatory status, the respective (matched by sq-scheduler salindex) Scheduler CSC needs to be enabled.