### PR TITLE
Add a toggle to the ObservatoryStatusMenu component to control whether to create a narrative entries on observatory status transitions triggered by users.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.11.5
+-------
+
+* Add a toggle to the ObservatoryStatusMenu component to control whether to create a narrative log entries on observatory status transitions triggered by users. `<https://github.com/lsst-ts/LOVE-frontend/pull/795>`_
+
 v6.11.4
 -------
 

--- a/love/src/components/ScriptQueue/ObservatoryStatusMenu/ObservatoryStatusMenu.jsx
+++ b/love/src/components/ScriptQueue/ObservatoryStatusMenu/ObservatoryStatusMenu.jsx
@@ -53,6 +53,7 @@ ObserversNote.propTypes = {
 const ObservatoryStatusMenu = ({ observatoryStateValue, updateObservatoryState }) => {
   const [newState, setNewState] = useState(observatoryStateValue);
   const [note, setNote] = useState();
+  const [sendNarrativelog, setSendNarrativelog] = useState(false);
 
   const hasChanged = newState !== observatoryStateValue || note?.trim().length > 0;
   const isDayTime = (observatoryStateValue & OBSERVATORY_STATES.DAYTIME) !== 0;
@@ -71,7 +72,7 @@ const ObservatoryStatusMenu = ({ observatoryStateValue, updateObservatoryState }
       setNewState(updatedState);
     };
     return (
-      <div title={title} className={styles.observatoryStatusContextMenu}>
+      <div title={title} className={styles.toggleContainer}>
         <Toggle
           toggled={isStatusActive}
           onToggle={onToggleState}
@@ -96,10 +97,19 @@ const ObservatoryStatusMenu = ({ observatoryStateValue, updateObservatoryState }
         <MenuOption label="Downtime" status={OBSERVATORY_STATES.DOWNTIME} />
       </div>
       <ObserversNote note={note} setNote={setNote} />
+      <div title="Create a narrative log upon observatory state transition." className={styles.toggleContainer}>
+        <Toggle
+          toggled={sendNarrativelog}
+          onToggle={() => setSendNarrativelog(!sendNarrativelog)}
+          activeColorClassName={styles.sliderActiveState}
+          disabled={!hasChanged}
+        />
+        <span className={sendNarrativelog ? styles.highlightedSliderLabel : ''}>Create narrative log</span>
+      </div>
       <Button
         status="info"
         disabled={!hasChanged}
-        onClick={() => updateObservatoryState(newState, note)}
+        onClick={() => updateObservatoryState(newState, note, sendNarrativelog)}
         command={true}
       >
         Update observatory state

--- a/love/src/components/ScriptQueue/ObservatoryStatusMenu/ObservatoryStatusMenu.module.css
+++ b/love/src/components/ScriptQueue/ObservatoryStatusMenu/ObservatoryStatusMenu.module.css
@@ -8,10 +8,15 @@
   border: 1px solid var(--secondary-font-dimmed-color);
 }
 
-.observatoryStatusContextMenu {
+.toggleContainer {
   display: flex;
   gap: var(--small-padding);
   align-items: center;
+}
+
+/* Style for customizing toggle */
+.toggleContainer > div > label {
+  margin: 0;
 }
 
 input:checked + .sliderActiveState {

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -572,10 +572,11 @@ export default class ScriptQueue extends Component {
           const messageText =
             `Observatory status updated to: ${observatoryStatusLabels}.\n` + `Note: ${note ?? 'Not provided.'}`;
           const now = new Date();
+          const nowTai = new Date(now.getTime() - this.props.taiToUtc * 1000); // this.props.taiToUtc is negative
           ManagerInterface.createMessageNarrativeLogs({
             level: 0,
-            date_begin: now.toISOString().slice(0, -1),
-            date_end: now.toISOString().slice(0, -1),
+            date_begin: nowTai.toISOString().slice(0, -1),
+            date_end: nowTai.toISOString().slice(0, -1),
             message_text: messageText,
             is_human: true,
             category: 'None',

--- a/love/src/components/ScriptQueue/ScriptQueue.jsx
+++ b/love/src/components/ScriptQueue/ScriptQueue.jsx
@@ -554,7 +554,7 @@ export default class ScriptQueue extends Component {
     return !allowedCommands.includes(commandName);
   };
 
-  observatoryStateCommand = (newState, note) => {
+  observatoryStateCommand = (newState, note, sendNarrativelog = false) => {
     this.props.requestSALCommand(
       {
         csc: 'Scheduler',
@@ -565,7 +565,7 @@ export default class ScriptQueue extends Component {
         },
       },
       (statusCode, ackData) => {
-        if (statusCode === 200) {
+        if (statusCode === 200 && sendNarrativelog) {
           const observatoryStatusLabels = getActiveObservatoryStates(newState)
             .map((status) => OBSERVATORY_STATE_DETAIL[status]?.name ?? status)
             .join(' | ');


### PR DESCRIPTION
This PR extends the feature to create narrative logs from observatory state transitions by adding a toggle so the user can select whether to create a log or not.