### PR TITLE
Integrate narrative log creation with observatory states feature.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.11.4
 -------
 
+* Integrate narrative log creation with observatory states feature. `<https://github.com/lsst-ts/LOVE-frontend/pull/791>`_
 * Add visual cue to ScriptQueue observatory state to indicate the Scheduler CSC is pending to be enabled `<https://github.com/lsst-ts/LOVE-frontend/pull/788>`_
 
 v6.11.3

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -118,12 +118,39 @@ export const CAMERA_CSC_NAMES = ['ATCamera', 'CCCamera', 'MTCamera'];
 /*****************************************************************************/
 
 export const OBSERVATORY_STATES = {
-  UNKNOWN: 0,
-  DAYTIME: 1 << 0,
-  OPERATIONAL: 1 << 1,
-  FAULT: 1 << 2,
-  WEATHER: 1 << 3,
-  DOWNTIME: 1 << 4,
+  UNKNOWN: 0, // 0
+  DAYTIME: 1 << 0, // 1
+  OPERATIONAL: 1 << 1, // 2
+  FAULT: 1 << 2, // 4
+  WEATHER: 1 << 3, // 8
+  DOWNTIME: 1 << 4, // 16
+};
+
+export const OBSERVATORY_STATE_DETAIL = {
+  0: {
+    name: 'UNKNOWN',
+    statusText: 'invalid',
+  },
+  1: {
+    name: 'DAYTIME',
+    statusText: 'ok',
+  },
+  2: {
+    name: 'OPERATIONAL',
+    statusText: 'ok',
+  },
+  4: {
+    name: 'FAULT',
+    statusText: 'alert',
+  },
+  8: {
+    name: 'WEATHER',
+    statusText: 'alert',
+  },
+  16: {
+    name: 'DOWNTIME',
+    statusText: 'warning',
+  },
 };
 
 /*****************************************************************************/

--- a/love/src/Utils.js
+++ b/love/src/Utils.js
@@ -33,6 +33,7 @@ import {
   OLE_OBS_SUBSYSTEMS,
   OLE_OBS_SUBSYSTEMS_COMPONENTS,
   EFD_INSTANCES,
+  OBSERVATORY_STATES,
 } from 'Config';
 import { HTTP_STATUS } from 'Constants';
 
@@ -2687,4 +2688,21 @@ export function acronymizeString(str, separator = '_') {
     }
   });
   return acronym;
+}
+
+/**
+ * Function to get the active observatory states from a decimal value.
+ * The function receives a decimal value which represents the combination of the different observatory states
+ * through bitwise operations. It returns an array with the active states.
+ * @param {number} decimalValue - The decimal value representing the combination of observatory states.
+ * @returns {Array} - An array of active (numeric) observatory states.
+ */
+export function getActiveObservatoryStates(decimalValue) {
+  const activeStatuses = [];
+  for (const [_, bitValue] of Object.entries(OBSERVATORY_STATES)) {
+    if ((decimalValue & bitValue) !== 0) {
+      activeStatuses.push(bitValue);
+    }
+  }
+  return activeStatuses;
 }

--- a/love/src/Utils.test.js
+++ b/love/src/Utils.test.js
@@ -8,6 +8,7 @@ import {
   isNightReportOld,
   getCutDateFromNightReport,
   acronymizeString,
+  getActiveObservatoryStates,
 } from './Utils';
 import { JIRA_TICKETS_BASE_URL } from './Config';
 
@@ -246,5 +247,40 @@ describe('acronymizeString', () => {
     expect(acronymizeString('DETAILED STATE', ' ')).toBe('DS');
     expect(acronymizeString('DETAILED STATE B', ' ')).toBe('DSB');
     expect(acronymizeString('DETAILED_STATE', ' ')).toBe('D');
+  });
+});
+
+describe('getActiveObservatoryStates', () => {
+  it('should return an empty array if no states are active', () => {
+    expect(getActiveObservatoryStates(0)).toEqual([]);
+  });
+
+  it('should return the active states for a given decimal value', () => {
+    // Single active states
+    expect(getActiveObservatoryStates(1)).toEqual([1]); // DAYTIME
+    expect(getActiveObservatoryStates(2)).toEqual([2]); // OPERATIONAL
+    expect(getActiveObservatoryStates(4)).toEqual([4]); // FAULT
+    expect(getActiveObservatoryStates(8)).toEqual([8]); // WEATHER
+    expect(getActiveObservatoryStates(16)).toEqual([16]); // DOWNTIME
+
+    // Multiple active states in daytime
+    expect(getActiveObservatoryStates(5)).toEqual([1, 4]); // DAYTIME + FAULT
+    expect(getActiveObservatoryStates(9)).toEqual([1, 8]); // DAYTIME + WEATHER
+    expect(getActiveObservatoryStates(17)).toEqual([1, 16]); // DAYTIME + DOWNTIME
+
+    expect(getActiveObservatoryStates(13)).toEqual([1, 4, 8]); // DAYTIME + FAULT + WEATHER
+    expect(getActiveObservatoryStates(21)).toEqual([1, 4, 16]); // DAYTIME + FAULT + DOWNTIME
+    expect(getActiveObservatoryStates(25)).toEqual([1, 8, 16]); // DAYTIME + WEATHER + DOWNTIME
+
+    expect(getActiveObservatoryStates(29)).toEqual([1, 4, 8, 16]); // DAYTIME + FAULT + WEATHER + DOWNTIME
+
+    // Multiple active states in nighttime
+    expect(getActiveObservatoryStates(10)).toEqual([2, 8]); // OPERATIONAL + WEATHER
+
+    expect(getActiveObservatoryStates(12)).toEqual([4, 8]); // FAULT + WEATHER
+    expect(getActiveObservatoryStates(20)).toEqual([4, 16]); // FAULT + DOWNTIME
+    expect(getActiveObservatoryStates(24)).toEqual([8, 16]); // WEATHER + DOWNTIME
+
+    expect(getActiveObservatoryStates(28)).toEqual([4, 8, 16]); // FAULT + WEATHER + DOWNTIME
   });
 });

