### PR TITLE
Fix CameraHexapod ControllerSubstate display.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Version History
 v6.11.4
 -------
 
+* Fix CameraHexapod ControllerSubstate display. `<https://github.com/lsst-ts/LOVE-frontend/pull/793>`_
 * Fix ScriptQueue CurrentScript elapsed time to use TAI scale. `<https://github.com/lsst-ts/LOVE-frontend/pull/792>`_
 * Integrate narrative log creation with observatory states feature. `<https://github.com/lsst-ts/LOVE-frontend/pull/791>`_
 * Add visual cue to ScriptQueue observatory state to indicate the Scheduler CSC is pending to be enabled `<https://github.com/lsst-ts/LOVE-frontend/pull/788>`_

--- a/love/src/components/MainTel/CameraHexapod/CameraHexapod.jsx
+++ b/love/src/components/MainTel/CameraHexapod/CameraHexapod.jsx
@@ -42,6 +42,8 @@ import {
   hexapodControllerStatetoStyle,
 } from 'Config';
 
+const MT_HEXAPOD_CONTROLLER_STATE_ENABLED = 2;
+
 class CameraHexapod extends Component {
   static propTypes = {
     /** Function to subscribe to streams to receive */
@@ -284,7 +286,7 @@ class CameraHexapod extends Component {
 
     // controllerState
     let controllerSubstate = '';
-    if (controllerState === 'Enabled') {
+    if (this.props.hexapodControllerState === MT_HEXAPOD_CONTROLLER_STATE_ENABLED) {
       controllerSubstate = hexapodControllerStateEnabledSubstateMap[this.props.hexapodConstrollerStateEnabledSubstate];
     } else {
       controllerSubstate = 'Offline';


### PR DESCRIPTION
This PR fix the `CameraHexapod` component to properly show the ControllerSubstate in base to the MTHexapod controller state.