### PR TITLE
Fix ScriptQueue CurrentScript elapsed time to use TAI scale.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.11.4
 -------
 
+* Fix ScriptQueue CurrentScript elapsed time to use TAI scale. `<https://github.com/lsst-ts/LOVE-frontend/pull/792>`_
 * Integrate narrative log creation with observatory states feature. `<https://github.com/lsst-ts/LOVE-frontend/pull/791>`_
 * Add visual cue to ScriptQueue observatory state to indicate the Scheduler CSC is pending to be enabled `<https://github.com/lsst-ts/LOVE-frontend/pull/788>`_
 

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -757,6 +757,8 @@ export default class ScriptQueue extends Component {
       this.props.observatoryStatuses?.private_sndStamp?.value + (this.props.taiToUtc ?? -37);
     const observatoryStateNote = this.props.observatoryStatuses?.note?.value ?? '';
 
+    const currentScriptTimestampRunStart = current.timestampRunStart + (this.props.taiToUtc ?? -37);
+
     return (
       <div
         id="container"
@@ -825,7 +827,7 @@ export default class ScriptQueue extends Component {
                 isStandard={current.type ? current.type.toUpperCase() === 'STANDARD' : undefined}
                 estimatedTime={current.expected_duration}
                 heartbeatData={this.state.indexedHeartbeats[current.index]}
-                timestampRunStart={current.timestampRunStart}
+                timestampRunStart={currentScriptTimestampRunStart}
                 stopScript={this.stopScript}
                 pauseScript={this.pauseScript}
                 onClickContextMenu={this.onClickContextMenu}


### PR DESCRIPTION
This PR fixes a long standing bug in the `CurrentScript` component where the elapsed time was being calculated without taking in consideration the scale is TAI.