--- a/love/src/components/ScriptQueue/GlobalState/GlobalState.jsx
+++ b/love/src/components/ScriptQueue/GlobalState/GlobalState.jsx
@@ -30,8 +30,8 @@ import InfoIcon from 'components/icons/InfoIcon/InfoIcon';
 import WarningIcon from 'components/icons/WarningIcon/WarningIcon';
 import MessageIcon from 'components/icons/MessageIcon/MessageIcon';
 import CSCDetail from 'components/CSCSummary/CSCDetail/CSCDetail.jsx';
-import { OBSERVATORY_STATES } from 'Config';
-import { acronymizeString, formatSecondsToDigital } from 'Utils';
+import { OBSERVATORY_STATE_DETAIL } from 'Config';
+import { acronymizeString, formatSecondsToDigital, getActiveObservatoryStates } from 'Utils';
 import styles from './GlobalState.module.css';
 
 const summaryStateToStylesMap = Object.values(CSCDetail.states).reduce((prevDict, value) => {
@@ -41,33 +41,6 @@ const summaryStateToStylesMap = Object.values(CSCDetail.states).reduce((prevDict
 }, {});
 
 const FULL_NAME_OBSERVATORY_STATES = ['OPERATIONAL', 'FAULT'];
-
-const OBSERVATORY_STATE_DETAIL = {
-  0: {
-    name: 'UNKNOWN',
-    statusText: 'invalid',
-  },
-  1: {
-    name: 'DAYTIME',
-    statusText: 'ok',
-  },
-  2: {
-    name: 'OPERATIONAL',
-    statusText: 'ok',
-  },
-  4: {
-    name: 'FAULT',
-    statusText: 'alert',
-  },
-  8: {
-    name: 'WEATHER',
-    statusText: 'alert',
-  },
-  16: {
-    name: 'DOWNTIME',
-    statusText: 'warning',
-  },
-};
 
 const observatoryStateTooltip =
   'Current state of the observatory. ' +
@@ -91,16 +64,6 @@ const observatoryStatusTimerTooltip =
   'This timer resets every time there is a change in any of the observatory statuses, ' +
   'and it can be used to track how long the observatory has been in the current state.' +
   '\nHover over the message bubble to see the note attached to the last change in the observatory state, if any.';
-
-function getActiveObservatoryStates(decimalValue) {
-  const activeStatuses = [];
-  for (const [_, bitValue] of Object.entries(OBSERVATORY_STATES)) {
-    if ((decimalValue & bitValue) !== 0) {
-      activeStatuses.push(bitValue);
-    }
-  }
-  return activeStatuses;
-}
 
 function renderObservatoryState(state, statusClass, acronymize = true) {
   return (

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -45,7 +45,9 @@ import GlobalState from './GlobalState/GlobalState';
 import ObservatoryStatusMenu from './ObservatoryStatusMenu/ObservatoryStatusMenu';
 import ScriptDetails from './Scripts/ScriptDetails';
 import ScriptConfig from './Scripts/ScriptConfig/ScriptConfig';
+import { OBSERVATORY_STATE_DETAIL } from 'Config';
 import { SUMMARY_STATE_COMMANDS, ALLOWED_SUMMARY_STATE_COMMANDS } from 'Constants';
+import ManagerInterface, { getActiveObservatoryStates } from 'Utils';
 
 const CONFIG_PANEL_INITIAL_WIDTH = 590;
 
@@ -553,14 +555,36 @@ export default class ScriptQueue extends Component {
   };
 
   observatoryStateCommand = (newState, note) => {
-    this.props.requestSALCommand({
-      csc: 'Scheduler',
-      cmd: 'cmd_updateObservatoryStatus',
-      params: {
-        status: newState,
-        note: note ?? '',
+    this.props.requestSALCommand(
+      {
+        csc: 'Scheduler',
+        cmd: 'cmd_updateObservatoryStatus',
+        params: {
+          status: newState,
+          note: note ?? '',
+        },
       },
-    });
+      (statusCode, ackData) => {
+        if (statusCode === 200) {
+          const observatoryStatusLabels = getActiveObservatoryStates(newState)
+            .map((status) => OBSERVATORY_STATE_DETAIL[status]?.name ?? status)
+            .join(' | ');
+          const messageText =
+            `Observatory status updated to: ${observatoryStatusLabels}.\n` + `Note: ${note ?? 'Not provided.'}`;
+          const now = new Date();
+          ManagerInterface.createMessageNarrativeLogs({
+            level: 0,
+            date_begin: now.toISOString().slice(0, -1),
+            date_end: now.toISOString().slice(0, -1),
+            message_text: messageText,
+            is_human: true,
+            category: 'None',
+            time_lost_type: 'fault',
+            request_type: 'narrative',
+          });
+        }
+      },
+    );
     this.closeContextMenu();
   };
 

--- a/love/src/redux/actions/ws.js
+++ b/love/src/redux/actions/ws.js
@@ -459,7 +459,7 @@ export const requestSALCommand = (data, callback) => {
         }));
       })
       .then(({ statusCode, data }) => {
-        if (callback) callback();
+        if (callback) callback(statusCode, data);
         dispatch(updateLastSALCommandStatus(SALCommandStatus.ACK, statusCode, data?.ack));
       });
   };


### PR DESCRIPTION
This PR extends the Observatory Status feature in the `ScriptQueue` component to automatically fan narrative logs on any change of the observatory states.