### PR TITLE
Include MTDome controlMode event in the MTDome component.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Version History
 ===============
 
-v6.11.5
+v6.12.0
 -------
 
+* Include MTDome controlMode event in the MTDome component. `<https://github.com/lsst-ts/LOVE-frontend/pull/797>`_
 * Implement PowerMonitor component. `<https://github.com/lsst-ts/LOVE-frontend/pull/796>`_
 * Add a toggle to the ObservatoryStatusMenu component to control whether to create a narrative log entries on observatory status transitions triggered by users. `<https://github.com/lsst-ts/LOVE-frontend/pull/795>`_
 

--- a/love/src/Config.js
+++ b/love/src/Config.js
@@ -2945,6 +2945,14 @@ export const mtDomeTrackingStatetoStyle = {
   UNKNOWN: 'invalid',
 };
 
+export const mtDomeControlModeStateToStyle = {
+  UNKNOWN: 'invalid',
+  REMOTE: 'ok',
+  'LOCAL PUSH BUTTONS': 'alert',
+  'LOCAL KEBA': 'alert',
+  'LOCAL EUI': 'alert',
+};
+
 export const atDomeTrackingStatetoStyle = {
   UNKNOWN: 'invalid',
 };
@@ -3346,6 +3354,14 @@ export const mtDomeMotionStateMap = {
   53: 'DISABLING',
   54: 'ENABLED',
   55: 'ENABLING',
+};
+
+export const mtDomeControlModeStateMap = {
+  0: 'UNKNOWN',
+  1: 'REMOTE',
+  2: 'LOCAL PUSH BUTTONS',
+  3: 'LOCAL KEBA',
+  4: 'LOCAL EUI',
 };
 
 export const atDomeTrackingStateMap = {

--- a/love/src/components/GeneralPurpose/StatusText/StatusText.jsx
+++ b/love/src/components/GeneralPurpose/StatusText/StatusText.jsx
@@ -27,6 +27,7 @@ export default class StatusText extends Component {
     title: PropTypes.string,
     children: PropTypes.string,
     small: PropTypes.bool,
+    flash: PropTypes.bool,
   };
 
   render() {
@@ -40,7 +41,12 @@ export default class StatusText extends Component {
     return (
       <span
         title={this.props.title}
-        className={[styles.status, statusStyle, this.props.small ? styles.small : ''].join(' ')}
+        className={[
+          styles.status,
+          statusStyle,
+          this.props.small ? styles.small : '',
+          this.props.flash ? styles.flash : '',
+        ].join(' ')}
       >
         {this.props.children}
       </span>

--- a/love/src/components/GeneralPurpose/StatusText/StatusText.module.css
+++ b/love/src/components/GeneralPurpose/StatusText/StatusText.module.css
@@ -52,3 +52,45 @@ this program. If not, see <http://www.gnu.org/licenses/>.
   color: var(--secondary-font-color);
   background: var(--second-tertiary-background-color);
 }
+
+.ok.flash {
+  animation: ok-flash 0.8s infinite;
+  animation-direction: alternate;
+}
+
+.warning.flash {
+  animation: warning-flash 0.8s infinite;
+  animation-direction: alternate;
+}
+
+.alert.flash {
+  animation: alert-flash 0.8s infinite;
+  animation-direction: alternate;
+}
+
+@keyframes ok-flash {
+  from {
+    background: var(--status-ok-dimmed-color-3);
+  }
+  to {
+    background: var(--status-ok-dimmed-color-2);
+  }
+}
+
+@keyframes warning-flash {
+  from {
+    background: var(--status-warning-dimmed-color-3);
+  }
+  to {
+    background: var(--status-warning-dimmed-color-2);
+  }
+}
+
+@keyframes alert-flash {
+  from {
+    background: var(--status-alert-dimmed-color-3);
+  }
+  to {
+    background: var(--status-alert-dimmed-color-2);
+  }
+}

--- a/love/src/components/MainTel/MTDome/MTDome.container.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.container.jsx
@@ -89,6 +89,7 @@ const MTDomeContainer = ({
   raDecHourFormat,
   louversMotionState,
   louversInPosition,
+  controlMode,
   ...props
 }) => {
   if (props.isRaw) {
@@ -125,6 +126,7 @@ const MTDomeContainer = ({
       raDecHourFormat={raDecHourFormat}
       louversMotionState={louversMotionState}
       louversInPosition={louversInPosition}
+      controlMode={controlMode}
     />
   );
 };
@@ -167,6 +169,7 @@ const mapDispatchToProps = (dispatch) => {
     'event-MTMount-0-summaryState',
     'event-MTPtg-0-currentTarget',
     'event-MTDome-0-louversMotion',
+    'event-MTDome-0-controlMode',
   ];
   return {
     subscriptions,

--- a/love/src/components/MainTel/MTDome/MTDome.jsx
+++ b/love/src/components/MainTel/MTDome/MTDome.jsx
@@ -713,6 +713,7 @@ export default class MTDome extends Component {
       raDecHourFormat,
       louversMotionState,
       louversInPosition,
+      controlMode,
     } = this.props;
 
     const currentPointing = {
@@ -803,6 +804,7 @@ export default class MTDome extends Component {
                 telescopeDecDeg={telescopeDecDeg}
                 telescopeRotatorDeg={telescopeRotatorDeg}
                 raDecHourFormat={raDecHourFormat}
+                controlMode={controlMode}
               />
             </div>
           </div>

--- a/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
+++ b/love/src/components/MainTel/MTDome/MTDomeSummaryTable/MTDomeSummaryTable.jsx
@@ -37,6 +37,8 @@ import {
   mtDomeAzimuthEnabledStatetoStyle,
   mtDomeMotionStateMap,
   mtDomeMotionStatetoStyle,
+  mtDomeControlModeStateMap,
+  mtDomeControlModeStateToStyle,
   MTMountLimits,
 } from 'Config';
 import { formatHoursToDigital, degreesToDMS, degrees, defaultNumberFormatter } from 'Utils';
@@ -78,6 +80,8 @@ export default class MTDomeSummaryTable extends Component {
     telescopeRotatorDeg: PropTypes.number,
     /** Whether to display the RA and DEC in hour format */
     raDecHourFormat: PropTypes.bool,
+    /** Control mode of the dome */
+    controlMode: PropTypes.number,
   };
 
   static defaultProps = {
@@ -93,6 +97,7 @@ export default class MTDomeSummaryTable extends Component {
     targetPointing: { az: 0, el: 0 },
     positionActualShutter: [],
     positionCommandedShutter: [],
+    controlMode: 0,
   };
 
   render() {
@@ -115,6 +120,7 @@ export default class MTDomeSummaryTable extends Component {
       telescopeDecDeg,
       telescopeRotatorDeg,
       raDecHourFormat,
+      controlMode,
     } = this.props;
 
     const mtDomeStatusText = summaryStateMap[mtDomeSummaryState];
@@ -122,6 +128,7 @@ export default class MTDomeSummaryTable extends Component {
     const azimuthDomeStateText = mtDomeAzimuthEnabledStateMap[azimuthDomeState];
     const azimuthDomeMotionText = mtDomeMotionStateMap[azimuthDomeMotion];
     const mtMountStatusText = summaryStateMap[mtMountSummaryState];
+    const controlModeText = mtDomeControlModeStateMap[controlMode];
 
     const { az: mountActualAz, el: mountActualEl } = currentPointing;
     const { az: mountCommandedAz, el: mountCommandedEl } = targetPointing;
@@ -162,6 +169,16 @@ export default class MTDomeSummaryTable extends Component {
           <Value>
             <StatusText title={modeDomeStatusText} status={mtDomeModeStatetoStyle[modeDomeStatusText]}>
               {modeDomeStatusText}
+            </StatusText>
+          </Value>
+          <Label>Control Mode</Label>
+          <Value>
+            <StatusText
+              title={controlModeText}
+              status={mtDomeControlModeStateToStyle[controlModeText]}
+              flash={mtDomeControlModeStateToStyle[controlModeText] === 'alert'}
+            >
+              {controlModeText}
             </StatusText>
           </Value>
           <Label>Az State</Label>

--- a/love/src/redux/selectors/selectors.js
+++ b/love/src/redux/selectors/selectors.js
@@ -1304,6 +1304,7 @@ export const getDomeStatus = (state) => {
     'event-MTDome-0-azMotion',
     'event-MTDome-0-azTarget',
     'event-MTDome-0-operationalMode',
+    'event-MTDome-0-controlMode',
   ];
   const domeStatus = getStreamsData(state, subscriptions);
   return {
@@ -1314,6 +1315,7 @@ export const getDomeStatus = (state) => {
     azimuthDomeTarget: domeStatus['event-MTDome-0-azTarget']?.[0]?.position?.value ?? 0,
     modeDomeStatus: domeStatus['event-MTDome-0-operationalMode']?.[0]?.operationalMode?.value ?? 0,
     mtMountSummaryState: domeStatus['event-MTMount-0-summaryState']?.[0]?.summaryState?.value ?? 0,
+    controlMode: domeStatus['event-MTDome-0-controlMode']?.[0]?.mode?.value ?? 0,
   };
 };
 


### PR DESCRIPTION
This PR extends the `MTDome` and `MTDomeSummaryTable` components to include a status text to show the state of the `MTDome.logevent_controlMode` topic. Additionally a "flashing light" option was added to the `StatusText` component to allow showing animated flashing states, for easier identification. This is set for the `controlMode` status display and it shows a flashing red light when the mode value is 2 (`LOCAL PUSH BUTTONS`), 3 (`LOCAL KEBA`) or 4 (`LOCAL EUI`).