### PR TITLE
Fix Watcher component not properly passing the acknowledgedBy parameter.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Version History
 ===============
 
+v6.12.2
+-------
+
+* Fix Watcher component not properly passing the acknowledgedBy parameter. `<https://github.com/lsst-ts/LOVE-frontend/pull/802>`_
+
 v6.12.1
 -------
 

--- a/love/src/components/Watcher/Watcher.container.jsx
+++ b/love/src/components/Watcher/Watcher.container.jsx
@@ -62,6 +62,7 @@ const WatcherContainer = ({ alarms, user, subscribeToStream, unsubscribeToStream
       subscribeToStream={subscribeToStream}
       unsubscribeToStream={unsubscribeToStream}
       alarms={alarms}
+      user={user}
     />
   );
 };


### PR DESCRIPTION
Micro PR to fix a property not being passed to the `Watcher` component (and finally the `AlarmsTable` component) producing default values ("Uknown User") to be passed to the `acknowledgedBy` parameter of the [Watcher_command_acknowledge](https://ts-xml.lsst.io/sal_interfaces/Watcher.html#acknowledge) command.